### PR TITLE
fix: steam league stats not loading for new games

### DIFF
--- a/backend/steam/serializers.py
+++ b/backend/steam/serializers.py
@@ -192,6 +192,42 @@ class LinkMatchRequestSerializer(serializers.Serializer):
 # =============================================================================
 
 
+def _get_league_for_stats(obj):
+    """Look up the League object from a LeaguePlayerStats' league_id (Steam league ID)."""
+    from app.models import League
+
+    try:
+        return League.objects.get(steam_league_id=obj.league_id)
+    except League.DoesNotExist:
+        return None
+
+
+def _get_base_mmr(obj):
+    from org.models import OrgUser
+
+    league = _get_league_for_stats(obj)
+    if not league or not league.organization:
+        return 0
+    try:
+        org_user = OrgUser.objects.get(user=obj.user, organization=league.organization)
+        return org_user.mmr or 0
+    except OrgUser.DoesNotExist:
+        return 0
+
+
+def _get_league_mmr(obj):
+    from league.models import LeagueUser
+
+    league = _get_league_for_stats(obj)
+    if not league:
+        return 0
+    try:
+        league_user = LeagueUser.objects.get(user=obj.user, league=league)
+        return league_user.mmr or 0
+    except LeagueUser.DoesNotExist:
+        return 0
+
+
 class LeaguePlayerStatsSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source="user.username", read_only=True)
     avatar = serializers.CharField(source="user.avatar", read_only=True)
@@ -222,24 +258,10 @@ class LeaguePlayerStatsSerializer(serializers.ModelSerializer):
         ]
 
     def get_base_mmr(self, obj):
-        from org.models import OrgUser
-
-        try:
-            org_user = OrgUser.objects.get(
-                user=obj.user, organization=obj.league.organization
-            )
-            return org_user.mmr or 0
-        except OrgUser.DoesNotExist:
-            return 0
+        return _get_base_mmr(obj)
 
     def get_league_mmr(self, obj):
-        from league.models import LeagueUser
-
-        try:
-            league_user = LeagueUser.objects.get(user=obj.user, league=obj.league)
-            return league_user.mmr or 0
-        except LeagueUser.DoesNotExist:
-            return 0
+        return _get_league_mmr(obj)
 
 
 class LeaderboardSerializer(serializers.ModelSerializer):
@@ -270,24 +292,10 @@ class LeaderboardSerializer(serializers.ModelSerializer):
         ]
 
     def get_base_mmr(self, obj):
-        from org.models import OrgUser
-
-        try:
-            org_user = OrgUser.objects.get(
-                user=obj.user, organization=obj.league.organization
-            )
-            return org_user.mmr or 0
-        except OrgUser.DoesNotExist:
-            return 0
+        return _get_base_mmr(obj)
 
     def get_league_mmr(self, obj):
-        from league.models import LeagueUser
-
-        try:
-            league_user = LeagueUser.objects.get(user=obj.user, league=obj.league)
-            return league_user.mmr or 0
-        except LeagueUser.DoesNotExist:
-            return 0
+        return _get_league_mmr(obj)
 
     def get_avg_kda(self, obj):
         if obj.avg_deaths == 0:

--- a/backend/steam/views.py
+++ b/backend/steam/views.py
@@ -98,10 +98,11 @@ class LeagueStatsView(APIView):
     """
 
     def get(self, request, user_id):
+        league_id = request.query_params.get("league_id", LEAGUE_ID)
         try:
             stats = LeaguePlayerStats.objects.select_related("user").get(
                 user_id=user_id,
-                league_id=LEAGUE_ID,
+                league_id=league_id,
             )
             serializer = LeaguePlayerStatsSerializer(stats)
             return Response(serializer.data)

--- a/frontend/app/components/bracket/modals/LinkSteamMatchModal.tsx
+++ b/frontend/app/components/bracket/modals/LinkSteamMatchModal.tsx
@@ -173,7 +173,7 @@ export function LinkSteamMatchModal({
     <>
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent
-          className="max-w-2xl max-h-[80vh] overflow-hidden flex flex-col"
+          className="max-w-2xl xl:max-w-5xl max-h-[80vh] overflow-hidden flex flex-col"
           data-testid="link-steam-match-modal"
         >
           <DialogHeader>
@@ -285,7 +285,7 @@ export function LinkSteamMatchModal({
                           >
                             <span className="font-medium">{tierLabel}</span>
                           </div>
-                          <div className="space-y-2 p-2 border border-t-0 rounded-b-lg">
+                          <div className="grid grid-cols-1 xl:grid-cols-2 gap-2 p-2 border border-t-0 rounded-b-lg">
                             {sortedTierSuggestions.map((suggestion) => (
                               <SteamMatchCard
                                 key={suggestion.match_id}

--- a/frontend/app/components/player/PlayerModal.tsx
+++ b/frontend/app/components/player/PlayerModal.tsx
@@ -51,10 +51,9 @@ export const PlayerModal: React.FC<PlayerModalProps> = ({
     currentUser?.discordId &&
     currentUser?.pk !== player.pk;
 
-  // Fetch league stats if leagueId is provided
-  // TODO: Update useUserLeagueStats to accept leagueId parameter when backend supports it
   const { data: leagueStats, isLoading: isLoadingStats } = useUserLeagueStats(
-    leagueId && player.pk ? player.pk : null
+    leagueId && player.pk ? player.pk : null,
+    leagueId
   );
 
   // Fetch full user data when modal opens

--- a/frontend/app/features/leaderboard/queries.ts
+++ b/frontend/app/features/leaderboard/queries.ts
@@ -31,8 +31,9 @@ async function fetchLeaderboard(
   return response.json();
 }
 
-async function fetchUserLeagueStats(userId: number): Promise<LeagueStats> {
-  const response = await fetch(`${API_BASE}/league-stats/${userId}/`);
+async function fetchUserLeagueStats(userId: number, leagueId?: number): Promise<LeagueStats> {
+  const params = leagueId ? `?league_id=${leagueId}` : "";
+  const response = await fetch(`${API_BASE}/league-stats/${userId}/${params}`);
   if (!response.ok) {
     throw new Error("Failed to fetch league stats");
   }
@@ -56,10 +57,10 @@ export function useLeaderboard(params: LeaderboardParams = {}) {
   });
 }
 
-export function useUserLeagueStats(userId: number | null) {
+export function useUserLeagueStats(userId: number | null, leagueId?: number) {
   return useQuery({
-    queryKey: ["league-stats", userId],
-    queryFn: () => fetchUserLeagueStats(userId!),
+    queryKey: ["league-stats", userId, leagueId],
+    queryFn: () => fetchUserLeagueStats(userId!, leagueId),
     enabled: userId !== null,
   });
 }


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'LeaguePlayerStats' object has no attribute 'league'` in serializer by looking up `League` via `steam_league_id` instead of nonexistent FK
- `LeagueStatsView` now accepts optional `league_id` query param (falls back to default constant)
- Frontend `useUserLeagueStats` hook passes `leagueId` from `PlayerModal` through to the API
- Widen `LinkSteamMatchModal` on xl screens (`xl:max-w-5xl`) with 2-col grid layout for match cards

## Test plan
- [ ] Verify `/api/steam/league-stats/<user_id>/` no longer throws AttributeError
- [ ] Verify passing `?league_id=X` returns stats for that league
- [ ] Verify PlayerModal shows league stats when opened from a league context
- [ ] Verify LinkSteamMatchModal displays wider with 2 columns on xl screens
- [ ] Verify leaderboard and UserPopover still work (use default league)

Closes #151