### PR TITLE
fix: add-user modal, calendar popover close, discord test endpoint

### DIFF
--- a/backend/tests/test_discord.py
+++ b/backend/tests/test_discord.py
@@ -1,0 +1,116 @@
+"""
+Test-only endpoint for seeding the Discord members cache.
+
+Populates the Redis cache key used by search_discord_members so that
+Playwright tests can exercise the Discord tab in AddUserModal without
+a real Discord API connection.
+"""
+
+import logging
+
+from django.core.cache import cache
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from common.utils import isTestEnvironment
+from tests.data.users import TOURNAMENT_USERS
+
+log = logging.getLogger(__name__)
+
+
+def _make_discord_member(discord_id: str, username: str, nick: str | None = None):
+    """Build a minimal Discord guild-member dict matching the Discord API shape."""
+    return {
+        "user": {
+            "id": discord_id,
+            "username": username,
+            "global_name": nick or username,
+            "avatar": None,
+            "discriminator": "0",
+            "public_flags": 0,
+        },
+        "nick": nick,
+    }
+
+
+# Unlinked Discord members (no matching CustomUser in the DB).
+# Tests can use these to exercise "add from Discord ID" flow.
+UNLINKED_DISCORD_MEMBERS = [
+    _make_discord_member(
+        "900000000000000001", "unlinked_discord_user", "Unlinked Test"
+    ),
+    _make_discord_member("900000000000000002", "unlinked_discord_alt", "Unlinked Alt"),
+]
+
+
+def _build_test_discord_members():
+    """Build the full list of fake Discord members for the test cache."""
+    members = []
+
+    # Tournament users — these have matching CustomUser.discordId in the DB,
+    # so search_discord_members will flag them has_site_account=True.
+    for username, user in TOURNAMENT_USERS.items():
+        if user.discord_id:
+            members.append(
+                _make_discord_member(user.discord_id, username, user.nickname)
+            )
+
+    # Unlinked members — no CustomUser match
+    members.extend(UNLINKED_DISCORD_MEMBERS)
+
+    return members
+
+
+@csrf_exempt
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([AllowAny])
+def seed_discord_members(request, org_id: int):
+    """
+    TEST ONLY: Seed the Discord members Redis cache for an organization.
+
+    This populates the same cache key that search_discord_members reads,
+    so Playwright tests can search and add Discord members without a real
+    Discord bot connection.
+
+    POST /api/tests/discord/<org_id>/seed-members/
+    """
+    if not isTestEnvironment(request):
+        return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+    from app.models import Organization
+
+    try:
+        org = Organization.objects.get(pk=org_id)
+    except Organization.DoesNotExist:
+        return Response(
+            {"error": f"Organization with pk {org_id} not found"},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    if not org.discord_server_id:
+        return Response(
+            {"error": "Organization has no discord_server_id configured"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    members = _build_test_discord_members()
+    cache_key = f"discord_members_search_{org.discord_server_id}"
+    cache.set(cache_key, members, timeout=3600)
+
+    log.info(f"Seeded {len(members)} Discord members into cache key {cache_key}")
+
+    return Response(
+        {
+            "seeded": True,
+            "count": len(members),
+            "cache_key": cache_key,
+        }
+    )

--- a/backend/tests/urls.py
+++ b/backend/tests/urls.py
@@ -21,6 +21,7 @@ from .test_auth import (
 )
 from .test_csv import reset_csv_import
 from .test_demo import generate_demo_bracket, get_demo_tournament, reset_demo_tournament
+from .test_discord import seed_discord_members
 from .test_herodraft import (
     force_herodraft_timeout,
     get_herodraft_by_key,
@@ -134,6 +135,12 @@ urlpatterns = [
         "csv-import/reset/",
         reset_csv_import,
         name="test-csv-import-reset",
+    ),
+    # Discord member cache seeding
+    path(
+        "discord/<int:org_id>/seed-members/",
+        seed_discord_members,
+        name="test-seed-discord-members",
     ),
     # Demo tournament endpoints (for video recording)
     # More specific paths first to avoid <str:key> catching them

--- a/frontend/app/components/tournament/create/editForm.tsx
+++ b/frontend/app/components/tournament/create/editForm.tsx
@@ -285,8 +285,8 @@ export const TournamentEditForm: React.FC<Props> = ({
                         onSelect={(date) => {
                           if (date) {
                             setSelectedDate(format(date, 'yyyy-MM-dd'));
-                            setCalendarOpen(false);
                           }
+                          setCalendarOpen(false);
                         }}
                         data-testid="tournament-calendar"
                       />

--- a/frontend/app/pages/tournament/tabs/PlayersTab.tsx
+++ b/frontend/app/pages/tournament/tabs/PlayersTab.tsx
@@ -30,13 +30,22 @@ export const PlayersTab: React.FC = memo(() => {
 
   // AddUserModal callbacks
   const handleAddMember = useCallback(
-    async (payload: AddMemberPayload) => {
+    async (payload: AddMemberPayload): Promise<UserType> => {
       if (!tournament?.pk) throw new Error('No tournament');
+      const oldPks = new Set(
+        (useUserStore.getState().tournament?.users ?? []).map((u) => u.pk),
+      );
       const rawTournament = await addTournamentMember(tournament.pk, payload);
       const hydrated = hydrateTournament(rawTournament as TournamentType & { _users?: Record<number, unknown> }) as TournamentType;
       setTournament(hydrated);
       // Invalidate React Query cache so useTournament refetches
       queryClient.invalidateQueries({ queryKey: ['tournament', tournament.pk] });
+      // Return the newly added user to satisfy AddUserModal's onAdd contract
+      const addedUser = (hydrated.users ?? []).find(
+        (u) => u.pk != null && !oldPks.has(u.pk),
+      );
+      if (!addedUser) throw new Error('Added user not found in response');
+      return addedUser;
     },
     [tournament?.pk, setTournament, queryClient]
   );

--- a/frontend/tests/playwright/e2e/03-tournaments/02-form.spec.ts
+++ b/frontend/tests/playwright/e2e/03-tournaments/02-form.spec.ts
@@ -73,13 +73,13 @@ test.describe('Tournaments - create (e2e)', () => {
     const calendar = page.locator('[data-slot="calendar"]');
     await calendar.waitFor({ state: 'visible', timeout: 5000 });
 
-    // Select day 15 of the current month using data-testid
-    const dayButton = calendar.locator('[data-testid="calendar-day-15"]').first();
-    // Use evaluate to bypass any popover positioning/z-index issues
-    await dayButton.evaluate((btn) => (btn as HTMLButtonElement).click());
+    // Select day 20 (avoids collision with today if today is the 15th —
+    // clicking an already-selected day deselects and skips popover close)
+    const dayButton = calendar.locator('[data-testid="calendar-day-20"]').first();
+    await dayButton.click();
 
     // Wait for popover to close
-    await calendar.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
+    await calendar.waitFor({ state: 'hidden', timeout: 5000 });
 
     // Submit the form
     await page.locator('[data-testid="tournament-submit-button"]').click();
@@ -167,14 +167,14 @@ test.describe('Tournaments - create (e2e)', () => {
     await typeOption.waitFor({ state: 'visible', timeout: 10000 });
     await typeOption.click();
 
-    // Select date
+    // Select date (day 20 to avoid collision with today's date)
     const datePicker = page.locator('[data-testid="tournament-date-picker"]');
     await datePicker.click();
     const calendar = page.locator('[data-slot="calendar"]');
     await calendar.waitFor({ state: 'visible', timeout: 5000 });
-    const dayButton = calendar.locator('[data-testid="calendar-day-15"]').first();
-    await dayButton.evaluate((btn) => (btn as HTMLButtonElement).click());
-    await calendar.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
+    const dayButton = calendar.locator('[data-testid="calendar-day-20"]').first();
+    await dayButton.click();
+    await calendar.waitFor({ state: 'hidden', timeout: 5000 });
 
     // Submit to create
     await page.locator('[data-testid="tournament-submit-button"]').click();


### PR DESCRIPTION
## Summary
- **AddUserModal fix**: `handleAddMember` in PlayersTab now returns the newly added `UserType` by diffing PK sets before/after the API call, satisfying `AddUserModal`'s `onAdd: Promise<UserType>` contract (broken during entity cache refactor)
- **Calendar popover fix**: Tournament form's calendar popover now always closes on day click — previously `setCalendarOpen(false)` was inside an `if(date)` guard, so re-clicking the already-selected day passed `undefined` and never closed the popover (date-dependent bug: only fails when today matches the test's selected day)
- **Test hardening**: Calendar test picks day 20 instead of 15, uses native `.click()` instead of `evaluate()`, removes `.catch(() => {})` that silently swallowed failures
- **New test endpoint**: `POST /api/tests/discord/<org_id>/seed-members/` seeds Redis cache with fake Discord members for Playwright E2E tests

## Test plan
- [x] `just test::pw::spec 03-tournaments/02-form` — all 4 pass (previously 2 failed on the 15th)
- [x] `just test::pw::spec 12-add-user-modal` — all 3 pass
- [x] Full suite: 107 passed, 0 related failures