### PR TITLE
fix: show server error message for Discord refresh rate limit

### DIFF
--- a/frontend/app/components/user/AddUserModal/AddUserModal.tsx
+++ b/frontend/app/components/user/AddUserModal/AddUserModal.tsx
@@ -86,8 +86,11 @@ export const AddUserModal: React.FC<AddUserModalProps> = ({
       toast.success(`Refreshed ${result.count} Discord members`);
       // Invalidate Discord search query to re-fetch
       queryClient.invalidateQueries({ queryKey: ['discordSearch'] });
-    } catch {
-      toast.error('Failed to refresh Discord members');
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+        || 'Failed to refresh Discord members';
+      toast.error(message);
     } finally {
       setRefreshing(false);
     }


### PR DESCRIPTION
## Summary
- Display the actual API error message (e.g. "Please wait before refreshing again") instead of generic "Failed to refresh Discord members" when the 5-minute cooldown is active (HTTP 429)

## Test plan
- [ ] Open Add User modal, click "Refresh Discord Members"
- [ ] Click it again within 5 minutes — should show "Please wait before refreshing again"