### PR TITLE
Add auto-labeling for PRs and issues

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,17 @@
+# Issue Labeler - auto-labels issues based on title/body keywords
+# Used by: .github/workflows/issue-labeler.yml (github/issue-labeler@v3)
+
+bug:
+  - "(bug|broken|crash|error|fail|fix|issue|problem|wrong)"
+Draft:
+  - "(draft|drafting|snake.?draft|shuffle.?draft|hero.?draft|captain.?mode)"
+Tournament:
+  - "(tournament|tourney|bracket.?stage|group.?stage|playoff|elimination)"
+brackets:
+  - "(bracket|seeding|match.?tree|double.?elim|single.?elim)"
+User:
+  - "(user|profile|login|auth|sign.?in|sign.?up|discord.?oauth|account)"
+enhancement:
+  - "(feature|enhancement|request|add|improve|new|support|implement)"
+documentation:
+  - "(docs|documentation|readme|guide|tutorial|instructions)"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,62 @@
+# PR Labeler - auto-labels PRs based on changed file paths
+# Used by: .github/workflows/pr-labeler.yml (actions/labeler@v5)
+
+Draft:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/app/components/draft/**
+          - frontend/app/components/teamdraft/**
+          - frontend/app/components/herodraft/**
+          - backend/app/**/shuffle_draft*
+          - backend/app/**/snake_draft*
+          - backend/app/**/hero_draft*
+          - backend/app/views/draft*
+
+Tournament:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/app/components/tournament/**
+          - backend/app/**/tournament*
+          - backend/app/views/tournament*
+
+brackets:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/app/components/bracket/**
+          - backend/app/**/bracket*
+
+User:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/app/components/user/**
+          - backend/app/**/auth*
+          - backend/app/**/social*
+          - backend/app/views/user*
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - '*.md'
+          - mkdocs.yml
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/**
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - backend/**
+
+infrastructure:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docker/**
+          - nginx/**
+          - .github/**
+          - Dockerfile*
+          - justfile
+          - pyproject.toml
+          - poetry.lock

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,18 @@
+name: Auto-label issues by keywords
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/issue-labeler.yml"
+          enable-versioned-regex: 0

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: Label PRs by changed files
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/labeler.yml"
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Adds PR labeler workflow (`actions/labeler@v5`) that auto-labels PRs based on changed file paths
- Adds issue labeler workflow (`github/issue-labeler@v3`) that auto-labels issues based on keyword regex in title/body
- Creates three new GitHub labels: `frontend`, `backend`, `infrastructure`

## Labels

**PR file-path labels:** Draft, Tournament, brackets, User, documentation, frontend, backend, infrastructure

**Issue keyword labels:** bug, Draft, Tournament, brackets, User, enhancement, documentation

## Files
| File | Purpose |
|------|---------|
| `.github/labeler.yml` | PR file-path → label mapping |
| `.github/issue-labeler.yml` | Issue keyword regex → label mapping |
| `.github/workflows/pr-labeler.yml` | PR labeler workflow |
| `.github/workflows/issue-labeler.yml` | Issue labeler workflow |