### PR TITLE
fix: add _users dict to WS broadcast and fix tie_roll history crash

### DIFF
--- a/backend/app/broadcast.py
+++ b/backend/app/broadcast.py
@@ -55,6 +55,7 @@ def broadcast_event(event, include_draft_state=True):
                 "tournament__users",
             ).get(pk=event.draft_id)
             draft_state = DraftSerializerSlim(draft).data
+            draft_state["_users"] = _build_users_dict(draft.tournament)
         except Exception as e:
             log.warning(f"Failed to serialize draft state: {e}")
 

--- a/frontend/app/components/teamdraft/DraftEventModal.tsx
+++ b/frontend/app/components/teamdraft/DraftEventModal.tsx
@@ -1,6 +1,6 @@
 import { InfoDialog } from "~/components/ui/dialogs";
 import { UserAvatar } from "~/components/user/UserAvatar";
-import type { DraftEvent, PlayerPickedPayload, CaptainAssignedPayload } from "~/types/draftEvent";
+import type { DraftEvent, PlayerPickedPayload, CaptainAssignedPayload, TieRollPayload } from "~/types/draftEvent";
 import { formatDistanceToNow } from "date-fns";
 
 interface DraftEventModalProps {
@@ -59,14 +59,10 @@ function getEventDescription(event: DraftEvent): string {
       return `${payload.captain_name} picked ${payload.picked_name} (Pick ${payload.pick_number})`;
     }
     case "tie_roll": {
-      const payload = event.payload as {
-        tied_captains: { name: string }[];
-        roll_rounds: { captain_id: number; roll: number }[][];
-        winner_name: string;
-      };
-      const names = payload.tied_captains.map((c) => c.name).join(" vs ");
-      const lastRound = payload.roll_rounds[payload.roll_rounds.length - 1];
-      const rolls = lastRound.map((r) => `${r.roll}`).join(" vs ");
+      const payload = event.payload as TieRollPayload;
+      const names = payload.tied_teams?.map((t) => t.name).join(" vs ") ?? "teams";
+      const lastRound = payload.roll_rounds?.[payload.roll_rounds.length - 1];
+      const rolls = lastRound?.map((r) => `${r.roll}`).join(" vs ") ?? "";
       return `Tie! ${names} rolled ${rolls} → ${payload.winner_name} wins`;
     }
     case "captain_assigned": {

--- a/frontend/app/types/draftEvent.ts
+++ b/frontend/app/types/draftEvent.ts
@@ -60,13 +60,14 @@ export interface PlayerPickedPayload {
 }
 
 export interface TieRollPayload {
-  tied_captains: {
+  pick_number: number;
+  tied_teams: {
     id: number;
     name: string;
     mmr: number;
   }[];
   roll_rounds: {
-    captain_id: number;
+    team_id: number;
     roll: number;
   }[][];
   winner_id: number;


### PR DESCRIPTION
## Summary
- Added `_build_users_dict()` call to `broadcast_event()` so WebSocket draft state includes the `_users` dict — fixes spectators/other captains seeing "?" for all players after each pick
- Fixed `DraftEventModal` crash when viewing tie_roll events in draft history — frontend expected `tied_captains`/`captain_id` but backend sends `tied_teams`/`team_id`
- Added defensive optional chaining to `TieRollPayload` rendering

## Test plan
- [x] Backend tests pass (11/11 `app.tests.test_draft_events`)
- [x] TypeScript check clean for modified files
- [ ] Manual: Open draft as spectator, verify players show names/avatars after picks (not "?")
- [ ] Manual: Click History button during a shuffle draft with tie rolls, verify no crash

Closes #150