### PR TITLE
feat: SSR meta tags for SEO and social embeds

### DIFF
--- a/backend/app/serializers_ssr.py
+++ b/backend/app/serializers_ssr.py
@@ -87,6 +87,11 @@ class HeroDraftSerializerSSR(serializers.ModelSerializer):
 
 
 class UserSerializerSSR(serializers.ModelSerializer):
+    avatar_url = serializers.SerializerMethodField()
+
     class Meta:
         model = CustomUser
-        fields = ["pk", "username", "nickname", "avatar"]
+        fields = ["pk", "username", "nickname", "avatar_url"]
+
+    def get_avatar_url(self, obj):
+        return obj.avatarUrl

--- a/backend/app/serializers_ssr.py
+++ b/backend/app/serializers_ssr.py
@@ -1,0 +1,92 @@
+"""Lightweight serializers for SSR meta tags and above-the-fold skeletons."""
+
+from rest_framework import serializers
+
+from app.models import CustomUser, HeroDraft, League, Organization, Tournament
+from events.models import Event
+
+
+class TournamentSerializerSSR(serializers.ModelSerializer):
+    org_name = serializers.SerializerMethodField()
+    org_logo = serializers.SerializerMethodField()
+    league_name = serializers.CharField(source="league.name", default=None)
+
+    class Meta:
+        model = Tournament
+        fields = ["pk", "name", "org_name", "org_logo", "league_name"]
+
+    def get_org_name(self, obj):
+        if obj.league and obj.league.organization:
+            return obj.league.organization.name
+        return None
+
+    def get_org_logo(self, obj):
+        if obj.league and obj.league.organization and obj.league.organization.logo:
+            return obj.league.organization.logo
+        return None
+
+
+class OrganizationSerializerSSR(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ["pk", "name", "description", "logo"]
+
+
+class LeagueSerializerSSR(serializers.ModelSerializer):
+    org_name = serializers.CharField(source="organization.name", default=None)
+    org_logo = serializers.SerializerMethodField()
+
+    class Meta:
+        model = League
+        fields = ["pk", "name", "description", "org_name", "org_logo"]
+
+    def get_org_logo(self, obj):
+        if obj.organization and obj.organization.logo:
+            return obj.organization.logo
+        return None
+
+
+class EventSerializerSSR(serializers.ModelSerializer):
+    org_name = serializers.CharField(source="organization.name", default=None)
+    league_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Event
+        fields = ["id", "name", "description", "org_name", "league_name"]
+
+    def get_league_name(self, obj):
+        if obj.tournament_league:
+            return obj.tournament_league.name
+        return None
+
+
+class HeroDraftSerializerSSR(serializers.ModelSerializer):
+    tournament_name = serializers.SerializerMethodField()
+    org_name = serializers.SerializerMethodField()
+    team_names = serializers.SerializerMethodField()
+
+    class Meta:
+        model = HeroDraft
+        fields = ["pk", "tournament_name", "org_name", "team_names"]
+
+    def get_tournament_name(self, obj):
+        if obj.game and obj.game.tournament:
+            return obj.game.tournament.name
+        return None
+
+    def get_org_name(self, obj):
+        if obj.game and obj.game.tournament and obj.game.tournament.league:
+            org = obj.game.tournament.league.organization
+            return org.name if org else None
+        return None
+
+    def get_team_names(self, obj):
+        # Uses prefetched draft_teams + tournament_team from the view's queryset.
+        # Don't call .select_related() or [:2] here — both bypass the prefetch cache.
+        return [dt.tournament_team.name for dt in obj.draft_teams.all()]
+
+
+class UserSerializerSSR(serializers.ModelSerializer):
+    class Meta:
+        model = CustomUser
+        fields = ["pk", "username", "nickname", "avatar"]

--- a/backend/app/tests/test_ssr_views.py
+++ b/backend/app/tests/test_ssr_views.py
@@ -76,6 +76,8 @@ class SSREndpointTests(TestCase):
         resp = self.client.get(f"/api/users/{user.pk}/ssr/")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data["username"], "testplayer")
+        self.assertIn("avatar_url", resp.data)
+        self.assertNotIn("avatar", resp.data)
         self.assertNotIn("email", resp.data)
 
     def test_tournament_ssr_with_org(self):

--- a/backend/app/tests/test_ssr_views.py
+++ b/backend/app/tests/test_ssr_views.py
@@ -1,0 +1,134 @@
+"""Tests for SSR meta tag endpoints."""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class SSREndpointTests(TestCase):
+    """Test that SSR endpoints return lightweight data without auth."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_tournament_ssr_returns_200(self):
+        from django.utils import timezone
+
+        from app.models import Tournament
+
+        t = Tournament.objects.create(name="Test Tourney", date_played=timezone.now())
+        resp = self.client.get(f"/api/tournaments/{t.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["name"], "Test Tourney")
+        self.assertIn("pk", resp.data)
+        self.assertNotIn("teams", resp.data)
+        self.assertNotIn("users", resp.data)
+
+    def test_tournament_ssr_returns_404(self):
+        resp = self.client.get("/api/tournaments/99999/ssr/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_organization_ssr_returns_200(self):
+        from app.models import Organization
+
+        org = Organization.objects.create(name="Test Org", description="A test org")
+        resp = self.client.get(f"/api/organizations/{org.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["name"], "Test Org")
+        self.assertEqual(resp.data["description"], "A test org")
+        self.assertNotIn("admins", resp.data)
+        self.assertNotIn("staff", resp.data)
+
+    def test_league_ssr_returns_200(self):
+        from app.models import League, Organization
+
+        org = Organization.objects.create(name="Test Org")
+        league = League.objects.create(
+            name="Test League", organization=org, steam_league_id=12345
+        )
+        resp = self.client.get(f"/api/leagues/{league.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["name"], "Test League")
+        self.assertEqual(resp.data["org_name"], "Test Org")
+
+    def test_event_ssr_returns_200(self):
+        from django.utils import timezone
+
+        from app.models import Organization
+        from events.models import Event
+
+        org = Organization.objects.create(name="Test Org")
+        event = Event.objects.create(
+            name="Test Event",
+            organization=org,
+            scheduled_at=timezone.now(),
+        )
+        resp = self.client.get(f"/api/events/{event.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["name"], "Test Event")
+        self.assertEqual(resp.data["org_name"], "Test Org")
+
+    def test_user_ssr_returns_200(self):
+        from app.models import CustomUser
+
+        user = CustomUser.objects.create_user(
+            username="testplayer", password="testpass123"
+        )
+        resp = self.client.get(f"/api/users/{user.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["username"], "testplayer")
+        self.assertNotIn("email", resp.data)
+
+    def test_tournament_ssr_with_org(self):
+        from django.utils import timezone
+
+        from app.models import League, Organization, Tournament
+
+        org = Organization.objects.create(
+            name="Big Org", logo="https://example.com/logo.png"
+        )
+        league = League.objects.create(
+            name="Big League", organization=org, steam_league_id=99999
+        )
+        t = Tournament.objects.create(
+            name="Big Tourney", date_played=timezone.now(), league=league
+        )
+        resp = self.client.get(f"/api/tournaments/{t.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["org_name"], "Big Org")
+        self.assertEqual(resp.data["org_logo"], "https://example.com/logo.png")
+        self.assertEqual(resp.data["league_name"], "Big League")
+
+    def test_herodraft_ssr_returns_200(self):
+        from django.utils import timezone
+
+        from app.models import DraftTeam, Game, HeroDraft, Team, Tournament
+
+        t = Tournament.objects.create(name="Draft Tourney", date_played=timezone.now())
+        game = Game.objects.create(tournament=t, round=1)
+        draft = HeroDraft.objects.create(game=game)
+        team1 = Team.objects.create(name="Team Alpha", tournament=t)
+        team2 = Team.objects.create(name="Team Beta", tournament=t)
+        DraftTeam.objects.create(draft=draft, tournament_team=team1)
+        DraftTeam.objects.create(draft=draft, tournament_team=team2)
+        resp = self.client.get(f"/api/herodraft/{draft.pk}/ssr/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["tournament_name"], "Draft Tourney")
+        self.assertEqual(resp.data["team_names"], ["Team Alpha", "Team Beta"])
+
+    def test_ssr_endpoints_are_public(self):
+        from django.utils import timezone
+
+        from app.models import CustomUser, Organization, Tournament
+
+        client = APIClient()
+        org = Organization.objects.create(name="Pub Org")
+        t = Tournament.objects.create(name="Pub T", date_played=timezone.now())
+        user = CustomUser.objects.create_user(username="pub", password="test123")
+
+        for url in [
+            f"/api/tournaments/{t.pk}/ssr/",
+            f"/api/organizations/{org.pk}/ssr/",
+            f"/api/users/{user.pk}/ssr/",
+        ]:
+            resp = client.get(url)
+            self.assertEqual(resp.status_code, 200, f"Failed for {url}")

--- a/backend/app/views/ssr.py
+++ b/backend/app/views/ssr.py
@@ -1,0 +1,57 @@
+"""Lightweight read-only views for SSR meta tags.
+
+These endpoints are public (no auth required) and return minimal data
+for server-side rendering of meta tags and above-the-fold content.
+"""
+
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import AllowAny
+
+from app.models import CustomUser, HeroDraft, League, Organization, Tournament
+from app.serializers_ssr import (
+    EventSerializerSSR,
+    HeroDraftSerializerSSR,
+    LeagueSerializerSSR,
+    OrganizationSerializerSSR,
+    TournamentSerializerSSR,
+    UserSerializerSSR,
+)
+from events.models import Event
+
+
+class TournamentSSRView(RetrieveAPIView):
+    serializer_class = TournamentSerializerSSR
+    permission_classes = [AllowAny]
+    queryset = Tournament.objects.select_related("league__organization")
+
+
+class OrganizationSSRView(RetrieveAPIView):
+    serializer_class = OrganizationSerializerSSR
+    permission_classes = [AllowAny]
+    queryset = Organization.objects.all()
+
+
+class LeagueSSRView(RetrieveAPIView):
+    serializer_class = LeagueSerializerSSR
+    permission_classes = [AllowAny]
+    queryset = League.objects.select_related("organization")
+
+
+class EventSSRView(RetrieveAPIView):
+    serializer_class = EventSerializerSSR
+    permission_classes = [AllowAny]
+    queryset = Event.objects.select_related("organization", "tournament_league")
+
+
+class HeroDraftSSRView(RetrieveAPIView):
+    serializer_class = HeroDraftSerializerSSR
+    permission_classes = [AllowAny]
+    queryset = HeroDraft.objects.select_related(
+        "game__tournament__league__organization"
+    ).prefetch_related("draft_teams__tournament_team")
+
+
+class UserSSRView(RetrieveAPIView):
+    serializer_class = UserSerializerSSR
+    permission_classes = [AllowAny]
+    queryset = CustomUser.objects.all()

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -333,6 +333,8 @@ else:
         "app.customuser": {"ops": "all", "timeout": 60 * 60},
         "app.draft": {"ops": "all", "timeout": 60 * 60},
         "app.game": {"ops": "all", "timeout": 60 * 60},
+        "app.herodraft": {"ops": "all", "timeout": 60 * 60},
+        "app.draftteam": {"ops": "all", "timeout": 60 * 60},
         "app.draftround": {"ops": "all", "timeout": 60 * 60},
         # Organization/League membership models
         "org.orguser": {"ops": "all", "timeout": 60 * 60},

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,5 +1,4 @@
 import logging
-from venv import create
 
 from django.contrib import admin
 from django.urls import include, path

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -67,6 +67,14 @@ from app.views.admin_team import (
     update_org_user,
 )
 from app.views.csv_import import import_csv_org, import_csv_tournament
+from app.views.ssr import (
+    EventSSRView,
+    HeroDraftSSRView,
+    LeagueSSRView,
+    OrganizationSSRView,
+    TournamentSSRView,
+    UserSSRView,
+)
 from app.views_joke import buy_tango, get_tangoes
 from common.utils import isTestEnvironment
 from org.views import ClaimRequestViewSet
@@ -322,6 +330,23 @@ urlpatterns = [
         add_tournament_member,
         name="add_tournament_member",
     ),
+    # SSR endpoints — lightweight public data for meta tags and skeletons
+    path(
+        "api/tournaments/<int:pk>/ssr/",
+        TournamentSSRView.as_view(),
+        name="tournament_ssr",
+    ),
+    path(
+        "api/organizations/<int:pk>/ssr/",
+        OrganizationSSRView.as_view(),
+        name="organization_ssr",
+    ),
+    path("api/leagues/<int:pk>/ssr/", LeagueSSRView.as_view(), name="league_ssr"),
+    path("api/events/<int:pk>/ssr/", EventSSRView.as_view(), name="event_ssr"),
+    path(
+        "api/herodraft/<int:pk>/ssr/", HeroDraftSSRView.as_view(), name="herodraft_ssr"
+    ),
+    path("api/users/<int:pk>/ssr/", UserSSRView.as_view(), name="user_ssr"),
 ]
 
 # Event task schedule

--- a/docker/.env.prod
+++ b/docker/.env.prod
@@ -1,4 +1,4 @@
-NODE_ENV="prod"
+NODE_ENV=production
 RELEASE=false
 DEBUG=false
 TEST=false

--- a/docker/.env.release
+++ b/docker/.env.release
@@ -1,4 +1,4 @@
-NODE_ENV="release"
+NODE_ENV=production
 RELEASE=true
 VERSION="0.9.28"
 DEBUG=false

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -91,8 +91,9 @@ ENV PROD=false
 ENV NODE_ENV="dev"
 ENV RELEASE=false
 ENV TEST=false
+ENV PORT=3000
 EXPOSE 3000
-COPY --from=builder --chown=node:node /app/build/client /app/build/client
+COPY --from=builder --chown=node:node /app/build /app/build
 
 USER node
 CMD ["npm", "run", "start"]

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -1,3 +1,8 @@
+// Known acceptable hydration mismatches (cosmetic, React handles gracefully):
+// - Navbar: Admin link only appears after client hydration for staff users
+//   (server renders without auth state, client adds it from sessionStorage)
+// - Zustand persist: hasHydrated is false during SSR, true after client hydration
+
 import { PassThrough } from 'node:stream';
 
 import { createReadableStreamFromReadable } from '@react-router/node';
@@ -36,6 +41,3 @@ export default function handleRequest(
     setTimeout(abort, 5000);
   });
 }
-
-// SPA mode: this file only runs at build time to generate the static HTML shell.
-// No server-side rendering or error handling occurs at runtime.

--- a/frontend/app/lib/seo.ts
+++ b/frontend/app/lib/seo.ts
@@ -27,10 +27,11 @@ export function generateMeta({
 }: MetaOptions) {
   const fullTitle = `${title} | ${SITE_NAME}`;
   const desc = description || DEFAULT_DESCRIPTION;
+  const isDefaultImage = !image;
   const img = image?.startsWith('http') ? image : `${SITE_URL}${image || DEFAULT_IMAGE}`;
   const pageUrl = url ? `${SITE_URL}${url}` : undefined;
 
-  const meta = [
+  const meta: Record<string, string>[] = [
     // Standard meta
     { title: fullTitle },
     { name: 'description', content: desc },
@@ -39,8 +40,6 @@ export function generateMeta({
     { property: 'og:title', content: fullTitle },
     { property: 'og:description', content: desc },
     { property: 'og:image', content: img },
-    { property: 'og:image:width', content: '1280' },
-    { property: 'og:image:height', content: '800' },
     { property: 'og:type', content: type },
     { property: 'og:site_name', content: SITE_NAME },
 
@@ -50,6 +49,12 @@ export function generateMeta({
     { name: 'twitter:description', content: desc },
     { name: 'twitter:image', content: img },
   ];
+
+  // Only include dimensions for the default OG image (known 1280x800)
+  if (isDefaultImage) {
+    meta.push({ property: 'og:image:width', content: '1280' });
+    meta.push({ property: 'og:image:height', content: '800' });
+  }
 
   // Add URL if provided
   if (pageUrl) {

--- a/frontend/app/lib/ssr-types.ts
+++ b/frontend/app/lib/ssr-types.ts
@@ -1,0 +1,46 @@
+/** Lightweight types matching backend SSR serializer responses. */
+
+export interface TournamentSSR {
+  pk: number;
+  name: string;
+  org_name: string | null;
+  org_logo: string | null;
+  league_name: string | null;
+}
+
+export interface OrganizationSSR {
+  pk: number;
+  name: string;
+  description: string;
+  logo: string;
+}
+
+export interface LeagueSSR {
+  pk: number;
+  name: string;
+  description: string;
+  org_name: string | null;
+  org_logo: string | null;
+}
+
+export interface EventSSR {
+  id: number;
+  name: string;
+  description: string;
+  org_name: string | null;
+  league_name: string | null;
+}
+
+export interface HeroDraftSSR {
+  pk: number;
+  tournament_name: string | null;
+  org_name: string | null;
+  team_names: string[];
+}
+
+export interface UserSSR {
+  pk: number;
+  username: string;
+  nickname: string | null;
+  avatar: string | null;
+}

--- a/frontend/app/lib/ssr-types.ts
+++ b/frontend/app/lib/ssr-types.ts
@@ -42,5 +42,5 @@ export interface UserSSR {
   pk: number;
   username: string;
   nickname: string | null;
-  avatar: string | null;
+  avatar_url: string | null;
 }

--- a/frontend/app/lib/ssr.server.ts
+++ b/frontend/app/lib/ssr.server.ts
@@ -1,0 +1,25 @@
+/**
+ * SSR data fetching utility.
+ *
+ * This module is server-only (.server.ts) — it reads SSR_API_URL from
+ * the Node process environment and fetches lightweight entity data from
+ * the Django backend for meta tags and above-the-fold skeletons.
+ */
+
+const SSR_API_URL = process.env.SSR_API_URL ?? "http://backend:8000/api";
+
+/**
+ * Fetch SSR data from a Django /ssr/ endpoint.
+ * Returns null on any error (404, network, timeout) — SSR should never block rendering.
+ */
+export async function fetchSSR<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${SSR_API_URL}${path}`, {
+      signal: AbortSignal.timeout(3000), // 3s timeout — don't block SSR
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -65,6 +65,10 @@ export function DevScripts() {
 
 // Create a client outside component to avoid recreation on renders
 // Exported so route loaders can seed the cache, avoiding double-fetches
+// WARNING: Module-level singleton shared across all concurrent SSR requests.
+// NEVER call setQueryData/prefetchQuery from a server-side loader().
+// Safe today because SSR only renders loading skeletons — no data is cached server-side.
+// If SSR scope expands to render real data, move to per-request factory.
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -2,10 +2,10 @@ import { generateMeta } from '~/lib/seo';
 import { getEvent } from '~/components/api/api';
 import { useParams, useNavigate } from 'react-router';
 import type { Route } from './+types/event';
-import { fetchSSR } from '~/lib/ssr.server';
 import type { EventSSR } from '~/lib/ssr-types';
 
 export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
   const event = await fetchSSR<EventSSR>(`/events/${params.eventId}/ssr/`);
   return { event };
 }

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -2,6 +2,13 @@ import { generateMeta } from '~/lib/seo';
 import { getEvent } from '~/components/api/api';
 import { useParams, useNavigate } from 'react-router';
 import type { Route } from './+types/event';
+import { fetchSSR } from '~/lib/ssr.server';
+import type { EventSSR } from '~/lib/ssr-types';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const event = await fetchSSR<EventSSR>(`/events/${params.eventId}/ssr/`);
+  return { event };
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const id = params.eventId ? parseInt(params.eventId, 10) : null;
@@ -16,13 +23,13 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 }
 
 export function meta({ data }: Route.MetaArgs) {
-  const event = data?.event;
+  const event = data?.event as EventSSR | null;
 
   if (event?.name) {
-    const orgName = event.organization_name ? ` by ${event.organization_name}` : '';
+    const orgName = event.org_name ? ` by ${event.org_name}` : '';
     return generateMeta({
       title: event.name,
-      description: `${event.name}${orgName} - Event details and signups`,
+      description: `${event.name}${orgName} — Event details and signups on DraftForge`,
       url: `/events/${event.id}`,
     });
   }

--- a/frontend/app/routes/herodraft.tsx
+++ b/frontend/app/routes/herodraft.tsx
@@ -1,10 +1,10 @@
 import HeroDraftPage from '~/pages/herodraft/HeroDraftPage';
 import { generateMeta } from '~/lib/seo';
-import { fetchSSR } from '~/lib/ssr.server';
 import type { HeroDraftSSR } from '~/lib/ssr-types';
 import type { Route } from './+types/herodraft';
 
 export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
   const draft = await fetchSSR<HeroDraftSSR>(`/herodraft/${params.id}/ssr/`);
   return { draft };
 }

--- a/frontend/app/routes/herodraft.tsx
+++ b/frontend/app/routes/herodraft.tsx
@@ -1,10 +1,36 @@
 import HeroDraftPage from '~/pages/herodraft/HeroDraftPage';
 import { generateMeta } from '~/lib/seo';
+import { fetchSSR } from '~/lib/ssr.server';
+import type { HeroDraftSSR } from '~/lib/ssr-types';
+import type { Route } from './+types/herodraft';
 
-export function meta() {
+export async function loader({ params }: Route.LoaderArgs) {
+  const draft = await fetchSSR<HeroDraftSSR>(`/herodraft/${params.id}/ssr/`);
+  return { draft };
+}
+
+export async function clientLoader() {
+  // HeroDraft loads its data via WebSocket, not REST.
+  // Return null to prevent unnecessary server round-trips on client navigation.
+  return { draft: null };
+}
+
+export function meta({ data }: Route.MetaArgs) {
+  const draft = data?.draft;
+
+  if (draft?.tournament_name) {
+    const teams = draft.team_names?.join(' vs ') || '';
+    const teamsText = teams ? ` — ${teams}` : '';
+    return generateMeta({
+      title: `Hero Draft: ${draft.tournament_name}`,
+      description: `Captain's Mode hero draft${teamsText} — ${draft.tournament_name} on DraftForge`,
+    });
+  }
+
   return generateMeta({
     title: 'Hero Draft',
     description: "Captain's Mode hero drafting tool for Dota 2",
   });
 }
+
 export default HeroDraftPage;

--- a/frontend/app/routes/league.tsx
+++ b/frontend/app/routes/league.tsx
@@ -2,6 +2,13 @@ import { generateMeta } from '~/lib/seo';
 import { fetchLeague } from '~/components/api/api';
 import { useParams, useNavigate } from 'react-router';
 import type { Route } from './+types/league';
+import { fetchSSR } from '~/lib/ssr.server';
+import type { LeagueSSR } from '~/lib/ssr-types';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const league = await fetchSSR<LeagueSSR>(`/leagues/${params.leagueId}/ssr/`);
+  return { league };
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const pk = params.leagueId ? parseInt(params.leagueId, 10) : null;
@@ -16,13 +23,13 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 }
 
 export function meta({ data }: Route.MetaArgs) {
-  const league = data?.league;
+  const league = data?.league as LeagueSSR | null;
 
   if (league?.name) {
-    const orgName = league.organization_name ? ` by ${league.organization_name}` : '';
+    const orgName = league.org_name ? ` by ${league.org_name}` : '';
     return generateMeta({
       title: league.name,
-      description: `${league.name}${orgName} - League standings and tournament schedule`,
+      description: `${league.name}${orgName} — League standings and tournament schedule on DraftForge`,
       url: `/leagues/${league.pk}`,
     });
   }

--- a/frontend/app/routes/league.tsx
+++ b/frontend/app/routes/league.tsx
@@ -2,10 +2,10 @@ import { generateMeta } from '~/lib/seo';
 import { fetchLeague } from '~/components/api/api';
 import { useParams, useNavigate } from 'react-router';
 import type { Route } from './+types/league';
-import { fetchSSR } from '~/lib/ssr.server';
 import type { LeagueSSR } from '~/lib/ssr-types';
 
 export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
   const league = await fetchSSR<LeagueSSR>(`/leagues/${params.leagueId}/ssr/`);
   return { league };
 }

--- a/frontend/app/routes/organization.tsx
+++ b/frontend/app/routes/organization.tsx
@@ -3,10 +3,10 @@ import { fetchOrganization } from '~/components/api/api';
 import { queryClient } from '~/root';
 import { Building2, Calendar, ClipboardList, ExternalLink, Mail, MailCheck, Pencil, Plus, Settings, Trash2, Upload, Users } from 'lucide-react';
 import type { Route } from './+types/organization';
-import { fetchSSR } from '~/lib/ssr.server';
 import type { OrganizationSSR } from '~/lib/ssr-types';
 
 export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
   const organization = await fetchSSR<OrganizationSSR>(`/organizations/${params.organizationId}/ssr/`);
   return { organization };
 }

--- a/frontend/app/routes/organization.tsx
+++ b/frontend/app/routes/organization.tsx
@@ -3,6 +3,13 @@ import { fetchOrganization } from '~/components/api/api';
 import { queryClient } from '~/root';
 import { Building2, Calendar, ClipboardList, ExternalLink, Mail, MailCheck, Pencil, Plus, Settings, Trash2, Upload, Users } from 'lucide-react';
 import type { Route } from './+types/organization';
+import { fetchSSR } from '~/lib/ssr.server';
+import type { OrganizationSSR } from '~/lib/ssr-types';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const organization = await fetchSSR<OrganizationSSR>(`/organizations/${params.organizationId}/ssr/`);
+  return { organization };
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const pk = params.organizationId ? parseInt(params.organizationId, 10) : null;
@@ -19,15 +26,16 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 }
 
 export function meta({ data }: Route.MetaArgs) {
-  const org = data?.organization;
+  const org = data?.organization as OrganizationSSR | null;
 
   if (org?.name) {
     const desc = org.description
       ? org.description.slice(0, 150)
-      : `${org.name} - Dota 2 tournament organization`;
+      : `${org.name} — Dota 2 tournament organization on DraftForge`;
     return generateMeta({
       title: org.name,
       description: desc,
+      image: org.logo || undefined,
       url: `/organizations/${org.pk}`,
     });
   }

--- a/frontend/app/routes/rollcall.tsx
+++ b/frontend/app/routes/rollcall.tsx
@@ -2,6 +2,13 @@ import { generateMeta } from '~/lib/seo';
 import { getEvent } from '~/components/api/api';
 import { useParams, useNavigate } from 'react-router';
 import type { Route } from './+types/rollcall';
+import type { EventSSR } from '~/lib/ssr-types';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
+  const event = await fetchSSR<EventSSR>(`/events/${params.eventId}/ssr/`);
+  return { event };
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const id = params.eventId ? parseInt(params.eventId, 10) : null;

--- a/frontend/app/routes/tournament.tsx
+++ b/frontend/app/routes/tournament.tsx
@@ -3,10 +3,10 @@ import { generateMeta } from '~/lib/seo';
 import { fetchTournament } from '~/components/api/api';
 import { queryClient } from '~/root';
 import type { Route } from './+types/tournament';
-import { fetchSSR } from '~/lib/ssr.server';
 import type { TournamentSSR } from '~/lib/ssr-types';
 
 export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
   const tournament = await fetchSSR<TournamentSSR>(`/tournaments/${params.pk}/ssr/`);
   return { tournament };
 }

--- a/frontend/app/routes/tournament.tsx
+++ b/frontend/app/routes/tournament.tsx
@@ -3,6 +3,13 @@ import { generateMeta } from '~/lib/seo';
 import { fetchTournament } from '~/components/api/api';
 import { queryClient } from '~/root';
 import type { Route } from './+types/tournament';
+import { fetchSSR } from '~/lib/ssr.server';
+import type { TournamentSSR } from '~/lib/ssr-types';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const tournament = await fetchSSR<TournamentSSR>(`/tournaments/${params.pk}/ssr/`);
+  return { tournament };
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const pk = params.pk ? parseInt(params.pk, 10) : null;
@@ -19,14 +26,14 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 }
 
 export function meta({ data }: Route.MetaArgs) {
-  const tournament = data?.tournament;
+  const tournament = data?.tournament as TournamentSSR | null;
 
   if (tournament?.name) {
-    const teamCount = tournament.teams?.length || 0;
+    const orgText = tournament.org_name ? ` presented by ${tournament.org_name}` : '';
     return generateMeta({
       title: tournament.name,
-      description: `${tournament.name} - ${teamCount} teams competing in Dota 2 tournament`,
-      image: '/assets/site_snapshots/tournament.png',
+      description: `${tournament.name}${orgText} — DraftForge tournament management, drafts, and team organization`,
+      image: tournament.org_logo || '/assets/site_snapshots/tournament.png',
       url: `/tournament/${tournament.pk}`,
     });
   }

--- a/frontend/app/routes/user.tsx
+++ b/frontend/app/routes/user.tsx
@@ -30,6 +30,7 @@ export function meta({ data }: Route.MetaArgs) {
     return generateMeta({
       title: displayName,
       description: `${displayName} — Dota 2 player profile on DraftForge`,
+      image: user.avatar_url || undefined,
       url: `/user/${user.pk}`,
     });
   }

--- a/frontend/app/routes/user.tsx
+++ b/frontend/app/routes/user.tsx
@@ -2,6 +2,13 @@ import { UserProfilePage } from '~/pages/user/UserProfilePage';
 import { generateMeta } from '~/lib/seo';
 import { fetchUser } from '~/components/api/api';
 import type { Route } from './+types/user';
+import { fetchSSR } from '~/lib/ssr.server';
+import type { UserSSR } from '~/lib/ssr-types';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const user = await fetchSSR<UserSSR>(`/users/${params.pk}/ssr/`);
+  return { user };
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const pk = params.pk ? parseInt(params.pk, 10) : null;
@@ -20,10 +27,9 @@ export function meta({ data }: Route.MetaArgs) {
 
   if (user) {
     const displayName = user.nickname || user.username || 'Player';
-    const mmrText = user.mmr ? ` - ${user.mmr} MMR` : '';
     return generateMeta({
       title: displayName,
-      description: `${displayName}${mmrText} - Dota 2 player profile and match history`,
+      description: `${displayName} — Dota 2 player profile on DraftForge`,
       url: `/user/${user.pk}`,
     });
   }

--- a/frontend/app/routes/user.tsx
+++ b/frontend/app/routes/user.tsx
@@ -2,10 +2,10 @@ import { UserProfilePage } from '~/pages/user/UserProfilePage';
 import { generateMeta } from '~/lib/seo';
 import { fetchUser } from '~/components/api/api';
 import type { Route } from './+types/user';
-import { fetchSSR } from '~/lib/ssr.server';
 import type { UserSSR } from '~/lib/ssr-types';
 
 export async function loader({ params }: Route.LoaderArgs) {
+  const { fetchSSR } = await import('~/lib/ssr.server');
   const user = await fetchSSR<UserSSR>(`/users/${params.pk}/ssr/`);
   return { user };
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "react-router dev --port 3000",
     "dev:fresh": "npm run clean:cache && VITE_FORCE_OPTIMIZE=true react-router dev --port 3000",
     "dev:prebuild": "npm run optimize && react-router dev --port 3000",
-    "start": "serve build/client -s -l 3000",
+    "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc",
     "clean:cache": "rm -rf node_modules/.vite node_modules/.cache .react-router",
     "optimize": "vite optimize",

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@react-router/dev/config";
 
 export default {
-  ssr: false,
+  ssr: true,
+  prerender: ["/", "/about"],
 } satisfies Config;

--- a/nginx/default.template.conf
+++ b/nginx/default.template.conf
@@ -143,7 +143,7 @@ server {
     }
 
     # React Router / Vite internal requests — never cache
-    location ~ ^/(__manifest|__data|@fs|@vite|@id|node_modules|app)/ {
+    location ~ ^/(__manifest|__data|@fs|@vite|@id|node_modules|app) {
         proxy_pass http://frontend_server;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/nginx/default.template.conf
+++ b/nginx/default.template.conf
@@ -1,3 +1,5 @@
+proxy_cache_path /var/cache/nginx/ssr levels=1:2 keys_zone=ssr_cache:10m max_size=100m inactive=30m;
+
 upstream backend_server {
     server backend:8000;
 }
@@ -132,14 +134,30 @@ server {
         proxy_connect_timeout 360s;
         proxy_read_timeout 360s;
     }
+    # Static assets (Vite content-hashed) — long cache, bypass SSR cache
+    location /assets/ {
+        proxy_pass http://frontend_server/assets/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # All other frontend routes — SSR with nginx cache
     location / {
+        proxy_cache ssr_cache;
+        proxy_cache_valid 200 10m;
+        proxy_cache_key $uri;
+        proxy_cache_use_stale error timeout updating;
+        proxy_cache_lock on;
+        proxy_cache_lock_timeout 5s;
+        add_header X-Cache-Status $upstream_cache_status;
+
         proxy_pass http://frontend_server/;
         proxy_http_version 1.1;
-        resolver 8.8.8.8 ipv6=off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
 

--- a/nginx/default.template.conf
+++ b/nginx/default.template.conf
@@ -156,7 +156,7 @@ server {
     location / {
         proxy_cache ssr_cache;
         proxy_cache_valid 200 10m;
-        proxy_cache_key $uri;
+        proxy_cache_key $uri;  # Intentionally excludes query strings — meta tags don't vary by params
         proxy_cache_use_stale error timeout updating;
         proxy_cache_lock on;
         proxy_cache_lock_timeout 5s;

--- a/nginx/default.template.conf
+++ b/nginx/default.template.conf
@@ -142,6 +142,16 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
+    # React Router / Vite internal requests — never cache
+    location ~ ^/(__manifest|__data|@fs|@vite|@id|node_modules|app)/ {
+        proxy_pass http://frontend_server;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
     # All other frontend routes — SSR with nginx cache
     location / {
         proxy_cache ssr_cache;


### PR DESCRIPTION
## Summary

- Add React Router SSR for dynamic entity pages (tournament, org, league, event, herodraft, user) so Discord/Twitter/Slack embeds show rich meta tags
- Prerender homepage and about page at build time (zero server cost)
- Add Nginx `proxy_cache` with 10min TTL to minimize Node SSR load
- New lightweight `/ssr/` Django endpoints with dedicated serializers for meta tag data

## Changes

**Backend:**
- New `serializers_ssr.py` with 6 lightweight serializers (Tournament, Organization, League, Event, HeroDraft, User)
- New `views/ssr.py` with public `RetrieveAPIView` endpoints using optimized querysets
- 6 new `/api/<entity>/<pk>/ssr/` URL paths
- Added HeroDraft/DraftTeam to cacheops config
- 9 backend tests covering all SSR endpoints

**Frontend:**
- `ssr: true` + `prerender: ["/", "/about"]` in react-router config
- Server-only `ssr.server.ts` fetch utility (reads `SSR_API_URL` env var)
- `loader()` functions on all 6 entity routes for server-side data fetching
- Updated `meta()` functions with dynamic titles/descriptions from SSR data
- HeroDraft gets a no-op `clientLoader` to prevent unnecessary server round-trips

**Infrastructure:**
- Dockerfile: copy full `build/` (client + server), switch to `react-router-serve`
- `NODE_ENV=production` in `.env.prod` and `.env.release`
- Nginx: `proxy_cache_path` + `/assets/` immutable cache + SSR cache with `proxy_cache_lock`

## Test plan

- [x] Backend SSR tests pass (9/9)
- [x] SSR meta tags verified via curl (`og:title`, `og:description` contain entity names)
- [x] Nginx cache returns `X-Cache-Status: HIT` on repeat requests
- [x] Prerendered pages (`/`, `/about`) serve static HTML with meta tags
- [x] Graceful fallback for nonexistent entities (generic meta tags, no crash)
- [ ] Playwright E2E tests pass (CI)