### PR TITLE
fix: shuffle draft captain assignment bugs

### DIFF
--- a/backend/app/functions/shuffle_draft.py
+++ b/backend/app/functions/shuffle_draft.py
@@ -3,6 +3,9 @@
 import random
 from typing import Optional
 
+# Maximum team size (captain + 4 drafted players)
+MAX_TEAM_SIZE = 5
+
 
 def get_team_total_mmr(team) -> int:
     """
@@ -128,7 +131,14 @@ def assign_next_shuffle_captain(draft) -> Optional[dict]:
         return None
 
     teams = list(draft.tournament.teams.all())
-    next_team, tie_data = get_lowest_mmr_team(teams)
+
+    # Filter out teams that have reached max size (5 members)
+    eligible_teams = [t for t in teams if t.members.count() < MAX_TEAM_SIZE]
+
+    if not eligible_teams:
+        return None  # All teams full, draft complete
+
+    next_team, tie_data = get_lowest_mmr_team(eligible_teams)
 
     next_round.captain = next_team.captain
     if tie_data:


### PR DESCRIPTION
## Summary
- Filter out full teams (5 members) when assigning next shuffle captain
- Clear next round's captain on undo to allow proper recalculation
- Add tests for both fixes

## Changes
- `shuffle_draft.py`: Added `MAX_TEAM_SIZE = 5` constant, filter eligible teams in `assign_next_shuffle_captain`
- `tournament.py`: Clear next round's captain/tie data in `undo_last_pick`, initialize `tie_data` before conditional
- `test_shuffle_draft.py`: Added `FullTeamNotAssignedTest` and `UndoClearsNextCaptainTest` test classes

## Test plan
- [x] `test_full_team_not_assigned_as_next_picker` - verifies full team is skipped
- [x] `test_returns_none_when_all_teams_full` - verifies None when all teams full
- [x] `test_undo_clears_next_round_captain` - verifies undo clears captain
- [x] `test_undo_clears_tie_data_on_next_round` - verifies tie data cleared

Fixes #47, fixes #43
