### PR TITLE
feat: separate celery beat/worker — make workers DB-free

### DIFF
--- a/backend/app/internal_client.py
+++ b/backend/app/internal_client.py
@@ -327,7 +327,45 @@ def get_due_scheduled_events():
     return []
 
 
-# ---- Steam writes ----
+# ---- Steam sync ----
+
+
+def get_steam_sync_state(league_id):
+    """Get LeagueSyncState for a league (creates if missing)."""
+    resp = _get(f"/steam/sync-state/{league_id}/")
+    if resp and resp.ok:
+        return resp.json()
+    return None
+
+
+def update_steam_sync_state(league_id, **fields):
+    """Update sync state fields. Returns True on success."""
+    resp = _patch(f"/steam/sync-state/{league_id}/", fields)
+    return resp is not None and resp.ok
+
+
+def store_steam_match(match_data):
+    """Store a match + player stats. Returns response dict or None."""
+    resp = _post("/steam/store-match/", match_data)
+    if resp and resp.ok:
+        return resp.json()
+    return None
+
+
+def update_league_stats(league_id):
+    """Trigger league stats recalculation. Returns updated_count or None."""
+    resp = _post(f"/steam/update-league-stats/{league_id}/", {})
+    if resp and resp.ok:
+        return resp.json().get("updated_count")
+    return None
+
+
+def recalculate_user_mmr(user_id):
+    """Recalculate a user's league MMR. Returns response dict or None."""
+    resp = _post(f"/steam/recalculate-mmr/{user_id}/", {})
+    if resp and resp.ok:
+        return resp.json()
+    return None
 
 
 def batch_upsert_matches(data):

--- a/backend/app/tests/test_internal_steam.py
+++ b/backend/app/tests/test_internal_steam.py
@@ -1,0 +1,85 @@
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+TOKEN = "test-internal-token"
+HEADERS = {"HTTP_X_INTERNAL_TOKEN": TOKEN}
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class SteamSyncStateEndpointTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = "/api/internal/steam/sync-state/12345/"
+
+    def test_get_creates_state_if_missing(self):
+        resp = self.client.get(self.url, **HEADERS)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["league_id"], 12345)
+        self.assertFalse(data["is_syncing"])
+        self.assertIsNone(data["last_match_id"])
+        self.assertEqual(data["failed_match_ids"], [])
+
+    def test_get_returns_existing_state(self):
+        from steam.models import LeagueSyncState
+
+        LeagueSyncState.objects.create(
+            league_id=12345,
+            is_syncing=True,
+            last_match_id=99999,
+            failed_match_ids=[111, 222],
+        )
+        resp = self.client.get(self.url, **HEADERS)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["league_id"], 12345)
+        self.assertTrue(data["is_syncing"])
+        self.assertEqual(data["last_match_id"], 99999)
+        self.assertEqual(data["failed_match_ids"], [111, 222])
+
+    def test_patch_updates_allowed_fields(self):
+        from steam.models import LeagueSyncState
+
+        LeagueSyncState.objects.create(league_id=12345)
+        resp = self.client.patch(
+            self.url,
+            {
+                "is_syncing": True,
+                "last_match_id": 77777,
+                "failed_match_ids": [333],
+            },
+            format="json",
+            **HEADERS,
+        )
+        self.assertEqual(resp.status_code, 200)
+        state = LeagueSyncState.objects.get(league_id=12345)
+        self.assertTrue(state.is_syncing)
+        self.assertEqual(state.last_match_id, 77777)
+        self.assertEqual(state.failed_match_ids, [333])
+        self.assertIsNotNone(state.last_sync_at)
+
+    def test_patch_ignores_unknown_fields(self):
+        from steam.models import LeagueSyncState
+
+        LeagueSyncState.objects.create(league_id=12345)
+        resp = self.client.patch(
+            self.url,
+            {"league_id": 99999, "is_syncing": True},
+            format="json",
+            **HEADERS,
+        )
+        self.assertEqual(resp.status_code, 200)
+        state = LeagueSyncState.objects.get(league_id=12345)
+        # league_id should NOT have changed
+        self.assertEqual(state.league_id, 12345)
+        self.assertTrue(state.is_syncing)
+
+    def test_rejects_unauthenticated_requests(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_rejects_wrong_token(self):
+        resp = self.client.get(
+            self.url, HTTP_X_INTERNAL_TOKEN="wrong-token"
+        )
+        self.assertEqual(resp.status_code, 403)

--- a/backend/app/tests/test_internal_steam.py
+++ b/backend/app/tests/test_internal_steam.py
@@ -83,3 +83,124 @@ class SteamSyncStateEndpointTest(TestCase):
             self.url, HTTP_X_INTERNAL_TOKEN="wrong-token"
         )
         self.assertEqual(resp.status_code, 403)
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class StoreMatchEndpointTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = "/api/internal/steam/store-match/"
+
+    def _match_payload(self, match_id=7000000001, players=None):
+        """Build a minimal match payload matching Steam API structure."""
+        if players is None:
+            players = [
+                {
+                    "account_id": 12345,
+                    "player_slot": 0,
+                    "hero_id": 1,
+                    "kills": 10,
+                    "deaths": 2,
+                    "assists": 15,
+                    "gold_per_min": 500,
+                    "xp_per_min": 600,
+                    "last_hits": 200,
+                    "denies": 10,
+                    "hero_damage": 25000,
+                    "tower_damage": 3000,
+                    "hero_healing": 0,
+                }
+            ]
+        return {
+            "match_id": match_id,
+            "radiant_win": True,
+            "duration": 2400,
+            "start_time": 1700000000,
+            "game_mode": 22,
+            "lobby_type": 1,
+            "league_id": 12345,
+            "players": players,
+        }
+
+    def test_creates_match_and_players(self):
+        from app.models import CustomUser
+        from steam.models import Match, PlayerMatchStats
+
+        # Create a user with matching steamid (32-bit 12345 -> 64-bit)
+        steam_id_64 = 12345 + 76561197960265728
+        user = CustomUser.objects.create_user(
+            username="testplayer", password="pass", steamid=steam_id_64
+        )
+
+        resp = self.client.post(
+            self.url, self._match_payload(), format="json", **HEADERS
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["match_id"], 7000000001)
+        self.assertTrue(data["created"])
+        self.assertEqual(data["players_stored"], 1)
+        self.assertEqual(data["players_linked"], 1)
+
+        # Verify Match created
+        match = Match.objects.get(match_id=7000000001)
+        self.assertTrue(match.radiant_win)
+        self.assertEqual(match.duration, 2400)
+
+        # Verify PlayerMatchStats created and user linked
+        stats = PlayerMatchStats.objects.get(match=match, steam_id=steam_id_64)
+        self.assertEqual(stats.kills, 10)
+        self.assertEqual(stats.user, user)
+
+    def test_updates_existing_match(self):
+        from steam.models import Match, PlayerMatchStats
+
+        # First POST creates
+        self.client.post(self.url, self._match_payload(), format="json", **HEADERS)
+        self.assertEqual(Match.objects.count(), 1)
+        self.assertEqual(PlayerMatchStats.objects.count(), 1)
+
+        # Second POST with same match_id updates (no duplicate)
+        payload = self._match_payload()
+        payload["duration"] = 3000
+        resp = self.client.post(self.url, payload, format="json", **HEADERS)
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertFalse(data["created"])
+
+        self.assertEqual(Match.objects.count(), 1)
+        self.assertEqual(PlayerMatchStats.objects.count(), 1)
+        match = Match.objects.get(match_id=7000000001)
+        self.assertEqual(match.duration, 3000)
+
+    def test_skips_players_without_account_id(self):
+        from steam.models import PlayerMatchStats
+
+        players = [
+            {
+                "player_slot": 0,
+                "hero_id": 1,
+                "kills": 0,
+                "deaths": 0,
+                "assists": 0,
+                "gold_per_min": 0,
+                "xp_per_min": 0,
+                "last_hits": 0,
+                "denies": 0,
+                "hero_damage": 0,
+                "tower_damage": 0,
+                "hero_healing": 0,
+            }
+        ]
+        resp = self.client.post(
+            self.url, self._match_payload(players=players), format="json", **HEADERS
+        )
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.json()["players_stored"], 0)
+        self.assertEqual(PlayerMatchStats.objects.count(), 0)
+
+    def test_rejects_missing_match_id(self):
+        payload = self._match_payload()
+        del payload["match_id"]
+        resp = self.client.post(self.url, payload, format="json", **HEADERS)
+        self.assertEqual(resp.status_code, 400)

--- a/backend/app/tests/test_internal_steam.py
+++ b/backend/app/tests/test_internal_steam.py
@@ -1,6 +1,9 @@
 from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
+from app.models import CustomUser
+from steam.models import Match, PlayerMatchStats
+
 TOKEN = "test-internal-token"
 HEADERS = {"HTTP_X_INTERNAL_TOKEN": TOKEN}
 
@@ -204,3 +207,89 @@ class StoreMatchEndpointTest(TestCase):
         del payload["match_id"]
         resp = self.client.post(self.url, payload, format="json", **HEADERS)
         self.assertEqual(resp.status_code, 400)
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class UpdateLeagueStatsEndpointTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = CustomUser.objects.create_user(
+            username="statsplayer", steamid=76561198000000001
+        )
+        # Create a match with player stats linked to user
+        match = Match.objects.create(
+            match_id=9000000001,
+            radiant_win=True,
+            duration=2000,
+            start_time=1713600000,
+            game_mode=2,
+            lobby_type=1,
+            league_id=17929,
+        )
+        PlayerMatchStats.objects.create(
+            match=match,
+            steam_id=76561198000000001,
+            user=self.user,
+            player_slot=0,
+            hero_id=1,
+            kills=5,
+            deaths=2,
+            assists=10,
+            gold_per_min=400,
+            xp_per_min=500,
+            last_hits=150,
+            denies=5,
+            hero_damage=15000,
+            tower_damage=2000,
+            hero_healing=0,
+        )
+
+    def test_updates_stats(self):
+        resp = self.client.post(
+            "/api/internal/steam/update-league-stats/17929/",
+            format="json",
+            **HEADERS,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["updated_count"], 1)
+        # Verify stats were created
+        from steam.models import LeaguePlayerStats
+
+        stats = LeaguePlayerStats.objects.get(user=self.user, league_id=17929)
+        self.assertEqual(stats.games_played, 1)
+        self.assertEqual(stats.wins, 1)
+
+    def test_no_stats_returns_zero(self):
+        resp = self.client.post(
+            "/api/internal/steam/update-league-stats/99999/",
+            format="json",
+            **HEADERS,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["updated_count"], 0)
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class RecalculateMmrEndpointTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = CustomUser.objects.create_user(
+            username="mmrplayer", steamid=76561198000000002
+        )
+
+    def test_recalculates_mmr(self):
+        resp = self.client.post(
+            f"/api/internal/steam/recalculate-mmr/{self.user.pk}/",
+            format="json",
+            **HEADERS,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["user_id"], self.user.pk)
+
+    def test_user_not_found(self):
+        resp = self.client.post(
+            "/api/internal/steam/recalculate-mmr/99999/",
+            format="json",
+            **HEADERS,
+        )
+        self.assertEqual(resp.status_code, 404)

--- a/backend/app/views/internal_steam.py
+++ b/backend/app/views/internal_steam.py
@@ -1,0 +1,54 @@
+"""Internal API endpoints for Steam/match sync operations.
+
+All endpoints require InternalServiceAuth (X-Internal-Token header).
+"""
+
+from django.utils import timezone
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.response import Response
+
+from app.auth import InternalServiceAuth, IsInternalService
+from app.cache_utils import invalidate_after_commit
+
+_auth = [InternalServiceAuth]
+_perm = [IsInternalService]
+
+SYNC_STATE_ALLOWED_FIELDS = {"is_syncing", "last_match_id", "failed_match_ids"}
+
+
+@api_view(["GET", "PATCH"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def steam_sync_state(request, league_id):
+    """GET: return (or create) sync state for a league. PATCH: update allowed fields."""
+    from steam.models import LeagueSyncState
+
+    if request.method == "GET":
+        state, _created = LeagueSyncState.objects.get_or_create(league_id=league_id)
+        return Response({
+            "league_id": state.league_id,
+            "is_syncing": state.is_syncing,
+            "last_match_id": state.last_match_id,
+            "last_sync_at": state.last_sync_at.isoformat() if state.last_sync_at else None,
+            "failed_match_ids": state.failed_match_ids,
+        })
+
+    # PATCH
+    state = LeagueSyncState.objects.get(league_id=league_id)
+    for field in SYNC_STATE_ALLOWED_FIELDS:
+        if field in request.data:
+            setattr(state, field, request.data[field])
+    state.last_sync_at = timezone.now()
+    state.save()
+    invalidate_after_commit(state)
+    return Response({
+        "league_id": state.league_id,
+        "is_syncing": state.is_syncing,
+        "last_match_id": state.last_match_id,
+        "last_sync_at": state.last_sync_at.isoformat() if state.last_sync_at else None,
+        "failed_match_ids": state.failed_match_ids,
+    })

--- a/backend/app/views/internal_steam.py
+++ b/backend/app/views/internal_steam.py
@@ -3,6 +3,8 @@
 All endpoints require InternalServiceAuth (X-Internal-Token header).
 """
 
+import logging
+
 from django.utils import timezone
 from rest_framework.decorators import (
     api_view,
@@ -13,6 +15,8 @@ from rest_framework.response import Response
 
 from app.auth import InternalServiceAuth, IsInternalService
 from app.cache_utils import invalidate_after_commit
+
+logger = logging.getLogger(__name__)
 
 _auth = [InternalServiceAuth]
 _perm = [IsInternalService]
@@ -52,3 +56,85 @@ def steam_sync_state(request, league_id):
         "last_sync_at": state.last_sync_at.isoformat() if state.last_sync_at else None,
         "failed_match_ids": state.failed_match_ids,
     })
+
+
+STEAM_ID_64_BASE = 76561197960265728
+
+
+@api_view(["POST"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def store_match(request):
+    """Store a match and its player stats from raw Steam API data."""
+    from app.models import CustomUser
+    from steam.models import Match, PlayerMatchStats
+
+    data = request.data
+    match_id = data.get("match_id")
+    if not match_id:
+        return Response({"error": "match_id is required"}, status=400)
+
+    # Create or update the Match record
+    match, created = Match.objects.update_or_create(
+        match_id=match_id,
+        defaults={
+            "radiant_win": data["radiant_win"],
+            "duration": data["duration"],
+            "start_time": data["start_time"],
+            "game_mode": data["game_mode"],
+            "lobby_type": data["lobby_type"],
+            "league_id": data.get("league_id"),
+        },
+    )
+
+    players_stored = 0
+    players_linked = 0
+
+    for player in data.get("players", []):
+        account_id = player.get("account_id")
+        if not account_id:
+            continue
+
+        steam_id_64 = account_id + STEAM_ID_64_BASE
+
+        stats, _ = PlayerMatchStats.objects.update_or_create(
+            match=match,
+            steam_id=steam_id_64,
+            defaults={
+                "player_slot": player["player_slot"],
+                "hero_id": player["hero_id"],
+                "kills": player["kills"],
+                "deaths": player["deaths"],
+                "assists": player["assists"],
+                "gold_per_min": player["gold_per_min"],
+                "xp_per_min": player["xp_per_min"],
+                "last_hits": player["last_hits"],
+                "denies": player["denies"],
+                "hero_damage": player["hero_damage"],
+                "tower_damage": player["tower_damage"],
+                "hero_healing": player["hero_healing"],
+            },
+        )
+
+        # Link user by steamid
+        try:
+            user = CustomUser.objects.get(steamid=steam_id_64)
+            stats.user = user
+            stats.save(update_fields=["user"])
+            players_linked += 1
+        except CustomUser.DoesNotExist:
+            pass
+
+        players_stored += 1
+
+    invalidate_after_commit(match)
+
+    return Response(
+        {
+            "match_id": match_id,
+            "created": created,
+            "players_stored": players_stored,
+            "players_linked": players_linked,
+        },
+        status=201,
+    )

--- a/backend/app/views/internal_steam.py
+++ b/backend/app/views/internal_steam.py
@@ -11,6 +11,7 @@ from rest_framework.decorators import (
     authentication_classes,
     permission_classes,
 )
+from rest_framework import status
 from rest_framework.response import Response
 
 from app.auth import InternalServiceAuth, IsInternalService
@@ -138,3 +139,31 @@ def store_match(request):
         },
         status=201,
     )
+
+
+@api_view(["POST"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def update_league_stats(request, league_id):
+    """Recalculate LeaguePlayerStats for all users in a league."""
+    from steam.functions.stats_update import update_all_league_stats_for_league
+
+    updated_count = update_all_league_stats_for_league(league_id)
+    return Response({"updated_count": updated_count})
+
+
+@api_view(["POST"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def recalculate_mmr(request, user_id):
+    """Recalculate a single user's league MMR."""
+    from app.models import CustomUser
+    from steam.functions.mmr_calculation import update_user_league_mmr
+
+    try:
+        user = CustomUser.objects.get(pk=user_id)
+    except CustomUser.DoesNotExist:
+        return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    update_user_league_mmr(user)
+    return Response({"user_id": user_id, "status": "recalculated"})

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -456,10 +456,11 @@ urlpatterns += [
 ]
 
 # Internal API — Steam sync endpoints
-from app.views.internal_steam import steam_sync_state
+from app.views.internal_steam import steam_sync_state, store_match
 
 urlpatterns += [
     path("api/internal/steam/sync-state/<int:league_id>/", steam_sync_state),
+    path("api/internal/steam/store-match/", store_match),
 ]
 
 log.debug(f"Test Environ:  {isTestEnvironment()}")

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -456,11 +456,20 @@ urlpatterns += [
 ]
 
 # Internal API — Steam sync endpoints
-from app.views.internal_steam import steam_sync_state, store_match
+from app.views.internal_steam import (
+    recalculate_mmr,
+    steam_sync_state,
+    store_match,
+    update_league_stats,
+)
 
 urlpatterns += [
     path("api/internal/steam/sync-state/<int:league_id>/", steam_sync_state),
     path("api/internal/steam/store-match/", store_match),
+    path(
+        "api/internal/steam/update-league-stats/<int:league_id>/", update_league_stats
+    ),
+    path("api/internal/steam/recalculate-mmr/<int:user_id>/", recalculate_mmr),
 ]
 
 log.debug(f"Test Environ:  {isTestEnvironment()}")

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -455,6 +455,13 @@ urlpatterns += [
     path("api/internal/users/<int:pk>/avatar/", update_user_avatar),
 ]
 
+# Internal API — Steam sync endpoints
+from app.views.internal_steam import steam_sync_state
+
+urlpatterns += [
+    path("api/internal/steam/sync-state/<int:league_id>/", steam_sync_state),
+]
+
 log.debug(f"Test Environ:  {isTestEnvironment()}")
 if isTestEnvironment():
     log.debug("Adding test environment URLs")

--- a/backend/config/settings_celery.py
+++ b/backend/config/settings_celery.py
@@ -1,12 +1,9 @@
-"""Minimal Django settings for Celery workers.
+"""Minimal Django settings for Celery workers. No ORM, no DB.
 
-Loads just enough Django to register tasks, connect to Redis, and access
-the database (steam tasks use ORM directly). No middleware, no templates.
-Event tasks communicate with Django/Daphne over HTTP via internal_client.py.
+Tasks communicate with Django/Daphne over HTTP via internal_client.py.
 """
 
 import os
-from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -28,26 +25,8 @@ INSTALLED_APPS = [
     "steam",
 ]
 
-# Database — steam tasks (sync_league_matches, update_league_stats) use ORM
-BASE_DIR = Path(__file__).resolve().parent.parent
-
-db_name = "prod.db.sqlite3"
-match os.environ.get("NODE_ENV", "").lower():
-    case "dev":
-        db_name = "dev.db.sqlite3"
-    case "test":
-        db_name = "test.db.sqlite3"
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / db_name,
-        "OPTIONS": {
-            "timeout": 30,
-            "transaction_mode": "IMMEDIATE",
-        },
-    }
-}
+# No database — all tasks use internal HTTP API
+DATABASES = {}
 
 # Celery configuration
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")

--- a/backend/steam/tasks.py
+++ b/backend/steam/tasks.py
@@ -1,10 +1,23 @@
+"""Celery tasks for Steam league sync.
+
+All DB operations via internal HTTP API — no ORM imports.
+Workers can run off-host with only broker + backend URL access.
+"""
+
 import logging
 
 from celery import shared_task
 
+from app.internal_client import (
+    get_steam_sync_state,
+    recalculate_user_mmr,
+    store_steam_match,
+    update_league_stats,
+    update_steam_sync_state,
+)
 from steam.constants import LEAGUE_ID
-from steam.functions.league_sync import sync_league_matches
-from steam.functions.stats_update import update_all_league_stats_for_league
+from steam.utils.retry import retry_with_backoff
+from steam.utils.steam_api_caller import SteamAPI
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +25,7 @@ logger = logging.getLogger(__name__)
 @shared_task(bind=True, max_retries=3)
 def sync_league_matches_task(self, league_id: int = None):
     """
-    Fetch new matches from Steam API for a league.
+    Fetch new matches from Steam API, store via internal API.
     Scheduled to run every minute.
     """
     if league_id is None:
@@ -20,57 +33,147 @@ def sync_league_matches_task(self, league_id: int = None):
 
     logger.info(f"Starting league sync for league {league_id}")
 
+    # 1. Check sync state
+    state = get_steam_sync_state(league_id)
+    if not state:
+        logger.error("Failed to fetch sync state from internal API")
+        raise self.retry(countdown=60)
+
+    if state["is_syncing"]:
+        logger.warning(f"Sync already in progress for league {league_id}")
+        return {"synced_count": 0, "failed_count": 0, "error": "Already syncing"}
+
+    # 2. Mark as syncing
+    update_steam_sync_state(league_id, is_syncing=True)
+
+    api = SteamAPI()
+    synced_count = 0
+    failed_count = 0
+    start_at_match_id = None
+    new_last_match_id = state["last_match_id"]
+
     try:
-        result = sync_league_matches(league_id, full_sync=False)
-        logger.info(
-            f"League sync complete: {result['synced_count']} synced, "
-            f"{result['failed_count']} failed"
+        while True:
+            result = api.get_match_history(
+                league_id=league_id,
+                start_at_match_id=start_at_match_id,
+                matches_requested=100,
+            )
+
+            if not result or "result" not in result:
+                logger.error(f"Failed to fetch match history for league {league_id}")
+                break
+
+            matches = result["result"].get("matches", [])
+            if not matches:
+                break
+
+            caught_up = False
+            for match_data in matches:
+                match_id = match_data["match_id"]
+                match_seq_num = match_data.get("match_seq_num")
+
+                # Skip already-processed matches
+                if state["last_match_id"] and match_id <= state["last_match_id"]:
+                    caught_up = True
+                    continue
+
+                # Fetch full match details from Steam and store via API
+                stored = _fetch_and_store_match(api, match_id, match_seq_num, league_id)
+
+                if stored:
+                    synced_count += 1
+                    if new_last_match_id is None or match_id > new_last_match_id:
+                        new_last_match_id = match_id
+                else:
+                    failed_count += 1
+
+            start_at_match_id = matches[-1]["match_id"]
+
+            if caught_up:
+                break
+
+    finally:
+        update_steam_sync_state(
+            league_id,
+            is_syncing=False,
+            last_match_id=new_last_match_id,
         )
 
-        # If new matches were synced, update stats
-        if result["synced_count"] > 0:
-            update_league_stats_task.delay(league_id)
+    # Trigger stats update if new matches were synced
+    if synced_count > 0:
+        update_league_stats_task.delay(league_id)
 
-        return result
-    except Exception as exc:
-        logger.error(f"League sync failed: {exc}")
-        raise self.retry(exc=exc, countdown=60)
+    logger.info(
+        f"League sync complete: {synced_count} synced, {failed_count} failed"
+    )
+
+    return {"synced_count": synced_count, "failed_count": failed_count}
+
+
+def _fetch_and_store_match(api, match_id, match_seq_num, league_id):
+    """Fetch match from Steam API and store via internal endpoint."""
+
+    def fetch():
+        if match_seq_num:
+            result = api.get_match_history_by_seq_num(
+                match_seq_num, matches_requested=1
+            )
+            if result and "result" in result:
+                for m in result["result"].get("matches", []):
+                    if m.get("match_id") == match_id:
+                        return {"result": m}
+            return None
+        else:
+            return api.get_match_details(match_id)
+
+    success, result = retry_with_backoff(fetch, max_retries=3, base_delay=1.0)
+
+    if not success or not result or "result" not in result:
+        logger.warning(f"Failed to fetch match {match_id} from Steam")
+        return False
+
+    data = result["result"]
+
+    # POST to backend for DB storage
+    stored = store_steam_match({
+        "match_id": data["match_id"],
+        "league_id": league_id,
+        "radiant_win": data.get("radiant_win", False),
+        "duration": data.get("duration", 0),
+        "start_time": data.get("start_time", 0),
+        "game_mode": data.get("game_mode", 0),
+        "lobby_type": data.get("lobby_type", 0),
+        "players": data.get("players", []),
+    })
+
+    return stored is not None
 
 
 @shared_task(bind=True)
 def update_league_stats_task(self, league_id: int = None):
-    """
-    Update LeaguePlayerStats for all users in a league.
-    Called after new matches are synced.
-    """
+    """Update LeaguePlayerStats for all users in a league via internal API."""
     if league_id is None:
         league_id = LEAGUE_ID
 
     logger.info(f"Updating league stats for league {league_id}")
 
-    try:
-        updated_count = update_all_league_stats_for_league(league_id)
-        logger.info(f"Updated stats for {updated_count} users")
-        return {"updated_count": updated_count}
-    except Exception as exc:
-        logger.error(f"Stats update failed: {exc}")
-        raise
+    updated_count = update_league_stats(league_id)
+    if updated_count is None:
+        logger.error("Failed to update league stats via internal API")
+        return {"updated_count": 0, "error": "API call failed"}
+
+    logger.info(f"Updated stats for {updated_count} users")
+    return {"updated_count": updated_count}
 
 
 @shared_task
 def recalculate_user_league_mmr_task(user_id: int):
-    """
-    Recalculate a single user's league_mmr.
-    Useful for manual recalculation.
-    """
-    from app.models import CustomUser
-    from steam.functions.mmr_calculation import update_user_league_mmr
-
-    try:
-        user = CustomUser.objects.get(pk=user_id)
-        update_user_league_mmr(user)
-        logger.info(f"Recalculated league MMR for {user.username}")
-        return {"user_id": user_id}
-    except CustomUser.DoesNotExist:
-        logger.error(f"User {user_id} not found")
+    """Recalculate a single user's league_mmr via internal API."""
+    result = recalculate_user_mmr(user_id)
+    if result is None:
+        logger.error(f"Failed to recalculate MMR for user {user_id}")
         return None
+
+    logger.info(f"Recalculated league MMR for user {user_id}")
+    return result

--- a/backend/steam/tests/test_tasks_http.py
+++ b/backend/steam/tests/test_tasks_http.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from steam.tasks import (
+    recalculate_user_league_mmr_task,
+    sync_league_matches_task,
+    update_league_stats_task,
+)
+
+
+class SyncLeagueMatchesTaskTest(TestCase):
+    @patch("steam.tasks.SteamAPI")
+    @patch("app.internal_client.requests.post")
+    @patch("app.internal_client.requests.patch")
+    @patch("app.internal_client.requests.get")
+    def test_sync_skips_when_already_syncing(self, mock_get, mock_patch, mock_post, mock_api):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "league_id": 17929,
+            "is_syncing": True,
+            "last_match_id": None,
+            "failed_match_ids": [],
+        }
+        mock_get.return_value = mock_resp
+
+        result = sync_league_matches_task(17929)
+        self.assertEqual(result["synced_count"], 0)
+        mock_patch.assert_not_called()
+
+    @patch("steam.tasks.update_league_stats_task")
+    @patch("steam.tasks.SteamAPI")
+    @patch("app.internal_client.requests.post")
+    @patch("app.internal_client.requests.patch")
+    @patch("app.internal_client.requests.get")
+    def test_sync_stores_matches_via_api(self, mock_get, mock_patch, mock_post, mock_api, mock_stats_task):
+        # GET sync-state returns not syncing
+        get_resp = MagicMock()
+        get_resp.ok = True
+        get_resp.json.return_value = {
+            "league_id": 17929,
+            "is_syncing": False,
+            "last_match_id": None,
+            "failed_match_ids": [],
+        }
+        mock_get.return_value = get_resp
+
+        # PATCH returns ok
+        patch_resp = MagicMock()
+        patch_resp.ok = True
+        mock_patch.return_value = patch_resp
+
+        # POST store-match returns created
+        post_resp = MagicMock()
+        post_resp.ok = True
+        post_resp.status_code = 201
+        post_resp.json.return_value = {
+            "match_id": 123, "created": True, "players_stored": 10, "players_linked": 7
+        }
+        mock_post.return_value = post_resp
+
+        # Steam API returns one match then empty
+        api_instance = mock_api.return_value
+        api_instance.get_match_history.side_effect = [
+            {"result": {"matches": [{"match_id": 123, "match_seq_num": 456}]}},
+            {"result": {"matches": []}},
+        ]
+        api_instance.get_match_history_by_seq_num.return_value = {
+            "result": {"matches": [{"match_id": 123, "radiant_win": True, "duration": 2000,
+                       "start_time": 0, "game_mode": 2, "lobby_type": 1, "players": []}]}
+        }
+
+        result = sync_league_matches_task(17929)
+        self.assertEqual(result["synced_count"], 1)
+
+
+class UpdateLeagueStatsTaskTest(TestCase):
+    @patch("app.internal_client.requests.post")
+    def test_calls_internal_api(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"updated_count": 5}
+        mock_post.return_value = mock_resp
+
+        result = update_league_stats_task(17929)
+        self.assertEqual(result["updated_count"], 5)
+
+
+class RecalculateMmrTaskTest(TestCase):
+    @patch("app.internal_client.requests.post")
+    def test_calls_internal_api(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"user_id": 1, "status": "recalculated"}
+        mock_post.return_value = mock_resp
+
+        result = recalculate_user_league_mmr_task(1)
+        self.assertEqual(result["user_id"], 1)
+
+    @patch("app.internal_client.requests.post")
+    def test_returns_none_on_failure(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 404
+        mock_resp.text = "Not Found"
+        mock_post.return_value = mock_resp
+
+        result = recalculate_user_league_mmr_task(99999)
+        self.assertIsNone(result)

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -57,7 +57,6 @@ services:
       DJANGO_SETTINGS_MODULE: config.settings_celery
       OTEL_SERVICE_NAME: celery-worker
     volumes:
-      - ./backend/db.sqlite3:/app/backend/prod.db.sqlite3
       - ./backend/.env:/app/backend/.env
     depends_on:
       - redis

--- a/docker/docker-compose.release.yaml
+++ b/docker/docker-compose.release.yaml
@@ -55,7 +55,6 @@ services:
       DJANGO_SETTINGS_MODULE: config.settings_celery
       OTEL_SERVICE_NAME: celery-worker
     volumes:
-      - ./backend/prod.db.sqlite3:/app/backend/prod.db.sqlite3
       - ./backend/.env:/app/backend/.env
     depends_on:
       - redis


### PR DESCRIPTION
## Summary

- Add internal API endpoints for steam sync operations (sync-state, store-match, update-league-stats, recalculate-mmr)
- Rewrite steam celery tasks to use internal HTTP API instead of direct ORM
- Remove DATABASES from celery worker settings — all workers are now DB-free and off-host capable
- Remove sqlite volume mounts from celery-worker in prod/release compose files

## Test plan

- [ ] 15 endpoint tests pass (`app.tests.test_internal_steam`)
- [ ] 5 task tests pass (`steam.tests.test_tasks_http`)
- [ ] CI passes
- [ ] Manual: trigger `sync_league_matches_task` and verify matches are stored via internal API