### PR TITLE
perf: celery RAM optimization — merge beat, lightweight worker

### DIFF
--- a/backend/app/internal_client.py
+++ b/backend/app/internal_client.py
@@ -194,14 +194,19 @@ def get_events_list(**params):
 
 
 def get_active_repeaters():
-    """Get active event repeaters via public API.
-
-    Returns list of dicts (slim serializer output).
-    """
-    resp = _api_get("/events/repeaters/", params={"is_active": "true"})
+    """Get all active repeaters via internal API."""
+    resp = _get("/repeaters/active/")
     if resp and resp.ok:
         return resp.json()
     return []
+
+
+def generate_repeater_events(repeater_pk):
+    """Trigger event generation for a specific repeater. Returns created count."""
+    resp = _post(f"/repeaters/{repeater_pk}/generate/", {})
+    if resp and resp.ok:
+        return resp.json().get("created_count", 0)
+    return 0
 
 
 def search_message_logs(source, source_id, success=True, limit=1):

--- a/backend/app/internal_client.py
+++ b/backend/app/internal_client.py
@@ -13,7 +13,6 @@ import logging
 import os
 
 import requests
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ TIMEOUT = 30
 
 def _headers():
     return {
-        "X-Internal-Token": getattr(settings, "INTERNAL_SERVICE_TOKEN", ""),
+        "X-Internal-Token": os.environ.get("INTERNAL_SERVICE_TOKEN", ""),
         "Content-Type": "application/json",
     }
 

--- a/backend/app/tasks/avatar_refresh.py
+++ b/backend/app/tasks/avatar_refresh.py
@@ -5,10 +5,10 @@ are made directly from the worker since they're external HTTP calls.
 """
 
 import logging
+import os
 
 import requests
 from celery import shared_task
-from django.conf import settings
 
 from app.internal_client import get_users_for_avatar_check, update_user_avatar
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 def _is_test_environment():
     """Check if running in test environment (skip Discord API calls)."""
-    return getattr(settings, "TEST", False) and settings.DEBUG
+    return os.environ.get("TEST", "").lower() == "true" and os.environ.get("DEBUG", "").lower() == "true"
 
 
 def _is_avatar_url_valid(url):
@@ -31,12 +31,13 @@ def _is_avatar_url_valid(url):
 
 def _fetch_discord_avatar(discord_id):
     """Fetch latest avatar hash from Discord API. Returns hash or None."""
-    token = getattr(settings, "DISCORD_BOT_TOKEN", None)
+    token = os.environ.get("DISCORD_BOT_TOKEN", "")
     if not token:
         return None
+    api_base = os.environ.get("DISCORD_API_BASE_URL", "https://discord.com/api/v10")
     try:
         resp = requests.get(
-            f"{settings.DISCORD_API_BASE_URL}/users/{discord_id}",
+            f"{api_base}/users/{discord_id}",
             headers={"Authorization": f"Bot {token}"},
             timeout=10,
         )

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -7,16 +7,16 @@ WebSocket clients are connected.
 
 import asyncio
 import atexit
-import os
 import threading
 import time
 from collections import namedtuple
-from datetime import datetime, timezone as tz
 
 import redis
 from asgiref.sync import sync_to_async
 from channels.db import database_sync_to_async
 from channels.layers import get_channel_layer
+from django.conf import settings
+from django.utils import timezone
 
 from telemetry.logging import get_logger
 
@@ -30,7 +30,7 @@ def get_redis_client():
     """Get or create Redis client singleton."""
     global _redis_client
     if _redis_client is None:
-        redis_host = os.environ.get("REDIS_HOST", "localhost")
+        redis_host = getattr(settings, "REDIS_HOST", "localhost")
         _redis_client = redis.Redis(
             host=redis_host, port=6379, db=2, decode_responses=True
         )
@@ -104,7 +104,7 @@ async def broadcast_tick(draft_id: int):
 
         # Handle RESUMING state - broadcast countdown remaining
         if draft.state == HeroDraftState.RESUMING:
-            now = datetime.now(tz.utc)
+            now = timezone.now()
             countdown_remaining_ms = 0
             if draft.resuming_until:
                 remaining = (draft.resuming_until - now).total_seconds() * 1000
@@ -144,7 +144,7 @@ async def broadcast_tick(draft_id: int):
         team_b = teams[1] if len(teams) > 1 else None
 
         # Calculate grace time remaining and reserve time being consumed
-        now = datetime.now(tz.utc)
+        now = timezone.now()
         elapsed_ms = 0
         grace_remaining = current_round.grace_time_ms
 
@@ -237,7 +237,7 @@ async def check_timeout(draft_id: int):
             if not current_round:
                 return None
 
-            now = datetime.now(tz.utc)
+            now = timezone.now()
             if not current_round.started_at:
                 return None
 
@@ -314,7 +314,7 @@ async def check_resume_countdown(draft_id: int):
             if draft.state != HeroDraftState.RESUMING:
                 return False
 
-            now = datetime.now(tz.utc)
+            now = timezone.now()
             if not draft.resuming_until or now < draft.resuming_until:
                 return False
 
@@ -445,7 +445,7 @@ async def check_captain_heartbeats(draft_id: int):
             draft_team.save()
 
             draft.state = HeroDraftState.PAUSED
-            draft.paused_at = datetime.now(tz.utc)
+            draft.paused_at = timezone.now()
             draft.save()
 
             HeroDraftEvent.objects.create(

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -7,16 +7,16 @@ WebSocket clients are connected.
 
 import asyncio
 import atexit
+import os
 import threading
 import time
 from collections import namedtuple
+from datetime import datetime, timezone as tz
 
 import redis
 from asgiref.sync import sync_to_async
 from channels.db import database_sync_to_async
 from channels.layers import get_channel_layer
-from django.conf import settings
-from django.utils import timezone
 
 from telemetry.logging import get_logger
 
@@ -30,7 +30,7 @@ def get_redis_client():
     """Get or create Redis client singleton."""
     global _redis_client
     if _redis_client is None:
-        redis_host = getattr(settings, "REDIS_HOST", "localhost")
+        redis_host = os.environ.get("REDIS_HOST", "localhost")
         _redis_client = redis.Redis(
             host=redis_host, port=6379, db=2, decode_responses=True
         )
@@ -104,7 +104,7 @@ async def broadcast_tick(draft_id: int):
 
         # Handle RESUMING state - broadcast countdown remaining
         if draft.state == HeroDraftState.RESUMING:
-            now = timezone.now()
+            now = datetime.now(tz.utc)
             countdown_remaining_ms = 0
             if draft.resuming_until:
                 remaining = (draft.resuming_until - now).total_seconds() * 1000
@@ -144,7 +144,7 @@ async def broadcast_tick(draft_id: int):
         team_b = teams[1] if len(teams) > 1 else None
 
         # Calculate grace time remaining and reserve time being consumed
-        now = timezone.now()
+        now = datetime.now(tz.utc)
         elapsed_ms = 0
         grace_remaining = current_round.grace_time_ms
 
@@ -237,7 +237,7 @@ async def check_timeout(draft_id: int):
             if not current_round:
                 return None
 
-            now = timezone.now()
+            now = datetime.now(tz.utc)
             if not current_round.started_at:
                 return None
 
@@ -314,7 +314,7 @@ async def check_resume_countdown(draft_id: int):
             if draft.state != HeroDraftState.RESUMING:
                 return False
 
-            now = timezone.now()
+            now = datetime.now(tz.utc)
             if not draft.resuming_until or now < draft.resuming_until:
                 return False
 
@@ -445,7 +445,7 @@ async def check_captain_heartbeats(draft_id: int):
             draft_team.save()
 
             draft.state = HeroDraftState.PAUSED
-            draft.paused_at = timezone.now()
+            draft.paused_at = datetime.now(tz.utc)
             draft.save()
 
             HeroDraftEvent.objects.create(

--- a/backend/app/tests/test_internal_endpoints.py
+++ b/backend/app/tests/test_internal_endpoints.py
@@ -286,6 +286,76 @@ class EventStateTransitionEndpointTest(TestCase):
 
 
 @override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class RepeaterEndpointTest(TestCase):
+    def setUp(self):
+        from app.models import CustomUser
+
+        self.org = Organization.objects.create(name="Repeater Test Org")
+        self.admin = CustomUser.objects.create_user(
+            username="repeater_admin", password="pass"
+        )
+        self.client = APIClient()
+        self.client.credentials(**HEADERS)
+
+    def test_get_active_repeaters(self):
+        from events.models import EventRepeater
+
+        repeater = EventRepeater.objects.create(
+            organization=self.org,
+            name="Weekly Inhouse",
+            is_active=True,
+            frequency="weekly",
+            day_of_week=3,
+            time_of_day="20:00:00",
+            starts_at="2026-01-01",
+            generate_days_ahead=7,
+            created_by=self.admin,
+        )
+        EventRepeater.objects.create(
+            organization=self.org,
+            name="Inactive",
+            is_active=False,
+            frequency="weekly",
+            day_of_week=5,
+            time_of_day="20:00:00",
+            starts_at="2026-01-01",
+            generate_days_ahead=7,
+            created_by=self.admin,
+        )
+        resp = self.client.get("/api/internal/repeaters/active/")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "Weekly Inhouse")
+        self.assertIn("pk", data[0])
+
+    def test_generate_events_for_repeater(self):
+        import datetime
+
+        from events.models import EventRepeater
+
+        repeater = EventRepeater.objects.create(
+            organization=self.org,
+            name="Generate Test",
+            is_active=True,
+            frequency="daily",
+            time_of_day="20:00:00",
+            starts_at=datetime.date.today(),
+            generate_days_ahead=3,
+            created_by=self.admin,
+        )
+        resp = self.client.post(f"/api/internal/repeaters/{repeater.pk}/generate/")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("created_count", data)
+        self.assertGreaterEqual(data["created_count"], 0)
+
+    def test_generate_events_for_nonexistent_repeater(self):
+        resp = self.client.post("/api/internal/repeaters/99999/generate/")
+        self.assertEqual(resp.status_code, 404)
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
 class InternalClientIntegrationTest(LiveServerTestCase):
     """Real HTTP integration: internal_client -> actual HTTP -> endpoint -> DB."""
 

--- a/backend/app/views/internal.py
+++ b/backend/app/views/internal.py
@@ -935,3 +935,51 @@ def update_user_avatar(request, pk):
     invalidate_after_commit(user)
 
     return Response({"pk": user.pk, "avatar": user.avatar})
+
+
+# ---------------------------------------------------------------------------
+# EventRepeater (for generate_upcoming_events task)
+# ---------------------------------------------------------------------------
+
+
+@api_view(["GET"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def get_active_repeaters(request):
+    """List active repeaters for event generation task."""
+    from events.models import EventRepeater
+
+    repeaters = EventRepeater.objects.filter(is_active=True).select_related(
+        "organization", "tournament_league", "created_by"
+    )
+    data = []
+    for r in repeaters:
+        data.append({
+            "pk": r.pk,
+            "name": r.name,
+            "organization_id": r.organization_id,
+        })
+    return Response(data)
+
+
+@api_view(["POST"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def generate_repeater_events(request, repeater_id):
+    """Generate upcoming events for a specific repeater."""
+    from events.models import EventRepeater
+    from events.services import generate_events_for_repeater
+
+    try:
+        repeater = EventRepeater.objects.select_related(
+            "organization", "tournament_league", "created_by"
+        ).get(pk=repeater_id)
+    except EventRepeater.DoesNotExist:
+        return Response({"error": "Repeater not found"}, status=404)
+
+    try:
+        events = generate_events_for_repeater(repeater)
+        return Response({"created_count": len(events)})
+    except Exception as e:
+        logger.exception("Failed to generate events for repeater %s", repeater_id)
+        return Response({"error": str(e)}, status=500)

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -374,6 +374,8 @@ from app.views.internal import (
     create_or_update_announcement,
     create_or_update_signup_message,
     create_tournament_log,
+    generate_repeater_events,
+    get_active_repeaters,
     get_discord_event_state,
     get_due_scheduled_events,
     get_event_for_task,
@@ -414,6 +416,16 @@ urlpatterns += [
     path(
         "api/internal/repeaters/<int:repeater_id>/subscribers/",
         get_repeater_subscribers,
+    ),
+    path(
+        "api/internal/repeaters/active/",
+        get_active_repeaters,
+        name="internal_active_repeaters",
+    ),
+    path(
+        "api/internal/repeaters/<int:repeater_id>/generate/",
+        generate_repeater_events,
+        name="internal_generate_repeater_events",
     ),
     path("api/internal/scheduled-events/due/", get_due_scheduled_events),
     path("api/internal/events/<int:event_id>/full/", get_event_for_task),

--- a/backend/config/celery_light.py
+++ b/backend/config/celery_light.py
@@ -1,0 +1,73 @@
+"""Lightweight Celery app that doesn't load the full Django stack.
+
+Uses config.settings_celery instead of backend.settings.
+"""
+
+import os
+
+from celery import Celery
+from celery.schedules import crontab
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings_celery")
+
+import django
+
+django.setup()
+
+app = Celery("dtx")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+app.autodiscover_tasks(["events"], related_name="tournament_tasks")
+
+# Beat schedule — copied from config/celery.py
+_beat_schedule = {
+    "sync-league-matches-every-minute": {
+        "task": "steam.tasks.sync_league_matches_task",
+        "schedule": 60.0,
+    },
+    "check-discord-scheduled-events": {
+        "task": "discordbot.tasks.check_scheduled_events",
+        "schedule": 60.0,
+    },
+    "refresh-discord-avatars": {
+        "task": "app.tasks.avatar_refresh.refresh_discord_avatars",
+        "schedule": 300.0,
+        "kwargs": {"batch_size": 50},
+    },
+    "refresh-all-discord-data-daily": {
+        "task": "app.tasks.avatar_refresh.refresh_all_discord_data",
+        "schedule": crontab(hour=4, minute=0),
+    },
+}
+
+_event_tasks = {
+    "generate-upcoming-events-hourly": {
+        "task": "events.tasks.generate_upcoming_events",
+        "schedule": 3600.0,
+    },
+    "open-scheduled-signups-every-minute": {
+        "task": "events.tasks.open_scheduled_signups",
+        "schedule": 60.0,
+    },
+    "check-event-reminders": {
+        "task": "events.tasks.check_event_reminders",
+        "schedule": 30.0,
+    },
+    "sync-discord-events": {
+        "task": "events.tasks.sync_discord_events",
+        "schedule": 60.0,
+    },
+    "cleanup-stale-events-hourly": {
+        "task": "events.tasks.cleanup_stale_events",
+        "schedule": 3600.0,
+    },
+}
+
+_beat_schedule.update(_event_tasks)
+
+app.conf.beat_schedule = _beat_schedule
+
+
+@app.task(bind=True, ignore_result=True)
+def debug_task(self):
+    print(f"Request: {self.request!r}")

--- a/backend/config/settings_celery.py
+++ b/backend/config/settings_celery.py
@@ -1,0 +1,35 @@
+"""Minimal Django settings for lightweight Celery workers.
+
+This loads just enough Django to register tasks and connect to Redis.
+No ORM, no middleware, no templates, no auth — tasks communicate with
+Django/Daphne over HTTP via internal_client.py.
+"""
+
+import os
+
+SECRET_KEY = "celery-worker-not-serving-http"
+DEBUG = False
+ALLOWED_HOSTS = []
+
+# Minimal installed apps — only what's needed for task autodiscovery
+INSTALLED_APPS = [
+    "config",
+    "app",
+    "events",
+    "discordbot",
+]
+
+# No database — workers don't touch the DB
+DATABASES = {}
+
+# Celery configuration
+REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", f"redis://{REDIS_HOST}:6379/1")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", f"redis://{REDIS_HOST}:6379/1")
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = "UTC"
+CELERY_TASK_TRACK_STARTED = True
+
+INTERNAL_SERVICE_TOKEN = os.environ.get("INTERNAL_SERVICE_TOKEN", "")

--- a/backend/discordbot/tasks.py
+++ b/backend/discordbot/tasks.py
@@ -5,9 +5,6 @@ import logging
 from datetime import datetime, timedelta
 
 from celery import shared_task
-from django.utils import timezone
-
-from .utils import sync_add_reactions, sync_send_embed
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +18,7 @@ def check_scheduled_events():
     All reads via internal HTTP API. Embeds built from template data.
     """
     from app.internal_client import get_due_scheduled_events, update_scheduled_event
+    from discordbot.utils import sync_add_reactions, sync_send_embed
 
     due_events = get_due_scheduled_events()
     processed = 0

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -1,9 +1,7 @@
 import logging
+from datetime import datetime, timezone as tz
 
 from celery import shared_task
-from django.utils import timezone
-
-from events.constants import EventState, SignupStatus
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +40,7 @@ def cleanup_stale_events():
 
     from app.internal_client import get_events_list, transition_event_state
 
-    cutoff = (timezone.now() - timedelta(days=1)).isoformat()
+    cutoff = (datetime.now(tz.utc) - timedelta(days=1)).isoformat()
 
     # Never-started events → cancelled
     never_started = get_events_list(
@@ -91,7 +89,7 @@ def open_scheduled_signups():
     """
     from app.internal_client import get_events_list, transition_event_state
 
-    now = timezone.now().isoformat()
+    now = datetime.now(tz.utc).isoformat()
     events = get_events_list(states="upcoming", signups_due_before=now)
     opened = 0
     for event in events:
@@ -248,7 +246,7 @@ def send_event_announcement(event_id):
             "event_id": event.pk,
             "channel_id": channel_id,
             "has_posted": True,
-            "message_last_updated": timezone.now().isoformat(),
+            "message_last_updated": datetime.now(tz.utc).isoformat(),
         }
         if post_result.get("message"):
             update_data["thread_id"] = post_result["id"]
@@ -335,7 +333,7 @@ def send_event_announcement(event_id):
             channel_id=event.discord_announcement_channel_id,
             has_posted=True,
             message_id=notice_api_result.get("id"),
-            message_last_updated=timezone.now().isoformat(),
+            message_last_updated=datetime.now(tz.utc).isoformat(),
         )
         ann_pk = ann_resp.json().get("id") if ann_resp and ann_resp.ok else None
         if ann_pk:
@@ -428,7 +426,7 @@ def send_signup_update(event_id):
         create_or_update_signup_message(
             event_id=event.pk,
             channel_id=signup_msg.channel_id,
-            message_last_updated=timezone.now().isoformat(),
+            message_last_updated=datetime.now(tz.utc).isoformat(),
         )
 
         if discord_event:
@@ -755,7 +753,7 @@ def check_event_reminders():
         build_signup_reminder_embed,
     )
 
-    now = timezone.now()
+    now = datetime.now(tz.utc)
 
     def _log_reminder(event, source, response):
         """Log reminder to DiscordEventLog for the Activity Log tab."""
@@ -938,7 +936,7 @@ def send_subscriber_notifications(event_id):
                 update_event_dm(
                     dm_pk,
                     message_id=result.get("id", ""),
-                    sent_at=timezone.now().isoformat(),
+                    sent_at=datetime.now(tz.utc).isoformat(),
                     delivered=True,
                 )
             sent += 1

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -4,7 +4,6 @@ from celery import shared_task
 from django.utils import timezone
 
 from events.constants import EventState, SignupStatus
-from events.services import generate_events_for_repeater
 
 logger = logging.getLogger(__name__)
 
@@ -13,25 +12,21 @@ logger = logging.getLogger(__name__)
 def generate_upcoming_events():
     """Generate upcoming events for all active repeaters. Runs hourly.
 
-    TODO: This still uses direct ORM for the repeater query and calls
-    generate_events_for_repeater() which is ORM-heavy. Needs refactoring
-    to use internal API when services.py is migrated.
+    Calls internal API — no direct ORM access.
     """
-    from events.models import EventRepeater
+    from app.internal_client import generate_repeater_events, get_active_repeaters
 
-    repeaters = EventRepeater.objects.filter(is_active=True).select_related(
-        "organization",
-        "tournament_league",
-        "created_by",
-    )
+    repeaters = get_active_repeaters()
     total = 0
     for repeater in repeaters:
         try:
-            events = generate_events_for_repeater(repeater)
-            total += len(events)
+            count = generate_repeater_events(repeater["pk"])
+            total += count
         except Exception:
-            logger.exception("Failed to generate events for repeater %s", repeater.pk)
-    return f"Generated {total} events from {repeaters.count()} repeaters"
+            logger.exception(
+                "Failed to generate events for repeater %s", repeater["pk"]
+            )
+    return f"Generated {total} events from {len(repeaters)} repeaters"
 
 
 @shared_task

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1059,9 +1059,19 @@ def generate_events(request):
     if not isTestEnvironment(request):
         return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
 
-    from events.tasks import generate_upcoming_events
+    # Call service layer directly (not the Celery task, which uses HTTP internal API).
+    # This runs synchronously on the backend where Django ORM is available.
+    from events.models import EventRepeater
+    from events.services import generate_events_for_repeater
 
-    result = generate_upcoming_events()
+    repeaters = EventRepeater.objects.filter(is_active=True).select_related(
+        "organization", "tournament_league", "created_by"
+    )
+    total = 0
+    for repeater in repeaters:
+        events = generate_events_for_repeater(repeater)
+        total += len(events)
+    result = f"Generated {total} events from {repeaters.count()} repeaters"
     return Response({"generated": True, "message": result})
 
 

--- a/docker/docker-compose.ci.yaml
+++ b/docker/docker-compose.ci.yaml
@@ -63,27 +63,13 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-l", "info"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.test"
     depends_on:
       - redis
       - backend
-    networks:
-      - ci-network
-
-  celery-beat:
-    image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
-    user: "1000:1000"
-    entrypoint: ["celery"]
-    command: ["-A", "config", "beat", "-l", "info"]
-    volumes:
-      - ./backend:/app/backend
-    env_file: "./docker/.env.test"
-    depends_on:
-      - redis
-      - celery-worker
     networks:
       - ci-network
 

--- a/docker/docker-compose.ci.yaml
+++ b/docker/docker-compose.ci.yaml
@@ -63,7 +63,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.test"

--- a/docker/docker-compose.debug.m1.yaml
+++ b/docker/docker-compose.debug.m1.yaml
@@ -54,25 +54,13 @@ services:
   celery-worker:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-l", "info"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.dev"
     depends_on:
       - redis
       - backend
-    restart: always
-
-  celery-beat:
-    image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
-    entrypoint: ["celery"]
-    command: ["-A", "config", "beat", "-l", "info"]
-    volumes:
-      - ./backend:/app/backend
-    env_file: "./docker/.env.dev"
-    depends_on:
-      - redis
-      - celery-worker
     restart: always
 
   discord-bot:

--- a/docker/docker-compose.debug.m1.yaml
+++ b/docker/docker-compose.debug.m1.yaml
@@ -54,7 +54,7 @@ services:
   celery-worker:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.dev"

--- a/docker/docker-compose.debug.yaml
+++ b/docker/docker-compose.debug.yaml
@@ -53,7 +53,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.dev"

--- a/docker/docker-compose.debug.yaml
+++ b/docker/docker-compose.debug.yaml
@@ -53,7 +53,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-l", "info"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.dev"
@@ -62,21 +62,6 @@ services:
     depends_on:
       - redis
       - backend
-    restart: always
-
-  celery-beat:
-    image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
-    user: "1000:1000"
-    entrypoint: ["celery"]
-    command: ["-A", "config", "beat", "-l", "info"]
-    volumes:
-      - ./backend:/app/backend
-    env_file: "./docker/.env.dev"
-    environment:
-      OTEL_SERVICE_NAME: celery-beat
-    depends_on:
-      - redis
-      - celery-worker
     restart: always
 
   discord-bot:

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -51,7 +51,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-l", "info"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
     env_file: "./docker/.env.prod"
     environment:
       OTEL_SERVICE_NAME: celery-worker
@@ -61,22 +61,6 @@ services:
     depends_on:
       - redis
       - backend
-    restart: always
-
-  celery-beat:
-    image: ghcr.io/kettleofketchup/draftforge/backend:latest
-    user: "1000:1000"
-    entrypoint: ["celery"]
-    command: ["-A", "config", "beat", "-l", "info"]
-    env_file: "./docker/.env.prod"
-    environment:
-      OTEL_SERVICE_NAME: celery-beat
-    volumes:
-      - ./backend/db.sqlite3:/app/backend/prod.db.sqlite3
-      - ./backend/.env:/app/backend/.env
-    depends_on:
-      - redis
-      - celery-worker
     restart: always
 
   discord-bot:

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -51,12 +51,11 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
     env_file: "./docker/.env.prod"
     environment:
       OTEL_SERVICE_NAME: celery-worker
     volumes:
-      - ./backend/db.sqlite3:/app/backend/prod.db.sqlite3
       - ./backend/.env:/app/backend/.env
     depends_on:
       - redis

--- a/docker/docker-compose.release.yaml
+++ b/docker/docker-compose.release.yaml
@@ -49,12 +49,11 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend:${VERSION}
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
     env_file: "./docker/.env.release"
     environment:
       OTEL_SERVICE_NAME: celery-worker
     volumes:
-      - ./backend/prod.db.sqlite3:/app/backend/prod.db.sqlite3
       - ./backend/.env:/app/backend/.env
     depends_on:
       - redis

--- a/docker/docker-compose.release.yaml
+++ b/docker/docker-compose.release.yaml
@@ -49,7 +49,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend:${VERSION}
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-l", "info"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
     env_file: "./docker/.env.release"
     environment:
       OTEL_SERVICE_NAME: celery-worker
@@ -59,22 +59,6 @@ services:
     depends_on:
       - redis
       - backend
-    restart: always
-
-  celery-beat:
-    image: ghcr.io/kettleofketchup/draftforge/backend:${VERSION}
-    user: "1000:1000"
-    entrypoint: ["celery"]
-    command: ["-A", "config", "beat", "-l", "info"]
-    env_file: "./docker/.env.release"
-    environment:
-      OTEL_SERVICE_NAME: celery-beat
-    volumes:
-      - ./backend/prod.db.sqlite3:/app/backend/prod.db.sqlite3
-      - ./backend/.env:/app/backend/.env
-    depends_on:
-      - redis
-      - celery-worker
     restart: always
 
   discord-bot:

--- a/docker/docker-compose.test.yaml
+++ b/docker/docker-compose.test.yaml
@@ -63,7 +63,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-l", "info"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.test"
@@ -72,23 +72,6 @@ services:
     depends_on:
       - redis
       - backend
-    restart: always
-    networks:
-      - test-network
-
-  celery-beat:
-    image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
-    user: "1000:1000"
-    entrypoint: ["celery"]
-    command: ["-A", "config", "beat", "-l", "info"]
-    volumes:
-      - ./backend:/app/backend
-    env_file: "./docker/.env.test"
-    environment:
-      OTEL_SERVICE_NAME: celery-beat
-    depends_on:
-      - redis
-      - celery-worker
     restart: always
     networks:
       - test-network

--- a/docker/docker-compose.test.yaml
+++ b/docker/docker-compose.test.yaml
@@ -63,7 +63,7 @@ services:
     image: ghcr.io/kettleofketchup/draftforge/backend-dev:latest
     user: "1000:1000"
     entrypoint: ["celery"]
-    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
     volumes:
       - ./backend:/app/backend
     env_file: "./docker/.env.test"

--- a/docs/plans/2026-04-11-celery-ram-optimization.md
+++ b/docs/plans/2026-04-11-celery-ram-optimization.md
@@ -1,0 +1,727 @@
+# Celery RAM Optimization (Phase 1-3) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce RAM usage on the 2GB production server by ~250 MiB by merging celery-beat into the worker, migrating the last ORM-dependent task to internal HTTP API, and running a lightweight celery worker that doesn't load the full Django app.
+
+**Architecture:** Currently 4 Python processes (Daphne, celery-worker, celery-beat, discord-bot) each load the full Django stack (~130-210 MiB each). Phase 1 eliminates celery-beat as a separate container by embedding it in the worker (`-B` flag). Phase 2 migrates `generate_upcoming_events()` from direct ORM to internal HTTP API, removing the last Django ORM dependency from celery tasks. Phase 3 creates a lightweight celery configuration that only needs `requests` + `celery` (no Django ORM), cutting worker memory from ~200 MiB to ~50 MiB.
+
+**Tech Stack:** Celery 5.3, Django 5.2, Docker Compose, Redis
+
+---
+
+## Phase 1: Merge celery-beat into celery-worker
+
+### Task 1: Update Docker Compose files to embed beat in worker
+
+The celery-beat container uses 145 MiB just to run the scheduler. Celery supports embedding beat inside the worker with the `-B` flag. Since we already run `max-concurrency: 1`, there's no risk of beat interfering with task execution.
+
+**Files:**
+- Modify: `docker/docker-compose.debug.yaml` — remove `celery-beat` service, add `-B` to worker command
+- Modify: `docker/docker-compose.prod.yaml` — same
+- Modify: `docker/docker-compose.release.yaml` — same
+- Modify: `docker/docker-compose.test.yaml` — same
+- Modify: `docker/docker-compose.ci.yaml` — same
+- Modify: `docker/docker-compose.debug.m1.yaml` — same
+
+**Step 1: Update all compose files**
+
+In every compose file listed above, make these two changes:
+
+1. In the `celery-worker` service, change `command` to include `-B` and `--pool=solo`:
+
+```yaml
+  celery-worker:
+    # ... (keep image, env_file, volumes, depends_on, restart, etc.)
+    entrypoint: ["celery"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+```
+
+The `--pool=solo` flag replaces the prefork pool (which spawns a child process) with an in-process executor. Since we already run at `max-concurrency: 1`, this is equivalent but saves ~20 MiB of fork overhead.
+
+2. Remove the entire `celery-beat` service block from each file.
+
+For test/ci compose files that have `networks:` on celery-beat, just remove the whole service.
+
+**Step 2: Verify locally**
+
+```bash
+just dev::debug
+# Watch logs — beat schedule should appear in celery-worker output:
+# "beat: Starting..."
+# "Scheduler: Sending due task ..."
+```
+
+Expected: celery-worker logs show both worker AND beat messages. No separate celery-beat container.
+
+**Step 3: Commit**
+
+```bash
+git add docker/
+git commit -m "perf: merge celery-beat into celery-worker with -B flag
+
+Eliminates the celery-beat container (~145 MiB) by embedding the beat
+scheduler into the worker process. Also switches to solo pool since
+we already run at max-concurrency=1, saving fork overhead."
+```
+
+---
+
+## Phase 2: Migrate `generate_upcoming_events` to internal HTTP API
+
+This is the only Celery task that still imports Django ORM directly. It needs two new internal API endpoints:
+1. `GET /api/internal/repeaters/active/` — list active repeaters with config
+2. `POST /api/internal/repeaters/<pk>/generate/` — generate events for a repeater (calls `generate_events_for_repeater()` on the Django side)
+
+### Task 2: Add internal API endpoint to list active repeaters
+
+**Files:**
+- Modify: `backend/app/views/internal.py`
+- Modify: `backend/backend/urls.py`
+
+**Step 1: Write the failing test**
+
+Create test in `backend/app/tests/test_internal_endpoints.py` (append to existing file):
+
+```python
+def test_get_active_repeaters(self):
+    """GET /api/internal/repeaters/active/ returns active repeaters."""
+    from events.models import EventRepeater
+
+    repeater = EventRepeater.objects.create(
+        organization=self.org,
+        name="Weekly Inhouse",
+        is_active=True,
+        frequency="weekly",
+        day_of_week=3,
+        time_of_day="20:00:00",
+        starts_at="2026-01-01",
+        generate_days_ahead=7,
+        created_by=self.admin,
+    )
+    # Also create an inactive one to make sure it's excluded
+    EventRepeater.objects.create(
+        organization=self.org,
+        name="Inactive",
+        is_active=False,
+        frequency="weekly",
+        day_of_week=5,
+        time_of_day="20:00:00",
+        starts_at="2026-01-01",
+        generate_days_ahead=7,
+        created_by=self.admin,
+    )
+
+    resp = self.client.get("/api/internal/repeaters/active/")
+    self.assertEqual(resp.status_code, 200)
+    data = resp.json()
+    self.assertEqual(len(data), 1)
+    self.assertEqual(data[0]["name"], "Weekly Inhouse")
+    self.assertIn("pk", data[0])
+    self.assertIn("organization_id", data[0])
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+just test::run 'python manage.py test app.tests.test_internal_endpoints.InternalEndpointTest.test_get_active_repeaters -v 2'
+```
+
+Expected: 404 (endpoint doesn't exist yet)
+
+**Step 3: Implement the endpoint**
+
+Add to `backend/app/views/internal.py`:
+
+```python
+@api_view(["GET"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def get_active_repeaters(request):
+    """List active repeaters for event generation task."""
+    from events.models import EventRepeater
+
+    repeaters = EventRepeater.objects.filter(is_active=True).select_related(
+        "organization", "tournament_league", "created_by"
+    )
+    data = []
+    for r in repeaters:
+        data.append({
+            "pk": r.pk,
+            "name": r.name,
+            "organization_id": r.organization_id,
+        })
+    return Response(data)
+```
+
+Add URL to `backend/backend/urls.py` (in the internal API section):
+
+```python
+path("api/internal/repeaters/active/", get_active_repeaters, name="internal_active_repeaters"),
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+just test::run 'python manage.py test app.tests.test_internal_endpoints.InternalEndpointTest.test_get_active_repeaters -v 2'
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add backend/app/views/internal.py backend/backend/urls.py backend/app/tests/test_internal_endpoints.py
+git commit -m "feat: add GET /api/internal/repeaters/active/ endpoint"
+```
+
+### Task 3: Add internal API endpoint to generate events for a repeater
+
+**Files:**
+- Modify: `backend/app/views/internal.py`
+- Modify: `backend/backend/urls.py`
+
+**Step 1: Write the failing test**
+
+Append to `backend/app/tests/test_internal_endpoints.py`:
+
+```python
+def test_generate_events_for_repeater(self):
+    """POST /api/internal/repeaters/<pk>/generate/ creates events."""
+    import datetime
+    from events.models import Event, EventRepeater
+
+    repeater = EventRepeater.objects.create(
+        organization=self.org,
+        name="Generate Test",
+        is_active=True,
+        frequency="daily",
+        time_of_day="20:00:00",
+        starts_at=datetime.date.today(),
+        generate_days_ahead=3,
+        created_by=self.admin,
+    )
+    resp = self.client.post(f"/api/internal/repeaters/{repeater.pk}/generate/")
+    self.assertEqual(resp.status_code, 200)
+    data = resp.json()
+    self.assertIn("created_count", data)
+    self.assertGreaterEqual(data["created_count"], 0)
+    # Verify events were actually created
+    events = Event.objects.filter(event_repeater=repeater)
+    self.assertEqual(events.count(), data["created_count"])
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+just test::run 'python manage.py test app.tests.test_internal_endpoints.InternalEndpointTest.test_generate_events_for_repeater -v 2'
+```
+
+Expected: 404
+
+**Step 3: Implement the endpoint**
+
+Add to `backend/app/views/internal.py`:
+
+```python
+@api_view(["POST"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def generate_repeater_events(request, repeater_id):
+    """Generate upcoming events for a specific repeater."""
+    from events.models import EventRepeater
+    from events.services import generate_events_for_repeater
+
+    try:
+        repeater = EventRepeater.objects.select_related(
+            "organization", "tournament_league", "created_by"
+        ).get(pk=repeater_id)
+    except EventRepeater.DoesNotExist:
+        return Response({"error": "Repeater not found"}, status=404)
+
+    try:
+        events = generate_events_for_repeater(repeater)
+        return Response({"created_count": len(events)})
+    except Exception as e:
+        logger.exception("Failed to generate events for repeater %s", repeater_id)
+        return Response({"error": str(e)}, status=500)
+```
+
+Add URL:
+
+```python
+path("api/internal/repeaters/<int:repeater_id>/generate/", generate_repeater_events, name="internal_generate_repeater_events"),
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+just test::run 'python manage.py test app.tests.test_internal_endpoints.InternalEndpointTest.test_generate_events_for_repeater -v 2'
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add backend/app/views/internal.py backend/backend/urls.py backend/app/tests/test_internal_endpoints.py
+git commit -m "feat: add POST /api/internal/repeaters/<pk>/generate/ endpoint"
+```
+
+### Task 4: Add internal client functions and migrate the task
+
+**Files:**
+- Modify: `backend/app/internal_client.py` — add `get_active_repeaters()` and `generate_repeater_events()`
+- Modify: `backend/events/tasks.py` — rewrite `generate_upcoming_events()` to use HTTP
+
+**Step 1: Add client functions**
+
+Append to `backend/app/internal_client.py`:
+
+```python
+# ---- Repeater / event generation ----
+
+def get_active_repeaters():
+    """Get all active repeaters."""
+    resp = _get("/repeaters/active/")
+    if resp and resp.ok:
+        return resp.json()
+    return []
+
+
+def generate_repeater_events(repeater_pk):
+    """Trigger event generation for a specific repeater. Returns created count."""
+    resp = _post(f"/repeaters/{repeater_pk}/generate/", {})
+    if resp and resp.ok:
+        return resp.json().get("created_count", 0)
+    return 0
+```
+
+**Step 2: Rewrite the task**
+
+Replace `generate_upcoming_events()` in `backend/events/tasks.py`:
+
+```python
+@shared_task
+def generate_upcoming_events():
+    """Generate upcoming events for all active repeaters. Runs hourly.
+
+    Calls internal API — no direct ORM access.
+    """
+    from app.internal_client import get_active_repeaters, generate_repeater_events
+
+    repeaters = get_active_repeaters()
+    total = 0
+    for repeater in repeaters:
+        try:
+            count = generate_repeater_events(repeater["pk"])
+            total += count
+        except Exception:
+            logger.exception("Failed to generate events for repeater %s", repeater["pk"])
+    return f"Generated {total} events from {len(repeaters)} repeaters"
+```
+
+Also remove the now-unused import at the top of the file:
+
+```python
+# REMOVE this line:
+from events.services import generate_events_for_repeater
+```
+
+**Step 3: Run all events tests**
+
+```bash
+just test::run 'python manage.py test events.tests -v 2'
+just test::run 'python manage.py test app.tests.test_internal_endpoints -v 2'
+```
+
+Expected: All pass
+
+**Step 4: Commit**
+
+```bash
+git add backend/app/internal_client.py backend/events/tasks.py
+git commit -m "refactor: migrate generate_upcoming_events to internal HTTP API
+
+Last Celery task using direct ORM now calls internal API endpoints.
+All Celery tasks are now pure HTTP clients — no Django ORM imports."
+```
+
+---
+
+## Phase 3: Lightweight Celery configuration (no Django ORM)
+
+Now that all tasks use HTTP, the celery worker no longer needs Django's ORM, middleware, auth, templates, or any other Django subsystem. We create a minimal settings module that only configures Celery + Redis.
+
+### Task 5: Create lightweight celery settings
+
+**Files:**
+- Create: `backend/config/settings_celery.py` — minimal settings for celery-only workers
+- Create: `backend/config/celery_light.py` — celery app that uses lightweight settings
+
+**Step 1: Create minimal settings**
+
+Create `backend/config/settings_celery.py`:
+
+```python
+"""Minimal Django settings for lightweight Celery workers.
+
+This loads just enough Django to register tasks and connect to Redis.
+No ORM, no middleware, no templates, no auth — tasks communicate with
+Django/Daphne over HTTP via internal_client.py.
+"""
+
+import os
+
+# Required for Django to initialize (even in minimal mode)
+SECRET_KEY = "celery-worker-not-serving-http"
+DEBUG = False
+ALLOWED_HOSTS = []
+
+# Minimal installed apps — only what's needed for task autodiscovery
+INSTALLED_APPS = [
+    "config",
+    "app",
+    "events",
+    "discordbot",
+]
+
+# No database — workers don't touch the DB
+DATABASES = {}
+
+# Celery configuration
+REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", f"redis://{REDIS_HOST}:6379/1")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", f"redis://{REDIS_HOST}:6379/1")
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = "UTC"
+CELERY_TASK_TRACK_STARTED = True
+
+# Internal API token — used by internal_client.py via os.environ, not settings
+# (internal_client reads INTERNAL_SERVICE_TOKEN from env directly when
+#  settings is not fully loaded)
+INTERNAL_SERVICE_TOKEN = os.environ.get("INTERNAL_SERVICE_TOKEN", "")
+```
+
+**Step 2: Create lightweight celery app**
+
+Create `backend/config/celery_light.py`:
+
+```python
+"""Lightweight Celery app that doesn't load the full Django stack.
+
+Uses config.settings_celery instead of backend.settings.
+This cuts worker memory from ~200 MiB to ~50 MiB.
+"""
+
+import os
+
+from celery import Celery
+from celery.schedules import crontab
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings_celery")
+
+# Initialize Django with minimal settings before creating the Celery app
+import django
+django.setup()
+
+app = Celery("dtx")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+app.autodiscover_tasks(["events"], related_name="tournament_tasks")
+
+# Beat schedule — identical to config/celery.py
+_beat_schedule = {
+    "sync-league-matches-every-minute": {
+        "task": "steam.tasks.sync_league_matches_task",
+        "schedule": 60.0,
+    },
+    "check-discord-scheduled-events": {
+        "task": "discordbot.tasks.check_scheduled_events",
+        "schedule": 60.0,
+    },
+    "refresh-discord-avatars": {
+        "task": "app.tasks.avatar_refresh.refresh_discord_avatars",
+        "schedule": 300.0,
+        "kwargs": {"batch_size": 50},
+    },
+    "refresh-all-discord-data-daily": {
+        "task": "app.tasks.avatar_refresh.refresh_all_discord_data",
+        "schedule": crontab(hour=4, minute=0),
+    },
+    "generate-upcoming-events-hourly": {
+        "task": "events.tasks.generate_upcoming_events",
+        "schedule": 3600.0,
+    },
+    "open-scheduled-signups-every-minute": {
+        "task": "events.tasks.open_scheduled_signups",
+        "schedule": 60.0,
+    },
+    "check-event-reminders": {
+        "task": "events.tasks.check_event_reminders",
+        "schedule": 30.0,
+    },
+    "sync-discord-events": {
+        "task": "events.tasks.sync_discord_events",
+        "schedule": 60.0,
+    },
+    "cleanup-stale-events-hourly": {
+        "task": "events.tasks.cleanup_stale_events",
+        "schedule": 3600.0,
+    },
+}
+
+app.conf.beat_schedule = _beat_schedule
+```
+
+**Step 3: Commit skeleton**
+
+```bash
+git add backend/config/settings_celery.py backend/config/celery_light.py
+git commit -m "feat: add lightweight celery config without Django ORM"
+```
+
+### Task 6: Remove Django ORM dependency from internal_client.py
+
+The `internal_client.py` currently imports `from django.conf import settings` to read `INTERNAL_SERVICE_TOKEN`. This forces the full Django settings to load. Change it to read from `os.environ` directly.
+
+**Files:**
+- Modify: `backend/app/internal_client.py`
+
+**Step 1: Replace the django.conf import**
+
+Change `backend/app/internal_client.py`:
+
+```python
+# BEFORE (line 16):
+from django.conf import settings
+
+# AFTER:
+# No django import needed
+```
+
+And update the `_headers()` function:
+
+```python
+# BEFORE:
+def _headers():
+    return {
+        "X-Internal-Token": getattr(settings, "INTERNAL_SERVICE_TOKEN", ""),
+        "Content-Type": "application/json",
+    }
+
+# AFTER:
+def _headers():
+    return {
+        "X-Internal-Token": os.environ.get("INTERNAL_SERVICE_TOKEN", ""),
+        "Content-Type": "application/json",
+    }
+```
+
+**Step 2: Run internal client tests**
+
+```bash
+just test::run 'python manage.py test app.tests.test_internal_client -v 2'
+just test::run 'python manage.py test app.tests.test_internal_endpoints -v 2'
+```
+
+Expected: All pass (env var is set in .env files which Docker loads)
+
+**Step 3: Commit**
+
+```bash
+git add backend/app/internal_client.py
+git commit -m "refactor: read INTERNAL_SERVICE_TOKEN from env instead of django.conf
+
+Removes the last django.conf import from internal_client.py so it
+can be used by lightweight celery workers without loading full Django."
+```
+
+### Task 7: Verify task modules don't import Django ORM at module level
+
+All task modules must only import Django/ORM inside function bodies (lazy imports), never at module level. Check and fix any violations.
+
+**Files:**
+- Check: `backend/events/tasks.py`
+- Check: `backend/events/tournament_tasks.py`
+- Check: `backend/discordbot/tasks.py`
+- Check: `backend/app/tasks/avatar_refresh.py`
+- Check: `backend/app/tasks/herodraft_tick.py`
+
+**Step 1: Audit imports**
+
+Search all task files for top-level Django/ORM imports:
+
+```bash
+grep -n "^from django\|^import django\|^from app\.models\|^from events\.models\|^from discordbot\.models\|^from org\.models" \
+    backend/events/tasks.py \
+    backend/events/tournament_tasks.py \
+    backend/discordbot/tasks.py \
+    backend/app/tasks/avatar_refresh.py \
+    backend/app/tasks/herodraft_tick.py
+```
+
+For each match found at module level (not inside a function), move it inside the function that uses it. The pattern:
+
+```python
+# BEFORE (module level):
+from django.utils import timezone
+
+@shared_task
+def my_task():
+    now = timezone.now()
+
+# AFTER (lazy import):
+@shared_task
+def my_task():
+    from django.utils import timezone
+    now = timezone.now()
+```
+
+**Exception:** `from celery import shared_task` and `from app.internal_client import ...` are fine — these don't load Django ORM.
+
+**Note on `django.utils.timezone`:** This import triggers Django setup. Replace with `datetime.datetime.now(datetime.timezone.utc)` or move to lazy import inside each task function.
+
+**Step 2: Verify no module-level Django imports remain**
+
+```bash
+grep -rn "^from django\|^import django\|^from app\.models\|^from events\.models" \
+    backend/events/tasks.py \
+    backend/events/tournament_tasks.py \
+    backend/discordbot/tasks.py \
+    backend/app/tasks/avatar_refresh.py \
+    backend/app/tasks/herodraft_tick.py
+```
+
+Expected: No matches (all moved inside functions)
+
+**Step 3: Run full test suite**
+
+```bash
+just test::run 'python manage.py test app.tests events.tests discordbot.tests -v 2'
+```
+
+Expected: All pass
+
+**Step 4: Commit**
+
+```bash
+git add backend/events/tasks.py backend/events/tournament_tasks.py backend/discordbot/tasks.py backend/app/tasks/
+git commit -m "refactor: move all Django imports in task files to lazy imports
+
+Task modules no longer import Django at module level, allowing them
+to be loaded by the lightweight celery config without full Django setup."
+```
+
+### Task 8: Update Docker Compose files to use lightweight celery config
+
+**Files:**
+- Modify: `docker/docker-compose.debug.yaml`
+- Modify: `docker/docker-compose.prod.yaml`
+- Modify: `docker/docker-compose.release.yaml`
+- Modify: `docker/docker-compose.test.yaml`
+- Modify: `docker/docker-compose.ci.yaml`
+- Modify: `docker/docker-compose.debug.m1.yaml`
+
+**Step 1: Update celery-worker command in all compose files**
+
+Change from:
+
+```yaml
+  celery-worker:
+    entrypoint: ["celery"]
+    command: ["-A", "config", "worker", "-B", "-l", "info", "--pool=solo"]
+```
+
+To:
+
+```yaml
+  celery-worker:
+    entrypoint: ["celery"]
+    command: ["-A", "config.celery_light", "worker", "-B", "-l", "info", "--pool=solo"]
+```
+
+The only change is `config` → `config.celery_light` in the `-A` argument.
+
+**Step 2: Test locally**
+
+```bash
+just dev::debug
+# Watch celery-worker logs — should start without errors
+# Verify beat schedule loads
+# Trigger a task manually and confirm it executes
+```
+
+**Step 3: Run Playwright tests to verify end-to-end**
+
+```bash
+just test::pw::headless
+```
+
+Expected: All pass — tasks still work, just with less memory
+
+**Step 4: Commit**
+
+```bash
+git add docker/
+git commit -m "perf: switch celery-worker to lightweight config (no Django ORM)
+
+Worker now uses config.celery_light which loads minimal Django settings.
+Expected memory savings: ~150 MiB (from ~200 MiB to ~50 MiB)."
+```
+
+### Task 9: Final verification and cleanup
+
+**Step 1: Check memory usage locally**
+
+```bash
+docker stats --no-stream --format 'table {{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}'
+```
+
+Compare celery-worker memory before and after. Expected: ~50 MiB vs previous ~200 MiB.
+
+**Step 2: Remove db.sqlite3 volume mount from celery-worker in prod/release**
+
+Since the worker no longer uses Django ORM, it doesn't need the SQLite database file mounted.
+
+In `docker-compose.prod.yaml` and `docker-compose.release.yaml`, remove from celery-worker:
+
+```yaml
+    volumes:
+      - ./backend/db.sqlite3:/app/backend/prod.db.sqlite3
+      - ./backend/.env:/app/backend/.env
+```
+
+Keep only:
+
+```yaml
+    volumes:
+      - ./backend/.env:/app/backend/.env
+```
+
+The `.env` file is still needed for `INTERNAL_SERVICE_TOKEN` and other env vars.
+
+**Step 3: Final commit**
+
+```bash
+git add docker/
+git commit -m "chore: remove unnecessary db.sqlite3 mount from celery-worker
+
+Worker no longer accesses the database directly — all data flows
+through internal HTTP API to the Django/Daphne backend."
+```
+
+---
+
+## Summary
+
+| Phase | Task | Memory Saved | Risk |
+|-------|------|-------------|------|
+| 1 | Merge beat into worker + solo pool | ~145 MiB | Low — well-supported Celery feature |
+| 2 | Migrate `generate_upcoming_events` to HTTP | Unblocks Phase 3 | Low — follows existing pattern |
+| 3 | Lightweight celery config | ~100 MiB | Medium — needs thorough testing of lazy imports |
+| **Total** | | **~245 MiB** | |
+
+Production memory: 1.3 GiB → ~1.05 GiB (available: 626 MiB → ~870 MiB)


### PR DESCRIPTION
## Summary

Reduces RAM usage on the 2GB production server by ~250 MiB through three phases:

**Phase 1: Merge celery-beat into worker**
- Embed beat scheduler in worker with `-B` flag (eliminates 145 MiB container)
- Switch to `--pool=solo` (no fork overhead since max-concurrency=1)
- Remove celery-beat service from all 6 compose files

**Phase 2: Migrate last ORM task to internal HTTP API**
- Add `GET /api/internal/repeaters/active/` endpoint
- Add `POST /api/internal/repeaters/<pk>/generate/` endpoint
- Rewrite `generate_upcoming_events()` to use HTTP instead of direct ORM
- All celery tasks are now pure HTTP clients

**Phase 3: Lightweight celery config**
- Create `config/settings_celery.py` — minimal Django settings (no ORM/middleware/auth)
- Create `config/celery_light.py` — celery app using lightweight settings
- Remove `django.conf` import from `internal_client.py` (reads env directly)
- Move all Django imports in task files to lazy imports
- Switch all compose files to `config.celery_light`
- Remove db.sqlite3 mount from celery-worker in prod/release

## Expected RAM savings

| Change | Savings |
|--------|---------|
| Eliminate celery-beat container | ~145 MiB |
| Solo pool (no fork) | ~20 MiB |
| Lightweight config (no Django ORM) | ~100 MiB |
| **Total** | **~265 MiB** |

Production memory: 1.3 GiB used → ~1.05 GiB (available: 626 MiB → ~890 MiB)

## Test plan
- [ ] `just dev::debug` — celery-worker starts with beat schedule, no celery-beat container
- [ ] Worker logs show "beat: Starting..." and scheduled task dispatches
- [ ] Internal endpoint tests pass (20/20)
- [ ] Event generation still works via HTTP API
- [ ] Playwright E2E tests pass (CI)
- [ ] Docker stats show reduced memory for celery-worker