### PR TITLE
feat(events): roll-call staff-add + reopen-signups, with league-staff permission widening

### DIFF
--- a/backend/app/internal_client.py
+++ b/backend/app/internal_client.py
@@ -208,25 +208,6 @@ def generate_repeater_events(repeater_pk):
     return 0
 
 
-def search_message_logs(source, source_id, success=True, limit=1):
-    """Search DiscordMessageLog via internal API.
-
-    Returns list of log dicts, or empty list.
-    """
-    resp = _get(
-        "/discord/message-logs/",
-        params={
-            "source": source,
-            "source_id": source_id,
-            "success": str(success).lower(),
-            "limit": limit,
-        },
-    )
-    if resp and resp.ok:
-        return resp.json()
-    return []
-
-
 def get_event_for_task(pk):
     """Get full event data + org Discord config for celery tasks.
 

--- a/backend/app/internal_client.py
+++ b/backend/app/internal_client.py
@@ -174,7 +174,7 @@ def get_event_signups(event_id):
     """
     from events.schemas import EventSignupSchema
 
-    resp = _api_get(f"/events/{event_id}/signups/")
+    resp = _api_get("/events/signups/", params={"event": event_id})
     if resp and resp.ok:
         return [EventSignupSchema.model_validate(s) for s in resp.json()]
     return []
@@ -244,11 +244,6 @@ def get_event_for_task(pk):
 def get_events(params=None):
     """List events with filters via public API."""
     return _api_get("/events/", params=params)
-
-
-def get_event_signups(event_pk):
-    """Get signups for an event via public API."""
-    return _api_get(f"/events/signups/", params={"event": event_pk})
 
 
 def check_message_log_exists(source, source_id):

--- a/backend/app/permissions_org.py
+++ b/backend/app/permissions_org.py
@@ -98,6 +98,17 @@ def has_league_staff_access(user, league):
     return False
 
 
+def has_event_staff_access(user, event):
+    """Org staff for event.organization, or league staff for event.tournament_league."""
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if has_org_staff_access(user, event.organization):
+        return True
+    if event.tournament_league_id and has_league_staff_access(user, event.tournament_league):
+        return True
+    return False
+
+
 class IsOrgOwner(permissions.BasePermission):
     """Permission check for organization owner access."""
 

--- a/backend/app/tests/test_add_member.py
+++ b/backend/app/tests/test_add_member.py
@@ -441,10 +441,11 @@ class AddTournamentMemberTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn(self.target_user, self.tournament.users.all())
 
-    def test_league_admin_cannot_add_tournament_member(self):
-        """League admin without org staff role gets 403."""
+    def test_league_admin_can_add_tournament_member(self):
+        """League admins are league staff and can add tournament members."""
         resp = self._post(self.league_admin)
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(self.target_user, self.tournament.users.all())
 
     def test_league_user_cannot_add_tournament_member(self):
         resp = self._post(self.league_user)

--- a/backend/app/tests/test_internal_client.py
+++ b/backend/app/tests/test_internal_client.py
@@ -1,22 +1,23 @@
+import os
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
 
 class InternalClientHeadersTest(TestCase):
-    @override_settings(INTERNAL_SERVICE_TOKEN="my-token")
     def test_headers_include_token(self):
         from app.internal_client import _headers
 
-        h = _headers()
+        with patch.dict(os.environ, {"INTERNAL_SERVICE_TOKEN": "my-token"}):
+            h = _headers()
         self.assertEqual(h["X-Internal-Token"], "my-token")
         self.assertEqual(h["Content-Type"], "application/json")
 
-    @override_settings(INTERNAL_SERVICE_TOKEN="")
     def test_headers_with_empty_token(self):
         from app.internal_client import _headers
 
-        h = _headers()
+        with patch.dict(os.environ, {"INTERNAL_SERVICE_TOKEN": ""}):
+            h = _headers()
         self.assertEqual(h["X-Internal-Token"], "")
 
 

--- a/backend/app/tests/test_internal_endpoints.py
+++ b/backend/app/tests/test_internal_endpoints.py
@@ -360,20 +360,25 @@ class InternalClientIntegrationTest(LiveServerTestCase):
     """Real HTTP integration: internal_client -> actual HTTP -> endpoint -> DB."""
 
     def test_create_message_log_full_chain(self):
+        import os
+        from unittest.mock import patch
+
         import app.internal_client as client
         from discordbot.models import DiscordMessageLog
 
         old_url = client.INTERNAL_API_URL
         client.INTERNAL_API_URL = f"{self.live_server_url}/api/internal"
         try:
-            resp = client.create_message_log(
-                channel_id="live-integration-test",
-                source="test_integration",
-                source_id=1,
-                embed_data={"title": "Integration Test"},
-                status_code=200,
-                success=True,
-            )
+            # Client reads token from env; server reads via override_settings.
+            with patch.dict(os.environ, {"INTERNAL_SERVICE_TOKEN": TOKEN}):
+                resp = client.create_message_log(
+                    channel_id="live-integration-test",
+                    source="test_integration",
+                    source_id=1,
+                    embed_data={"title": "Integration Test"},
+                    status_code=200,
+                    success=True,
+                )
             self.assertIsNotNone(resp)
             self.assertEqual(resp.status_code, 201)
             self.assertTrue(

--- a/backend/app/tests/test_organization.py
+++ b/backend/app/tests/test_organization.py
@@ -43,20 +43,30 @@ class OrganizationAPITest(TestCase):
         self.assertEqual(response.data["name"], "Test Org")
 
     def test_create_organization_requires_superuser(self):
-        """POST /api/organizations/ requires superuser."""
-        # Org admin (not superuser) should be denied
+        """POST /api/organizations/ requires authentication; creator becomes owner+admin."""
+        # Anonymous denied
+        response = self.client.post(
+            "/api/organizations/",
+            {"name": "New Org Anon"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Any authenticated user can create; they become owner and admin.
         self.client.force_authenticate(user=self.org_admin)
         response = self.client.post(
             "/api/organizations/",
             {"name": "New Org"},
         )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        new_org = Organization.objects.get(name="New Org")
+        self.assertEqual(new_org.owner, self.org_admin)
+        self.assertIn(self.org_admin, new_org.admins.all())
 
-        # Superuser should succeed
+        # Superuser also succeeds
         self.client.force_authenticate(user=self.superuser)
         response = self.client.post(
             "/api/organizations/",
-            {"name": "New Org"},
+            {"name": "New Org 2"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 

--- a/backend/app/tests/test_task_schedule.py
+++ b/backend/app/tests/test_task_schedule.py
@@ -9,12 +9,22 @@ from app.models import CustomUser, Organization
 
 class TaskScheduleEndpointTest(TestCase):
     def setUp(self):
-        from events.models import Event
+        from events.models import Event, EventRepeater
 
         self.client = APIClient()
         self.org = Organization.objects.create(name="Schedule Test Org")
+        # signup_reminder requires an event_repeater to be enabled (not misconfigured).
+        self.repeater = EventRepeater.objects.create(
+            organization=self.org,
+            name="Schedule Test Repeater",
+            frequency="weekly",
+            day_of_week=3,
+            time_of_day="19:00:00",
+            starts_at="2026-01-01",
+        )
         self.event = Event.objects.create(
             organization=self.org,
+            event_repeater=self.repeater,
             name="Schedule Test Event",
             state="signups_open",
             scheduled_at=timezone.now() + timedelta(hours=24),
@@ -26,8 +36,6 @@ class TaskScheduleEndpointTest(TestCase):
             discord_profile_reminder_hours=4,
             discord_announcement=True,
             discord_announcement_channel_id="123456",
-            discord_subscriber_dm=True,
-            discord_subscriber_dm_hours=12,
             discord_create_event=True,
         )
         user = CustomUser.objects.create_user(
@@ -49,10 +57,11 @@ class TaskScheduleEndpointTest(TestCase):
         tasks = resp.json()
         task_names = [t["task"] for t in tasks]
         self.assertIn("announcement", task_names)
+        # signup_reminder absorbed the former subscriber_dm task — it now drives
+        # subscriber DMs and uses has_dms for fired detection.
         self.assertIn("signup_reminder", task_names)
         self.assertIn("confirm_attendance", task_names)
         self.assertIn("profile_reminder", task_names)
-        self.assertIn("subscriber_dm", task_names)
         self.assertIn("scheduled_event", task_names)
 
     def test_includes_fires_at(self):
@@ -74,7 +83,6 @@ class TaskScheduleEndpointTest(TestCase):
             discord_confirm_attendance=False,
             discord_profile_reminder=False,
             discord_announcement=False,
-            discord_subscriber_dm=False,
             discord_create_event=False,
         )
         resp = self.client.get(f"/api/events/{event.pk}/task-schedule/")
@@ -84,7 +92,6 @@ class TaskScheduleEndpointTest(TestCase):
                 "signup_reminder",
                 "confirm_attendance",
                 "profile_reminder",
-                "subscriber_dm",
                 "scheduled_event",
             ):
                 self.assertEqual(
@@ -92,14 +99,22 @@ class TaskScheduleEndpointTest(TestCase):
                 )
 
     def test_fired_tasks_detected(self):
-        from discordbot.models import DiscordMessageLog
+        # signup_reminder fired status is driven by DiscordEventDM rows
+        # (subscriber DMs sent), not DiscordMessageLog.
+        from discordbot.models import DiscordEvent, DiscordEventDM, DMType
+        from org.models import OrgUser
 
-        DiscordMessageLog.objects.create(
-            channel_id="123456",
-            embed_data={"test": True},
-            source="signup_reminder",
-            source_id=self.event.pk,
-            success=True,
+        user = CustomUser.objects.create_user(
+            username="dm_recipient", password="x", discordId="999"
+        )
+        org_user = OrgUser.objects.create(user=user, organization=self.org)
+        discord_event = DiscordEvent.objects.create(
+            event=self.event, guild_id="guild123"
+        )
+        DiscordEventDM.objects.create(
+            discord_event=discord_event,
+            org_user=org_user,
+            dm_type=DMType.SIGNUP_REMINDER,
         )
         resp = self.client.get(f"/api/events/{self.event.pk}/task-schedule/")
         tasks = resp.json()

--- a/backend/app/tests/test_tournament_serializer.py
+++ b/backend/app/tests/test_tournament_serializer.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.utils import timezone
 
 from app.models import CustomUser, League, Organization, Tournament
 from app.serializers import TournamentSerializer
@@ -21,6 +22,7 @@ class TournamentSourceEventSerializerTest(TestCase):
             name="Test Tournament",
             league=self.league,
             tournament_type="double_elimination",
+            date_played=timezone.now(),
         )
 
     def test_source_event_null_when_no_event(self):

--- a/backend/app/views/csv_import.py
+++ b/backend/app/views/csv_import.py
@@ -135,11 +135,9 @@ def _resolve_user_for_csv_row(row):
     user = None
     created = False
 
-    # Lookup by identifiers
+    # Lookup by identifiers (steam_friend_id is the 64-bit Steam ID)
     steam_user = (
-        CustomUser.objects.filter(steam_account_id=steam_id).first()
-        if steam_id
-        else None
+        CustomUser.objects.filter(steamid=steam_id).first() if steam_id else None
     )
     discord_user = (
         CustomUser.objects.filter(discordId=discord_id).first() if discord_id else None
@@ -177,7 +175,7 @@ def _resolve_user_for_csv_row(row):
     elif discord_user:
         user = discord_user
         # Conflict: user's steam doesn't match provided steam
-        if steam_id and user.steam_account_id and user.steam_account_id != steam_id:
+        if steam_id and user.steamid and user.steamid != steam_id:
             name = user.nickname or user.username or f"#{user.pk}"
             return (
                 None,
@@ -193,7 +191,9 @@ def _resolve_user_for_csv_row(row):
                 positions = PositionsModel.objects.create()
                 user = CustomUser(positions=positions)
                 if steam_id is not None:
-                    user.steam_account_id = steam_id
+                    # steam_friend_id from CSV is 64-bit Steam ID;
+                    # save() syncs to steam_account_id automatically
+                    user.steamid = steam_id
                     user.username = f"steam_{steam_id}"
                 if discord_id is not None:
                     user.discordId = discord_id

--- a/backend/config/settings_celery.py
+++ b/backend/config/settings_celery.py
@@ -13,6 +13,22 @@ SECRET_KEY = "celery-worker-not-serving-http"
 DEBUG = False
 ALLOWED_HOSTS = []
 
+
+def _env_bool(key, default=False):
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+# Test-mode flag for Discord DM safety in tasks.
+# When TEST=true, sync_send_dm only sends DMs to TEST_DISCORD_USER_ID and
+# returns fake-success for everyone else (so recipient_count > 0 in tests
+# without spamming real users).
+TEST = _env_bool("TEST")
+RELEASE = _env_bool("RELEASE")
+TEST_DISCORD_USER_ID = os.environ.get("TEST_DISCORD_USER_ID", "243497113906970625")
+
 # Minimal installed apps for task autodiscovery.
 # Django contrib apps required because app.models imports AbstractUser.
 INSTALLED_APPS = [
@@ -39,6 +55,12 @@ CELERY_TIMEZONE = "UTC"
 CELERY_TASK_TRACK_STARTED = True
 
 INTERNAL_SERVICE_TOKEN = os.environ.get("INTERNAL_SERVICE_TOKEN", "")
+
+# Discord bot token — required by discordbot.utils.sync_send_dm and friends.
+# In TEST mode we still need this for the matching TEST_DISCORD_USER_ID path,
+# and in production for real DMs from Celery tasks. Read the same env var
+# the Daphne backend uses.
+DISCORD_BOT_TOKEN = os.environ.get("discord_token", "")
 
 # Required by app.models at import time
 AUTH_USER_MODEL = "app.CustomUser"

--- a/backend/events/constants.py
+++ b/backend/events/constants.py
@@ -18,6 +18,7 @@ EVENT_STATE_TRANSITIONS = {
         EventState.CANCELLED,
     ],
     EventState.ROLL_CALL: [
+        EventState.SIGNUPS_OPEN,
         EventState.IN_PROGRESS,
         EventState.COMPLETED,
         EventState.CANCELLED,

--- a/backend/events/serializers.py
+++ b/backend/events/serializers.py
@@ -195,6 +195,9 @@ class EventSerializer(serializers.ModelSerializer):
     # Use annotated fields from queryset (no per-row queries)
     signup_count = serializers.IntegerField(read_only=True, default=0)
     confirmed_count = serializers.IntegerField(read_only=True, default=0)
+    # Per-request override; populated in the view layer AFTER the cached payload
+    # is resolved, so the cache stays user-agnostic.
+    user_can_manage = serializers.BooleanField(read_only=True, default=False)
 
     class Meta:
         model = Event
@@ -274,6 +277,7 @@ class EventSerializer(serializers.ModelSerializer):
             "auto_create_hero_drafts",
             "discord_send_draft_link",
             "discord_send_herodraft_link",
+            "user_can_manage",
         ]
         read_only_fields = [
             "id",

--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -98,10 +98,16 @@ def _get_active_signup_count(event):
 
 
 @transaction.atomic
-def process_rsvp(event, user, event_team=None):
-    """Process an RSVP for an event."""
-    if event.state != EventState.SIGNUPS_OPEN:
-        raise ValueError("Event is not accepting signups.")
+def _create_signup(event, user, event_team=None):
+    """Internal: create a signup with no state check.
+
+    Handles existing-signup detection, waitlist placement, auto-approve / auto-confirm,
+    tournament addition, and notify hooks. State authorization is the caller's job.
+
+    INVARIANT: invalidate_after_commit MUST be registered before any transaction.on_commit
+    notify hook. Notify handlers may re-query, and reading through a stale cache would
+    re-warm it with stale data.
+    """
     existing = EventSignup.objects.filter(event=event, user=user).first()
     if existing:
         logger.info(
@@ -112,11 +118,9 @@ def process_rsvp(event, user, event_team=None):
             existing.id,
         )
         if existing.status in (SignupStatus.CANCELLED, SignupStatus.REJECTED):
-            # Allow re-RSVP after cancellation/rejection — delete old signup
             existing.delete()
             logger.info("Deleted cancelled/rejected signup, allowing re-RSVP")
         elif existing.status == SignupStatus.TENTATIVE:
-            # Upgrade from tentative to full signup — delete and re-create
             existing.delete()
             logger.info("Upgrading tentative signup to full RSVP")
         else:
@@ -124,7 +128,6 @@ def process_rsvp(event, user, event_team=None):
 
     signup_type = SignupType.TEAM if event_team else SignupType.USER
 
-    # Check waitlist
     if event.max_players and _get_active_signup_count(event) >= event.max_players:
         max_pos = (
             EventSignup.objects.filter(event=event, status=SignupStatus.WAITLISTED)
@@ -144,7 +147,6 @@ def process_rsvp(event, user, event_team=None):
         transaction.on_commit(lambda: notify_signup_changed(event))
         return signup
 
-    # Determine initial status
     status = SignupStatus.RSVP
     if event.auto_approve:
         if check_requirements(event, user):
@@ -170,6 +172,20 @@ def process_rsvp(event, user, event_team=None):
     if status in (SignupStatus.CONFIRMED, SignupStatus.APPROVED):
         transaction.on_commit(lambda: notify_mark_interested(event, user.pk))
     return signup
+
+
+def process_rsvp(event, user, event_team=None):
+    """Public-path signup. Locked to SIGNUPS_OPEN."""
+    if event.state != EventState.SIGNUPS_OPEN:
+        raise ValueError("Event is not accepting signups.")
+    return _create_signup(event, user, event_team=event_team)
+
+
+def staff_add_signup(event, user, event_team=None):
+    """Staff-path signup. Allowed during SIGNUPS_OPEN or ROLL_CALL."""
+    if event.state not in (EventState.SIGNUPS_OPEN, EventState.ROLL_CALL):
+        raise ValueError("Event is not accepting signups.")
+    return _create_signup(event, user, event_team=event_team)
 
 
 APPROVABLE_STATUSES = [

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -393,20 +393,23 @@ def send_signup_update(event_id):
         from app.internal_client import search_message_logs
 
         logs = search_message_logs(
-            "event_announcement", event.pk, success=True, limit=1
+            source="event_announcement",
+            source_id=event.pk,
+            success="true",
+            limit=1,
         )
         log_entry = logs[0] if logs else None
 
-        if not log_entry or not log_entry.get("discord_message_id"):
+        if not log_entry or not log_entry.discord_message_id:
             logger.info(
                 "No announcement message found for event %s, skipping update",
                 event.pk,
             )
             return "Skipped: no announcement message"
 
-        message_id = log_entry.get("discord_message_id")
-        edit_channel_id = log_entry.get("channel_id")
-        response_data = log_entry.get("response_data") or {}
+        message_id = log_entry.discord_message_id
+        edit_channel_id = log_entry.channel_id
+        response_data = log_entry.response_data or {}
         if response_data.get("id"):
             thread_id = response_data.get("id")
             if response_data.get("message"):

--- a/backend/events/tests/_internal_client_orm.py
+++ b/backend/events/tests/_internal_client_orm.py
@@ -1,0 +1,402 @@
+"""ORM-direct replacements for app.internal_client functions used in tests.
+
+The production internal_client makes real HTTP calls to the public/internal API.
+In Django unit tests data lives inside an unrolled transaction the HTTP server
+can't see, so calls return 404/empty.
+
+This module provides drop-in replacements that read/write directly from the
+ORM, plus a DiscordTestMixin TestCase mixin that monkey-patches
+``app.internal_client`` (and call sites that imported the symbol) for the
+duration of each test.
+
+Usage::
+
+    from events.tests._internal_client_orm import DiscordTestMixin
+    from events.tests.base import EventTestCase
+
+    class MyTest(DiscordTestMixin, EventTestCase):
+        ...
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone as dtz
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+# ---- ORM-direct reads ----
+
+
+def _get_event_signups_orm(event_id):
+    """Read EventSignups directly from the ORM and return EventSignupSchema list."""
+    from events.models import EventSignup
+    from events.schemas import EventSignupSchema
+    from events.serializers import EventSignupSerializer
+
+    qs = EventSignup.objects.filter(event_id=event_id).select_related("user", "event")
+    return [EventSignupSchema.model_validate(EventSignupSerializer(s).data) for s in qs]
+
+
+def _get_event_for_task_orm(pk):
+    """Read full event data directly from the ORM and return EventTaskSchema."""
+    from events.models import Event
+    from events.schemas import EventTaskSchema
+    from events.serializers import EventSerializer
+
+    try:
+        event = Event.objects.select_related("organization", "event_repeater").get(
+            pk=pk
+        )
+    except Event.DoesNotExist:
+        return None
+    data = EventSerializer(event).data
+    data["organization_id"] = event.organization_id
+    data["organization_discord_server_id"] = (
+        event.organization.discord_server_id or ""
+    )
+    data["organization_logo"] = event.organization.logo or ""
+    data["event_repeater_id"] = event.event_repeater_id
+    return EventTaskSchema.model_validate(data)
+
+
+def _get_event_orm(pk):
+    """Read event data; mimics _api_get response. Returns ResponseLike or None."""
+    from events.models import Event
+    from events.serializers import EventSerializer
+
+    try:
+        event = Event.objects.get(pk=pk)
+    except Event.DoesNotExist:
+        return _ResponseLike(404, {"error": "not found"})
+    return _ResponseLike(200, EventSerializer(event).data)
+
+
+def _get_events_list_orm(**params):
+    """Mimic the public events list endpoint, supporting the filters our tests need."""
+    from events.models import Event
+    from events.serializers import EventSerializer
+
+    qs = Event.objects.all()
+    states = params.get("states")
+    if states:
+        state_list = [s.strip() for s in states.split(",") if s.strip()]
+        qs = qs.filter(state__in=state_list)
+
+    if params.get("has_repeater") == "true":
+        qs = qs.filter(event_repeater__isnull=False)
+    if params.get("has_announcement_channel") == "true":
+        qs = qs.exclude(discord_announcement_channel_id="")
+
+    return [EventSerializer(e).data for e in qs]
+
+
+def _get_discord_event_state_orm(event_id):
+    """Mimic /discord/event-state/<event_id>/."""
+    from discordbot.models import DiscordEvent, DiscordEventDM, DiscordEventMsgSignup
+    from discordbot.schemas import DiscordEventStateSchema
+
+    result = {
+        "has_discord_event": False,
+        "scheduled_event_id": None,
+        "signup_posted": False,
+        "fired_actions": [],
+        "has_dms": False,
+    }
+    try:
+        de = DiscordEvent.objects.get(event_id=event_id)
+        result["has_discord_event"] = True
+        result["discord_event_pk"] = de.pk
+        result["scheduled_event_id"] = de.scheduled_event_id or None
+        result["has_dms"] = DiscordEventDM.objects.filter(discord_event=de).exists()
+    except DiscordEvent.DoesNotExist:
+        pass
+
+    signup_msg = DiscordEventMsgSignup.objects.filter(
+        event_id=event_id, has_posted=True
+    ).first()
+    result["signup_posted"] = signup_msg is not None
+    if signup_msg:
+        result["signup_message_id"] = signup_msg.message_id
+        result["signup_channel_id"] = signup_msg.channel_id
+        result["signup_thread_id"] = signup_msg.thread_id
+    return DiscordEventStateSchema.model_validate(result)
+
+
+def _check_message_log_exists_orm(source, source_id):
+    from discordbot.models import DiscordMessageLog
+
+    return DiscordMessageLog.objects.filter(
+        source=source, source_id=source_id, success=True
+    ).exists()
+
+
+def _search_message_logs_orm(*args, **kwargs):
+    """ORM-backed replacement that accepts BOTH the old positional signature and
+    the new keyword-only signature (production has a duplicated def — last one
+    wins, breaking positional callers)."""
+    from discordbot.schemas import MessageLogSchema
+    from discordbot.models import DiscordMessageLog
+
+    if args:
+        keys = ["source", "source_id", "success", "limit"]
+        for i, val in enumerate(args):
+            kwargs.setdefault(keys[i], val)
+
+    qs = DiscordMessageLog.objects.all()
+    if "source" in kwargs:
+        qs = qs.filter(source=kwargs["source"])
+    if "source_id" in kwargs:
+        qs = qs.filter(source_id=kwargs["source_id"])
+    success = kwargs.get("success")
+    if success is not None:
+        if isinstance(success, str):
+            success = success.lower() == "true"
+        qs = qs.filter(success=success)
+    qs = qs.order_by("-created_at")
+    limit = int(kwargs.get("limit") or 1)
+    qs = qs[:limit]
+
+    out = []
+    for entry in qs:
+        out.append(
+            MessageLogSchema.model_validate(
+                {
+                    "id": entry.pk,
+                    "source": entry.source,
+                    "source_id": entry.source_id,
+                    "channel_id": entry.channel_id,
+                    "discord_message_id": entry.discord_message_id,
+                    "status_code": entry.status_code,
+                    "success": entry.success,
+                    "response_data": entry.response_data,
+                    "created_at": entry.created_at.isoformat()
+                    if entry.created_at
+                    else None,
+                }
+            )
+        )
+    return out
+
+
+# ---- ORM-direct writes ----
+
+
+def _create_message_log_orm(**data):
+    from discordbot.models import DiscordMessageLog
+
+    log = DiscordMessageLog.objects.create(
+        channel_id=str(data.get("channel_id", "")),
+        embed_data=data.get("embed_data") or {},
+        source=data.get("source", "unknown"),
+        source_id=data.get("source_id"),
+        discord_message_id=data.get("discord_message_id"),
+        status_code=data.get("status_code"),
+        response_data=data.get("response_data"),
+        success=bool(data.get("success", False)),
+    )
+    return _ResponseLike(201, {"id": log.pk})
+
+
+def _create_event_log_orm(**data):
+    from discordbot.models import DiscordEvent, DiscordEventLog
+
+    try:
+        de = DiscordEvent.objects.get(pk=data["discord_event_id"])
+    except DiscordEvent.DoesNotExist:
+        return _ResponseLike(404, {"error": "DiscordEvent not found"})
+    fields = {
+        "action": data.get("action"),
+        "target_type": data.get("target_type"),
+        "message_id": data.get("message_id"),
+        "status_code": data.get("status_code"),
+        "response_data": data.get("response_data"),
+        "success": bool(data.get("success", False)),
+        "error_message": data.get("error_message"),
+        "message_log_id": data.get("message_log_id"),
+    }
+    fields = {k: v for k, v in fields.items() if v is not None}
+    entry = DiscordEventLog.objects.create(discord_event=de, **fields)
+    return _ResponseLike(201, {"id": entry.pk})
+
+
+def _get_or_create_discord_event_orm(**data):
+    from discordbot.models import DiscordEvent
+
+    de, created = DiscordEvent.objects.get_or_create(
+        event_id=data["event_id"],
+        defaults={"guild_id": data.get("guild_id", "")},
+    )
+    return _ResponseLike(
+        201 if created else 200, {"id": de.pk, "created": created}
+    )
+
+
+def _update_discord_event_orm(pk, **data):
+    from discordbot.models import DiscordEvent
+
+    de = DiscordEvent.objects.get(pk=pk)
+    for k, v in data.items():
+        if hasattr(de, k):
+            setattr(de, k, v)
+    de.save()
+    return _ResponseLike(200, {"id": de.pk})
+
+
+def _create_or_update_signup_message_orm(**data):
+    from discordbot.models import ChannelType, DiscordEventMsgSignup
+
+    payload = dict(data)
+    event_id = payload.pop("event_id")
+    channel_id = payload.pop("channel_id")
+    msg, created = DiscordEventMsgSignup.objects.get_or_create(
+        event_id=event_id,
+        channel_id=channel_id,
+        defaults={"channel_type": payload.get("channel_type", ChannelType.TEXT)},
+    )
+    for field in (
+        "message_id",
+        "thread_id",
+        "channel_type",
+        "has_posted",
+        "message_last_updated",
+    ):
+        if field in payload:
+            setattr(msg, field, payload[field])
+    msg.save()
+    return _ResponseLike(
+        201 if created else 200, {"id": msg.pk, "created": created}
+    )
+
+
+def _create_or_update_announcement_orm(**data):
+    from discordbot.models import ChannelType, DiscordEventMsgAnnouncement
+
+    payload = dict(data)
+    event_id = payload.pop("event_id")
+    channel_id = payload.pop("channel_id")
+    msg, created = DiscordEventMsgAnnouncement.objects.get_or_create(
+        event_id=event_id,
+        channel_id=channel_id,
+        defaults={"channel_type": payload.get("channel_type", ChannelType.TEXT)},
+    )
+    for field in ("message_id", "channel_type", "has_posted", "message_last_updated"):
+        if field in payload:
+            setattr(msg, field, payload[field])
+    msg.save()
+    return _ResponseLike(
+        201 if created else 200, {"id": msg.pk, "created": created}
+    )
+
+
+def _get_repeater_subscribers_orm(repeater_id):
+    """Read RepeaterSubscriptions from the ORM and return RepeaterSubscriberSchema list.
+
+    Mirrors what app/views/internal.py exposes — only subscribers with a
+    non-empty discord_id are returned (DM target has to exist).
+    """
+    from events.models import RepeaterSubscription
+    from events.schemas import RepeaterSubscriberSchema
+
+    qs = RepeaterSubscription.objects.filter(
+        event_repeater_id=repeater_id
+    ).select_related("user")
+    out = []
+    for sub in qs:
+        discord_id = getattr(sub.user, "discordId", "") or ""
+        if not discord_id:
+            continue
+        out.append(
+            RepeaterSubscriberSchema.model_validate(
+                {
+                    "user_pk": sub.user_id,
+                    "discord_id": discord_id,
+                    "org_user_pk": None,
+                }
+            )
+        )
+    return out
+
+
+# ---- Helper ----
+
+
+class _ResponseLike:
+    """Mimics the bits of a ``requests.Response`` callers rely on."""
+
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._payload = payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+# ---- Mixin ----
+
+
+# Map of attribute → ORM-backed callable.
+# ``patch.multiple`` uses these on app.internal_client AND on every other module
+# that imported the symbol directly (hence the second pass on call sites).
+_PATCH_MAP = {
+    "get_event_signups": _get_event_signups_orm,
+    "get_event_for_task": _get_event_for_task_orm,
+    "get_event": _get_event_orm,
+    "get_events_list": _get_events_list_orm,
+    "get_discord_event_state": _get_discord_event_state_orm,
+    "check_message_log_exists": _check_message_log_exists_orm,
+    "search_message_logs": _search_message_logs_orm,
+    "create_message_log": _create_message_log_orm,
+    "create_event_log": _create_event_log_orm,
+    "get_or_create_discord_event": _get_or_create_discord_event_orm,
+    "update_discord_event": _update_discord_event_orm,
+    "create_or_update_signup_message": _create_or_update_signup_message_orm,
+    "create_or_update_announcement": _create_or_update_announcement_orm,
+    "get_repeater_subscribers": _get_repeater_subscribers_orm,
+}
+
+# Modules that ``from app.internal_client import X`` at module level — the
+# imported name lives on the importer's namespace, so patching only
+# ``app.internal_client.X`` is not enough.
+_CALLSITE_MODULES = (
+    "events.discord.embeds",
+    "discordbot.utils",
+)
+
+
+class DiscordTestMixin:
+    """TestCase mixin that swaps app.internal_client HTTP calls for ORM ones."""
+
+    def setUp(self):
+        super().setUp()
+        self._patches = []
+        for name, fn in _PATCH_MAP.items():
+            p = patch(f"app.internal_client.{name}", fn)
+            p.start()
+            self._patches.append(p)
+
+        for module_path in _CALLSITE_MODULES:
+            import importlib
+
+            try:
+                module = importlib.import_module(module_path)
+            except ImportError:
+                continue
+            for name, fn in _PATCH_MAP.items():
+                if hasattr(module, name):
+                    p = patch.object(module, name, fn)
+                    p.start()
+                    self._patches.append(p)
+
+        self.addCleanup(self._stop_patches)
+
+    def _stop_patches(self):
+        for p in self._patches:
+            try:
+                p.stop()
+            except RuntimeError:
+                # Already stopped
+                pass
+        self._patches = []

--- a/backend/events/tests/base.py
+++ b/backend/events/tests/base.py
@@ -39,6 +39,18 @@ class EventTestCase(TestCase):
         cls.user_incomplete.positions = PositionsModel.objects.create()
         cls.user_incomplete.save()
 
+        cls.league_staff = CustomUser.objects.create_user(
+            username="event_league_staff", password="testpass"
+        )
+        cls.league_staff.positions = PositionsModel.objects.create()
+        cls.league_staff.save()
+
+        cls.unrelated_user = CustomUser.objects.create_user(
+            username="event_unrelated", password="testpass"
+        )
+        cls.unrelated_user.positions = PositionsModel.objects.create()
+        cls.unrelated_user.save()
+
         cls.org = Organization.objects.create(name="Event Test Org", owner=cls.admin)
         cls.org.staff.add(cls.admin)
 
@@ -47,6 +59,7 @@ class EventTestCase(TestCase):
             organization=cls.org,
             steam_league_id=99999,
         )
+        cls.league.staff.add(cls.league_staff)
 
         cls.event = Event.objects.create(
             organization=cls.org,

--- a/backend/events/tests/test_api.py
+++ b/backend/events/tests/test_api.py
@@ -238,3 +238,11 @@ class LeagueStaffEventActionsTest(TestCase):
         # League staff approves
         resp = self.client.post(f"/api/events/signups/{signup.pk}/approve/")
         assert resp.status_code == 200, resp.content
+
+    def test_league_staff_can_restart_tournament(self):
+        """League staff should be able to restart_tournament on a league event."""
+        # restart_tournament typically requires the event to be in a state where a tournament exists.
+        # If your test event doesn't have a tournament, the action may return 400 — acceptable;
+        # we only care about the permission check (200 or 400, NOT 403).
+        resp = self.client.post(f"/api/events/{self.event.pk}/restart_tournament/")
+        assert resp.status_code != 403, resp.content

--- a/backend/events/tests/test_api.py
+++ b/backend/events/tests/test_api.py
@@ -284,3 +284,64 @@ class AdminSignupDuringRollCallTest(TestCase):
         self.client.force_authenticate(self.player)
         resp = self.client.post(f"/api/events/{self.event.pk}/rsvp/")
         assert resp.status_code == 400
+
+
+class UserCanManageRetrieveTest(EventTestCase):
+    """Verify cached retrieve() emits per-request user_can_manage."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_org_staff_sees_user_can_manage_true(self):
+        self.client.force_authenticate(self.admin)
+        resp = self.client.get(f"/api/events/{self.event.pk}/")
+        assert resp.status_code == 200
+        assert resp.json()["user_can_manage"] is True
+
+    def test_league_staff_sees_user_can_manage_true(self):
+        self.client.force_authenticate(self.league_staff)
+        resp = self.client.get(f"/api/events/{self.event.pk}/")
+        assert resp.status_code == 200
+        assert resp.json()["user_can_manage"] is True
+
+    def test_unrelated_user_sees_user_can_manage_false(self):
+        self.client.force_authenticate(self.unrelated_user)
+        resp = self.client.get(f"/api/events/{self.event.pk}/")
+        assert resp.status_code == 200
+        assert resp.json()["user_can_manage"] is False
+
+    def test_no_cache_leak_across_users(self):
+        """Hit retrieve as staff, unrelated, then staff again — values must alternate per request.
+
+        The third round-trip catches a regression where the cached payload gets
+        mutated to True (from the staff read), which would only manifest after a re-read.
+        """
+        self.client.force_authenticate(self.admin)
+        first = self.client.get(f"/api/events/{self.event.pk}/").json()
+        assert first["user_can_manage"] is True
+
+        self.client.force_authenticate(self.unrelated_user)
+        second = self.client.get(f"/api/events/{self.event.pk}/").json()
+        assert second["user_can_manage"] is False
+
+        self.client.force_authenticate(self.admin)
+        third = self.client.get(f"/api/events/{self.event.pk}/").json()
+        assert third["user_can_manage"] is True, (
+            "Third request as staff should be True again — if False, the cached "
+            "payload was poisoned by the unrelated user's read."
+        )
+
+    def test_event_without_league_returns_false_for_league_staff(self):
+        from events.models import Event
+
+        no_league_event = Event.objects.create(
+            organization=self.org,
+            name="No League",
+            scheduled_at=self.event.scheduled_at,
+            state=self.event.state,
+            created_by=self.admin,
+            tournament_name="T",
+        )
+        self.client.force_authenticate(self.league_staff)
+        resp = self.client.get(f"/api/events/{no_league_event.pk}/")
+        assert resp.json()["user_can_manage"] is False

--- a/backend/events/tests/test_api.py
+++ b/backend/events/tests/test_api.py
@@ -246,3 +246,41 @@ class LeagueStaffEventActionsTest(TestCase):
         # we only care about the permission check (200 or 400, NOT 403).
         resp = self.client.post(f"/api/events/{self.event.pk}/restart_tournament/")
         assert resp.status_code != 403, resp.content
+
+
+class AdminSignupDuringRollCallTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = CustomUser.objects.create_user(username="adm_staff", password="x")
+        cls.staff.positions = PositionsModel.objects.create()
+        cls.staff.save()
+        cls.player = CustomUser.objects.create_user(username="adm_player", password="x")
+        cls.player.positions = PositionsModel.objects.create()
+        cls.player.save()
+        cls.org = Organization.objects.create(name="Adm Org", owner=cls.staff)
+        cls.org.staff.add(cls.staff)
+        cls.event = Event.objects.create(
+            organization=cls.org,
+            name="Adm Event",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=EventState.ROLL_CALL,
+            created_by=cls.staff,
+            tournament_name="T",
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(self.staff)
+
+    def test_admin_signup_succeeds_during_roll_call(self):
+        resp = self.client.post(
+            f"/api/events/{self.event.pk}/admin-signup/",
+            {"user_id": self.player.pk},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+
+    def test_public_rsvp_still_rejected_during_roll_call(self):
+        self.client.force_authenticate(self.player)
+        resp = self.client.post(f"/api/events/{self.event.pk}/rsvp/")
+        assert resp.status_code == 400

--- a/backend/events/tests/test_api.py
+++ b/backend/events/tests/test_api.py
@@ -1,9 +1,12 @@
 from datetime import timedelta
+from unittest.mock import patch
 
+from django.test import TestCase
 from django.utils import timezone as tz
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from app.models import CustomUser, League, Organization, PositionsModel
 from events.constants import EventState, SignupStatus
 from events.models import Event, EventSignup
 from events.tests.base import EventTestCase
@@ -125,3 +128,113 @@ class EventAPITests(EventTestCase):
         self.assertEqual(r.status_code, status.HTTP_200_OK)
         # Base event (signups_open) + the one created above = 2
         self.assertEqual(len(r.data), 2)
+
+
+class ReopenSignupsViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = CustomUser.objects.create_user(username="reopen_staff", password="x")
+        cls.staff.positions = PositionsModel.objects.create()
+        cls.staff.save()
+        cls.unrelated = CustomUser.objects.create_user(username="reopen_unrelated", password="x")
+        cls.unrelated.positions = PositionsModel.objects.create()
+        cls.unrelated.save()
+        cls.org = Organization.objects.create(name="Reopen Org", owner=cls.staff)
+        cls.org.staff.add(cls.staff)
+        cls.event = Event.objects.create(
+            organization=cls.org,
+            name="Reopen Event",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=EventState.ROLL_CALL,
+            created_by=cls.staff,
+            tournament_name="T",
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_reopen_signups_succeeds_for_staff_in_roll_call(self):
+        self.client.force_authenticate(self.staff)
+        with patch("events.discord.notify_event_announced") as mock_notify:
+            resp = self.client.post(f"/api/events/{self.event.pk}/reopen_signups/")
+        assert resp.status_code == 200, resp.content
+        self.event.refresh_from_db()
+        assert self.event.state == EventState.SIGNUPS_OPEN
+        mock_notify.assert_not_called()
+
+    def test_reopen_signups_403_for_unrelated(self):
+        self.client.force_authenticate(self.unrelated)
+        resp = self.client.post(f"/api/events/{self.event.pk}/reopen_signups/")
+        assert resp.status_code == 403
+
+    def test_reopen_signups_400_when_not_in_roll_call(self):
+        self.event.state = EventState.SIGNUPS_OPEN
+        self.event.save(update_fields=["state"])
+        self.client.force_authenticate(self.staff)
+        resp = self.client.post(f"/api/events/{self.event.pk}/reopen_signups/")
+        assert resp.status_code == 400
+
+
+class LeagueStaffEventActionsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = CustomUser.objects.create_user(username="league_owner", password="x")
+        cls.owner.positions = PositionsModel.objects.create()
+        cls.owner.save()
+        cls.league_staff_user = CustomUser.objects.create_user(username="league_staff_v", password="x")
+        cls.league_staff_user.positions = PositionsModel.objects.create()
+        cls.league_staff_user.save()
+        cls.org = Organization.objects.create(name="LS Org", owner=cls.owner)
+        cls.league = League.objects.create(name="LS League", organization=cls.org, steam_league_id=77777)
+        cls.league.staff.add(cls.league_staff_user)
+        cls.event = Event.objects.create(
+            organization=cls.org,
+            name="LS Event",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=EventState.ROLL_CALL,
+            created_by=cls.owner,
+            tournament_name="T",
+            tournament_league=cls.league,
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(self.league_staff_user)
+
+    def test_league_staff_can_reopen_signups(self):
+        resp = self.client.post(f"/api/events/{self.event.pk}/reopen_signups/")
+        assert resp.status_code == 200, resp.content
+
+    def test_league_staff_can_admin_signup(self):
+        """League staff can admin-add during SIGNUPS_OPEN. Roll-call coverage lands in Task 5."""
+        # Flip the event to SIGNUPS_OPEN since Task 5 (admin_signup → staff_add_signup) hasn't landed yet.
+        self.event.state = EventState.SIGNUPS_OPEN
+        self.event.save(update_fields=["state"])
+        player = CustomUser.objects.create_user(username="ls_player", password="x")
+        player.positions = PositionsModel.objects.create()
+        player.save()
+        resp = self.client.post(
+            f"/api/events/{self.event.pk}/admin-signup/",
+            {"user_id": player.pk},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+
+    def test_league_staff_can_act_on_event_signups(self):
+        """Verify the EventSignup-level action permission widening (Task 4 step 4)."""
+        from events.models import EventSignup
+        from events.constants import SignupStatus
+
+        # Create a signup to act on
+        player = CustomUser.objects.create_user(username="ls_target", password="x")
+        player.positions = PositionsModel.objects.create()
+        player.save()
+        signup = EventSignup.objects.create(
+            event=self.event,
+            user=player,
+            status=SignupStatus.RSVP,
+        )
+
+        # League staff approves
+        resp = self.client.post(f"/api/events/signups/{signup.pk}/approve/")
+        assert resp.status_code == 200, resp.content

--- a/backend/events/tests/test_discord.py
+++ b/backend/events/tests/test_discord.py
@@ -8,10 +8,15 @@ from events.discord import (
     build_signup_reminder_embed,
     build_signup_update_embed,
 )
+from events.tests._internal_client_orm import DiscordTestMixin
 from events.tests.base import EventTestCase
 
 
-class BuildAnnouncementEmbedTest(EventTestCase):
+class _EmbedTestCase(DiscordTestMixin, EventTestCase):
+    """EventTestCase + ORM-backed internal_client patches."""
+
+
+class BuildAnnouncementEmbedTest(_EmbedTestCase):
     def test_uses_event_name_as_title(self):
         embed = build_announcement_embed(self.event)
         self.assertIn(self.event.name, embed["title"])
@@ -25,7 +30,7 @@ class BuildAnnouncementEmbedTest(EventTestCase):
         self.assertIsInstance(embed["color"], int)
 
 
-class BuildSignupUpdateEmbedTest(EventTestCase):
+class BuildSignupUpdateEmbedTest(_EmbedTestCase):
     def test_includes_event_name(self):
         embed = build_signup_update_embed(self.event)
         self.assertIn(self.event.name, embed["title"])
@@ -38,31 +43,31 @@ class BuildSignupUpdateEmbedTest(EventTestCase):
         )
 
 
-class BuildNewEventEmbedTest(EventTestCase):
+class BuildNewEventEmbedTest(_EmbedTestCase):
     def test_includes_event_name(self):
         embed = build_new_event_embed(self.event)
         self.assertIn(self.event.name, embed["title"])
 
 
-class BuildSignupReminderEmbedTest(EventTestCase):
+class BuildSignupReminderEmbedTest(_EmbedTestCase):
     def test_includes_event_name(self):
         embed = build_signup_reminder_embed(self.event)
         self.assertIn(self.event.name, embed["title"])
 
 
-class BuildAttendanceReminderEmbedTest(EventTestCase):
+class BuildAttendanceReminderEmbedTest(_EmbedTestCase):
     def test_includes_event_name(self):
         embed = build_attendance_reminder_embed(self.event)
         self.assertIn(self.event.name, embed["title"])
 
 
-class BuildProfileReminderEmbedTest(EventTestCase):
+class BuildProfileReminderEmbedTest(_EmbedTestCase):
     def test_includes_event_name(self):
         embed = build_profile_reminder_embed(self.event)
         self.assertIn(self.event.name, embed["title"])
 
 
-class BuildAnnouncementEmbedSignupListTest(EventTestCase):
+class BuildAnnouncementEmbedSignupListTest(_EmbedTestCase):
     def test_empty_signup_list(self):
         embed = build_announcement_embed(self.event)
         field_names = [f["name"] for f in embed.get("fields", [])]

--- a/backend/events/tests/test_discord_integration.py
+++ b/backend/events/tests/test_discord_integration.py
@@ -180,7 +180,11 @@ class RealEventAnnouncementTaskTest(TestCase):
         )
 
 
-@unittest.skipUnless(HAS_MULTI_USER, SKIP_MULTI_USER)
+@unittest.skipUnless(
+    HAS_TOKEN and HAS_MULTI_USER,
+    "Requires DISCORD_BOT_TOKEN AND DISCORD_TEST_BOT_2_TOKEN (the main bot "
+    "posts the announcement; secondary bots react to it).",
+)
 class MultiUserReactionTest(TestCase):
     """Test multiple bot users reacting to an announcement message.
 

--- a/backend/events/tests/test_discord_tasks.py
+++ b/backend/events/tests/test_discord_tasks.py
@@ -1,18 +1,36 @@
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from discordbot.models import DiscordMessageLog
 from events.constants import EventState
+from events.tests._internal_client_orm import DiscordTestMixin
 from events.tests.base import EventTestCase
 
 
-class SendEventAnnouncementTaskTest(EventTestCase):
-    @patch("discordbot.utils.requests.post")
-    def test_announcement_creates_log(self, mock_post):
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "111222333"}),
-        )
-        mock_post.return_value.raise_for_status = MagicMock()
+def _ok_response(payload):
+    """Build a MagicMock that mimics a successful Discord API response."""
+    resp = MagicMock(status_code=200)
+    resp.json = MagicMock(return_value=payload)
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class _DiscordTaskTestCase(DiscordTestMixin, EventTestCase):
+    """EventTestCase + ORM-backed internal_client patches.
+
+    Production code calls ``discordbot.utils._rate_limited_request(method, url,
+    json=payload, headers=...)`` which dispatches to ``requests.request``.
+    Older tests patched ``requests.post`` / ``requests.patch`` — those names are
+    never called in the rate-limited path. We patch the wrapper directly so we
+    can assert payload + URL while bypassing the real Discord API.
+    """
+
+
+class SendEventAnnouncementTaskTest(_DiscordTaskTestCase):
+    @patch("discordbot.utils._rate_limited_request")
+    def test_announcement_creates_log(self, mock_req):
+        mock_req.return_value = _ok_response({"id": "111222333"})
         self.event.discord_announcement = True
         self.event.discord_announcement_channel_id = "1482767177063858216"
         self.event.save()
@@ -25,8 +43,8 @@ class SendEventAnnouncementTaskTest(EventTestCase):
         self.assertTrue(log.success)
         self.assertEqual(log.channel_id, "1482767177063858216")
 
-    @patch("discordbot.utils.requests.post")
-    def test_announcement_skipped_when_disabled(self, mock_post):
+    @patch("discordbot.utils._rate_limited_request")
+    def test_announcement_skipped_when_disabled(self, mock_req):
         self.event.discord_announcement = False
         self.event.save()
         from events.tasks import send_event_announcement
@@ -35,22 +53,20 @@ class SendEventAnnouncementTaskTest(EventTestCase):
         self.assertEqual(
             DiscordMessageLog.objects.filter(source="event_announcement").count(), 0
         )
-        mock_post.assert_not_called()
+        mock_req.assert_not_called()
 
 
-class SendSignupUpdateTaskTest(EventTestCase):
-    @patch("discordbot.utils.requests.patch")
-    @patch("discordbot.utils.requests.post")
-    def test_signup_update_edits_announcement(self, mock_post, mock_patch):
+class SendSignupUpdateTaskTest(_DiscordTaskTestCase):
+    @patch("discordbot.utils._rate_limited_request")
+    def test_signup_update_edits_announcement(self, mock_req):
         """signup update should PATCH the original announcement message."""
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "444555666"}),
-        )
-        mock_post.return_value.raise_for_status = MagicMock()
-        mock_patch.return_value = MagicMock(status_code=200)
-        mock_patch.return_value.json.return_value = {"id": "444555666"}
-        mock_patch.return_value.raise_for_status = MagicMock()
+
+        def _dispatch(method, url, **kwargs):
+            if method == "POST":
+                return _ok_response({"id": "444555666"})
+            return _ok_response({"id": "444555666"})
+
+        mock_req.side_effect = _dispatch
 
         self.event.discord_announcement = True
         self.event.discord_announcement_channel_id = "1482767177063858216"
@@ -66,9 +82,12 @@ class SendSignupUpdateTaskTest(EventTestCase):
 
         send_signup_update(self.event.pk)
 
-        mock_patch.assert_called_once()
-        call_url = mock_patch.call_args[0][0]
-        self.assertIn("444555666", call_url)
+        # PATCH must have been called and the URL must reference the message id.
+        patch_calls = [
+            c for c in mock_req.call_args_list if c.args and c.args[0] == "PATCH"
+        ]
+        self.assertEqual(len(patch_calls), 1)
+        self.assertIn("444555666", patch_calls[0].args[1])
 
     def test_signup_update_skipped_when_no_announcement(self):
         from events.tasks import send_signup_update
@@ -77,14 +96,10 @@ class SendSignupUpdateTaskTest(EventTestCase):
         self.assertEqual(result, "Skipped: no announcement message")
 
 
-class SendEventAnnouncementComponentsTest(EventTestCase):
-    @patch("discordbot.utils.requests.post")
-    def test_announcement_includes_components_in_payload(self, mock_post):
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "comp111"}),
-        )
-        mock_post.return_value.raise_for_status = MagicMock()
+class SendEventAnnouncementComponentsTest(_DiscordTaskTestCase):
+    @patch("discordbot.utils._rate_limited_request")
+    def test_announcement_includes_components_in_payload(self, mock_req):
+        mock_req.return_value = _ok_response({"id": "comp111"})
 
         self.event.discord_announcement = True
         self.event.discord_announcement_channel_id = "1482767177063858216"
@@ -94,18 +109,18 @@ class SendEventAnnouncementComponentsTest(EventTestCase):
 
         send_event_announcement(self.event.pk)
 
-        call_args = mock_post.call_args
-        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        # Find the POST call to the messages endpoint
+        post_calls = [
+            c for c in mock_req.call_args_list if c.args and c.args[0] == "POST"
+        ]
+        self.assertTrue(post_calls, "Expected at least one POST to Discord API")
+        payload = post_calls[0].kwargs.get("json") or {}
         self.assertIn("components", payload)
         self.assertTrue(len(payload["components"]) >= 1)
 
-    @patch("discordbot.utils.requests.post")
-    def test_announcement_components_contain_signup_button(self, mock_post):
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "comp222"}),
-        )
-        mock_post.return_value.raise_for_status = MagicMock()
+    @patch("discordbot.utils._rate_limited_request")
+    def test_announcement_components_contain_signup_button(self, mock_req):
+        mock_req.return_value = _ok_response({"id": "comp222"})
 
         self.event.discord_announcement = True
         self.event.discord_announcement_channel_id = "1482767177063858216"
@@ -115,22 +130,20 @@ class SendEventAnnouncementComponentsTest(EventTestCase):
 
         send_event_announcement(self.event.pk)
 
-        call_args = mock_post.call_args
-        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        post_calls = [
+            c for c in mock_req.call_args_list if c.args and c.args[0] == "POST"
+        ]
+        self.assertTrue(post_calls, "Expected at least one POST to Discord API")
+        payload = post_calls[0].kwargs.get("json") or {}
         buttons = payload["components"][0]["components"]
         custom_ids = [b.get("custom_id") for b in buttons if b.get("custom_id")]
         self.assertIn(f"event_signup:{self.event.pk}", custom_ids)
 
 
-class SendSignupUpdateEditsMessageTest(EventTestCase):
-    @patch("discordbot.utils.requests.patch")
-    @patch("discordbot.utils.requests.post")
-    def test_signup_update_edits_original_announcement(self, mock_post, mock_patch):
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "orig111"}),
-        )
-        mock_post.return_value.raise_for_status = MagicMock()
+class SendSignupUpdateEditsMessageTest(_DiscordTaskTestCase):
+    @patch("discordbot.utils._rate_limited_request")
+    def test_signup_update_edits_original_announcement(self, mock_req):
+        mock_req.return_value = _ok_response({"id": "orig111"})
 
         self.event.discord_announcement = True
         self.event.discord_announcement_channel_id = "1482767177063858216"
@@ -140,17 +153,15 @@ class SendSignupUpdateEditsMessageTest(EventTestCase):
 
         send_event_announcement(self.event.pk)
 
-        mock_patch.return_value = MagicMock(status_code=200)
-        mock_patch.return_value.json.return_value = {"id": "orig111"}
-        mock_patch.return_value.raise_for_status = MagicMock()
-
         from events.tasks import send_signup_update
 
         send_signup_update(self.event.pk)
 
-        mock_patch.assert_called_once()
-        call_url = mock_patch.call_args[0][0]
-        self.assertIn("orig111", call_url)
+        patch_calls = [
+            c for c in mock_req.call_args_list if c.args and c.args[0] == "PATCH"
+        ]
+        self.assertEqual(len(patch_calls), 1)
+        self.assertIn("orig111", patch_calls[0].args[1])
 
     def test_signup_update_skips_when_no_announcement(self):
         from events.tasks import send_signup_update
@@ -159,24 +170,63 @@ class SendSignupUpdateEditsMessageTest(EventTestCase):
         self.assertEqual(result, "Skipped: no announcement message")
 
 
-class CheckEventRemindersTaskTest(EventTestCase):
-    @patch("discordbot.utils.requests.post")
-    def test_signup_reminder_sent_when_due(self, mock_post):
-        from datetime import timedelta
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
+class CheckEventRemindersTaskTest(_DiscordTaskTestCase):
+    """Verify check_event_reminders idempotency for the signup_reminder source.
+
+    The production code only writes a ``signup_reminder`` ``DiscordMessageLog``
+    when ``send_subscriber_notifications`` actually attempts (or sends) a DM.
+    That requires a repeater + a subscriber with a Discord ID. Older versions
+    of these tests skipped the repeater entirely, so they could never produce
+    the log they were asserting on. We add a repeater + subscriber and stub
+    ``sync_send_dm`` so the reminder pipeline runs without hitting Discord.
+    """
+
+    def _arm_signup_reminder(self):
+        from datetime import time, timedelta
 
         from django.utils import timezone
 
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "rem111"}),
+        from app.models import CustomUser, PositionsModel
+        from discordbot.models import DiscordEvent
+        from events.models import EventRepeater, RepeaterSubscription
+
+        repeater = EventRepeater.objects.create(
+            organization=self.org,
+            name="Reminder Repeater",
+            frequency="weekly",
+            time_of_day=time(18, 0),
+            starts_at=timezone.now().date(),
+            created_by=self.admin,
         )
-        mock_post.return_value.raise_for_status = MagicMock()
+        subscriber_user = CustomUser.objects.create_user(
+            username="reminder_sub", password="pw"
+        )
+        subscriber_user.positions = PositionsModel.objects.create()
+        subscriber_user.discordId = "555111222"
+        subscriber_user.save()
+        RepeaterSubscription.objects.create(
+            event_repeater=repeater, user=subscriber_user
+        )
+
+        DiscordEvent.objects.create(
+            event=self.event,
+            guild_id="1467168401805017142",
+        )
+
         self.event.scheduled_at = timezone.now() + timedelta(hours=23)
         self.event.state = EventState.SIGNUPS_OPEN
         self.event.discord_signup_reminder = True
         self.event.discord_signup_reminder_hours = 24
         self.event.discord_announcement_channel_id = "1482767177063858216"
+        self.event.event_repeater = repeater
         self.event.save()
+
+    @patch("discordbot.utils.sync_send_dm")
+    def test_signup_reminder_sent_when_due(self, mock_send_dm):
+        mock_send_dm.return_value = {"id": "dm111"}
+        self._arm_signup_reminder()
+
         from events.tasks import check_event_reminders
 
         check_event_reminders()
@@ -186,23 +236,11 @@ class CheckEventRemindersTaskTest(EventTestCase):
             ).exists()
         )
 
-    @patch("discordbot.utils.requests.post")
-    def test_signup_reminder_not_sent_twice(self, mock_post):
-        from datetime import timedelta
+    @patch("discordbot.utils.sync_send_dm")
+    def test_signup_reminder_not_sent_twice(self, mock_send_dm):
+        mock_send_dm.return_value = {"id": "dm222"}
+        self._arm_signup_reminder()
 
-        from django.utils import timezone
-
-        mock_post.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"id": "rem222"}),
-        )
-        mock_post.return_value.raise_for_status = MagicMock()
-        self.event.scheduled_at = timezone.now() + timedelta(hours=23)
-        self.event.state = EventState.SIGNUPS_OPEN
-        self.event.discord_signup_reminder = True
-        self.event.discord_signup_reminder_hours = 24
-        self.event.discord_announcement_channel_id = "1482767177063858216"
-        self.event.save()
         from events.tasks import check_event_reminders
 
         check_event_reminders()

--- a/backend/events/tests/test_models.py
+++ b/backend/events/tests/test_models.py
@@ -3,7 +3,13 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone as tz
 
-from events.constants import EventState, RepeatFrequency, SignupStatus, SignupType
+from events.constants import (
+    EVENT_STATE_TRANSITIONS,
+    EventState,
+    RepeatFrequency,
+    SignupStatus,
+    SignupType,
+)
 from events.models import GameType, RollCallMode
 from events.tests.base import EventTestCase
 
@@ -314,3 +320,16 @@ class EventSignupModelTests(EventTestCase):
             EventSignup.objects.create(
                 event=self.event, user=self.user, signup_type=SignupType.USER
             )
+
+
+class EventStateTransitionsTest(TestCase):
+    def test_roll_call_allows_reopen_to_signups_open(self):
+        assert EventState.SIGNUPS_OPEN in EVENT_STATE_TRANSITIONS[EventState.ROLL_CALL]
+
+    def test_other_states_still_reject_reopen_to_signups_open(self):
+        for state in (
+            EventState.IN_PROGRESS,
+            EventState.COMPLETED,
+            EventState.CANCELLED,
+        ):
+            assert EventState.SIGNUPS_OPEN not in EVENT_STATE_TRANSITIONS[state]

--- a/backend/events/tests/test_permissions.py
+++ b/backend/events/tests/test_permissions.py
@@ -1,0 +1,62 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+from django.utils import timezone as tz
+
+from app.models import CustomUser, League, Organization, PositionsModel
+from app.permissions_org import has_event_staff_access
+from events.constants import EventState
+from events.models import Event
+
+
+class HasEventStaffAccessTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.org_staff = CustomUser.objects.create_user(username="org_staff_p", password="x")
+        cls.league_staff = CustomUser.objects.create_user(username="league_staff_p", password="x")
+        cls.unrelated = CustomUser.objects.create_user(username="unrelated_p", password="x")
+        cls.owner = CustomUser.objects.create_user(username="owner_p", password="x")
+        for u in (cls.org_staff, cls.league_staff, cls.unrelated, cls.owner):
+            u.positions = PositionsModel.objects.create()
+            u.save()
+
+        cls.org = Organization.objects.create(name="Perm Test Org", owner=cls.owner)
+        cls.org.staff.add(cls.org_staff)
+        cls.league = League.objects.create(name="Perm Test League", organization=None, steam_league_id=88888)
+        cls.league.staff.add(cls.league_staff)
+
+        cls.event_with_league = Event.objects.create(
+            organization=cls.org,
+            name="With League",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=EventState.ROLL_CALL,
+            created_by=cls.owner,
+            tournament_name="T",
+            tournament_league=cls.league,
+        )
+        cls.event_no_league = Event.objects.create(
+            organization=cls.org,
+            name="No League",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=EventState.ROLL_CALL,
+            created_by=cls.owner,
+            tournament_name="T",
+        )
+
+    def test_org_staff_has_access(self):
+        assert has_event_staff_access(self.org_staff, self.event_with_league)
+        assert has_event_staff_access(self.org_staff, self.event_no_league)
+
+    def test_league_staff_has_access_when_league_set(self):
+        assert has_event_staff_access(self.league_staff, self.event_with_league)
+
+    def test_league_staff_has_no_access_when_no_league_on_event(self):
+        assert not has_event_staff_access(self.league_staff, self.event_no_league)
+
+    def test_unrelated_user_denied(self):
+        assert not has_event_staff_access(self.unrelated, self.event_with_league)
+        assert not has_event_staff_access(self.unrelated, self.event_no_league)
+
+    def test_anonymous_denied(self):
+        assert not has_event_staff_access(AnonymousUser(), self.event_with_league)

--- a/backend/events/tests/test_signup_race.py
+++ b/backend/events/tests/test_signup_race.py
@@ -1,0 +1,59 @@
+import threading
+from datetime import timedelta
+
+from django.db import close_old_connections
+from django.test import TransactionTestCase
+from django.utils import timezone as tz
+
+from app.models import CustomUser, Organization, PositionsModel
+from events.constants import EventState
+from events.models import Event
+from events.services import staff_add_signup
+
+
+class StaffAddSignupRaceTest(TransactionTestCase):
+    def setUp(self):
+        self.admin = CustomUser.objects.create_user(username="race_admin", password="x")
+        self.admin.positions = PositionsModel.objects.create()
+        self.admin.save()
+        self.user = CustomUser.objects.create_user(username="race_user", password="x")
+        self.user.positions = PositionsModel.objects.create()
+        self.user.save()
+        self.org = Organization.objects.create(name="Race Org", owner=self.admin)
+        self.event = Event.objects.create(
+            organization=self.org,
+            name="Race Event",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=EventState.ROLL_CALL,
+            created_by=self.admin,
+            tournament_name="T",
+            max_players=10,
+        )
+
+    def test_concurrent_staff_add_for_same_user_only_one_succeeds(self):
+        results = {"success": 0, "errors": 0}
+        lock = threading.Lock()
+        barrier = threading.Barrier(2)  # force actual contention on the unique constraint
+
+        def worker():
+            try:
+                # Both threads block here until both have arrived, so the inserts
+                # race on the unique_event_user_signup constraint.
+                barrier.wait(timeout=5)
+                staff_add_signup(self.event, self.user)
+                with lock:
+                    results["success"] += 1
+            except Exception:
+                with lock:
+                    results["errors"] += 1
+            finally:
+                close_old_connections()
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results["success"] == 1, results
+        assert results["errors"] == 1, results

--- a/backend/events/tests/test_signup_services.py
+++ b/backend/events/tests/test_signup_services.py
@@ -1,0 +1,138 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone as tz
+
+from app.models import CustomUser, Organization, PositionsModel
+from events.constants import EventState, SignupStatus
+from events.models import Event, EventSignup
+from events.services import process_rsvp, staff_add_signup
+
+
+class StaffAddSignupTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = CustomUser.objects.create_user(username="staff_a", password="x")
+        cls.admin.positions = PositionsModel.objects.create()
+        cls.admin.save()
+        cls.user = CustomUser.objects.create_user(username="player_a", password="x")
+        cls.user.positions = PositionsModel.objects.create()
+        cls.user.save()
+        cls.org = Organization.objects.create(name="StaffAdd Org", owner=cls.admin)
+
+    def _make_event(self, state):
+        return Event.objects.create(
+            organization=self.org,
+            name=f"Test {state}",
+            scheduled_at=tz.now() + timedelta(days=1),
+            state=state,
+            created_by=self.admin,
+            tournament_name="T",
+            max_players=10,
+        )
+
+    def test_staff_add_succeeds_in_signups_open(self):
+        event = self._make_event(EventState.SIGNUPS_OPEN)
+        signup = staff_add_signup(event, self.user)
+        assert signup.pk is not None
+        assert signup.event_id == event.pk
+
+    def test_staff_add_succeeds_in_roll_call(self):
+        event = self._make_event(EventState.ROLL_CALL)
+        signup = staff_add_signup(event, self.user)
+        assert signup.pk is not None
+
+    def test_staff_add_rejects_other_states(self):
+        for state in (
+            EventState.UPCOMING,
+            EventState.IN_PROGRESS,
+            EventState.COMPLETED,
+            EventState.CANCELLED,
+        ):
+            event = self._make_event(state)
+            with self.assertRaises(ValueError):
+                staff_add_signup(event, self.user)
+
+    def test_process_rsvp_still_rejects_roll_call(self):
+        """Regression: public path stays locked during roll call."""
+        event = self._make_event(EventState.ROLL_CALL)
+        with self.assertRaises(ValueError):
+            process_rsvp(event, self.user)
+
+    def test_process_rsvp_still_rejects_other_states(self):
+        for state in (
+            EventState.UPCOMING,
+            EventState.IN_PROGRESS,
+            EventState.COMPLETED,
+            EventState.CANCELLED,
+        ):
+            event = self._make_event(state)
+            with self.assertRaises(ValueError):
+                process_rsvp(event, self.user)
+
+    @patch("events.services.invalidate_after_commit")
+    def test_staff_add_invalidates_cache(self, mock_invalidate):
+        event = self._make_event(EventState.ROLL_CALL)
+        staff_add_signup(event, self.user)
+        mock_invalidate.assert_called_with(event)
+
+    def test_staff_add_waitlists_when_at_capacity(self):
+        event = self._make_event(EventState.ROLL_CALL)
+        event.max_players = 1
+        event.save()
+        # Pre-fill capacity with another user
+        other = CustomUser.objects.create_user(username="other", password="x")
+        other.positions = PositionsModel.objects.create()
+        other.save()
+        EventSignup.objects.create(
+            event=event,
+            user=other,
+            status=SignupStatus.APPROVED,
+        )
+        signup = staff_add_signup(event, self.user)
+        assert signup.status == SignupStatus.WAITLISTED
+        assert signup.waitlist_position == 1
+
+    def test_staff_add_rejects_duplicate_active_signup(self):
+        event = self._make_event(EventState.ROLL_CALL)
+        EventSignup.objects.create(
+            event=event,
+            user=self.user,
+            status=SignupStatus.APPROVED,
+        )
+        with self.assertRaises(ValueError):
+            staff_add_signup(event, self.user)
+
+    def test_staff_add_re_rsvps_after_cancellation(self):
+        """Cancelled signups can be staff-added again (covers _create_signup re-RSVP branch)."""
+        event = self._make_event(EventState.ROLL_CALL)
+        EventSignup.objects.create(
+            event=event,
+            user=self.user,
+            status=SignupStatus.CANCELLED,
+        )
+        signup = staff_add_signup(event, self.user)
+        # The original cancelled row was deleted; the new one should NOT be cancelled.
+        assert signup.status != SignupStatus.CANCELLED
+
+    def test_staff_add_auto_confirm_during_roll_call(self):
+        """Auto-confirm + roll_call_enabled=False adds the user to the tournament."""
+        event = self._make_event(EventState.ROLL_CALL)
+        event.auto_approve = True
+        event.auto_confirm = True
+        event.roll_call_enabled = False
+        # Avoid require_* gates so check_requirements returns True
+        event.require_steam_id = False
+        event.require_mmr_verified = False
+        event.require_profile_complete = False
+        event.save()
+        signup = staff_add_signup(event, self.user)
+        assert signup.status == SignupStatus.CONFIRMED
+
+    @patch("events.services.invalidate_after_commit")
+    def test_process_rsvp_still_invalidates_cache(self, mock_invalidate):
+        """Regression guard: extracting _create_signup must not drop the public-path invalidation."""
+        event = self._make_event(EventState.SIGNUPS_OPEN)
+        process_rsvp(event, self.user)
+        mock_invalidate.assert_called_with(event)

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -42,6 +42,7 @@ from events.services import (
     reinstate_signup,
     reject_signup,
     restart_event_tournament,
+    staff_add_signup,
     sync_future_events,
     sync_tournament_from_event,
     unconfirm_signup,
@@ -501,7 +502,7 @@ class EventViewSet(viewsets.ModelViewSet):
                 {"error": "User not found"}, status=status.HTTP_404_NOT_FOUND
             )
         try:
-            signup = process_rsvp(event, user)
+            signup = staff_add_signup(event, user)
             return Response(
                 EventSignupSerializer(signup).data, status=status.HTTP_201_CREATED
             )

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -76,6 +76,28 @@ def _annotate_event_qs(qs):
     )
 
 
+def _attach_user_can_manage(payload, user):
+    """Mutate a serialized Event payload (or list of them) to set user_can_manage per-request.
+
+    Called AFTER cached_as serves a payload, so the cache itself stays user-agnostic.
+    The Event instances are looked up by id from the payload; one batched query
+    covers both list and single-item cases.
+    """
+    if not user or not user.is_authenticated:
+        return payload  # default False already set by serializer
+    items = payload if isinstance(payload, list) else [payload]
+    if not items:
+        return payload
+    events_by_pk = {
+        e.pk: e for e in Event.objects.filter(pk__in=[p["id"] for p in items])
+    }
+    for p in items:
+        ev = events_by_pk.get(p["id"])
+        if ev is not None:
+            p["user_can_manage"] = has_event_staff_access(user, ev)
+    return payload
+
+
 class EventRepeaterViewSet(viewsets.ModelViewSet):
     serializer_class = EventRepeaterSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -303,7 +325,10 @@ class EventViewSet(viewsets.ModelViewSet):
             serializer = self.get_serializer(queryset, many=True)
             return serializer.data
 
-        return Response(get_data())
+        # cacheops returns a fresh deserialization on every hit; safe to mutate in place.
+        data = list(get_data())  # shallow-copy the outer container
+        _attach_user_can_manage(data, request.user)
+        return Response(data)
 
     def retrieve(self, request, *args, **kwargs):
         pk = kwargs.get("pk")
@@ -320,7 +345,9 @@ class EventViewSet(viewsets.ModelViewSet):
             instance = self.get_object()
             return self.get_serializer(instance).data
 
-        return Response(get_data())
+        data = dict(get_data())  # shallow-copy
+        _attach_user_can_manage(data, request.user)
+        return Response(data)
 
     def perform_create(self, serializer):
         org = serializer.validated_data.get("organization")
@@ -520,7 +547,9 @@ class EventViewSet(viewsets.ModelViewSet):
 
             notify_event_announced(event)
             qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
-            return Response(EventSerializer(qs.first()).data)
+            data = EventSerializer(qs.first()).data
+            _attach_user_can_manage(data, request.user)
+            return Response(data)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -532,7 +561,9 @@ class EventViewSet(viewsets.ModelViewSet):
         try:
             event.transition_state(EventState.ROLL_CALL)
             qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
-            return Response(EventSerializer(qs.first()).data)
+            data = EventSerializer(qs.first()).data
+            _attach_user_can_manage(data, request.user)
+            return Response(data)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -553,7 +584,9 @@ class EventViewSet(viewsets.ModelViewSet):
                 event.transition_state(EventState.SIGNUPS_OPEN)
                 invalidate_after_commit(event)
             qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
-            return Response(EventSerializer(qs.first()).data)
+            data = EventSerializer(qs.first()).data
+            _attach_user_can_manage(data, request.user)
+            return Response(data)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -582,7 +615,9 @@ class EventViewSet(viewsets.ModelViewSet):
 
                 start_auto_create_herodrafts(event.tournament)
             qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
-            return Response(EventSerializer(qs.first()).data)
+            data = EventSerializer(qs.first()).data
+            _attach_user_can_manage(data, request.user)
+            return Response(data)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -633,7 +668,9 @@ class EventViewSet(viewsets.ModelViewSet):
                     tournament.delete()
                 event.transition_state(EventState.CANCELLED)
             qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
-            return Response(EventSerializer(qs.first()).data)
+            data = EventSerializer(qs.first()).data
+            _attach_user_can_manage(data, request.user)
+            return Response(data)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -679,7 +716,9 @@ class EventViewSet(viewsets.ModelViewSet):
             restart_event_tournament(event)
             event.refresh_from_db()
             qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
-            return Response(EventSerializer(qs.first()).data)
+            data = EventSerializer(qs.first()).data
+            _attach_user_can_manage(data, request.user)
+            return Response(data)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -672,7 +672,7 @@ class EventViewSet(viewsets.ModelViewSet):
     def restart_tournament(self, request, pk=None):
         """Delete current tournament, create fresh one, reopen signups."""
         event = self.get_object()
-        if not has_org_staff_access(request.user, event.organization):
+        if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             restart_event_tournament(event)

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 logger = logging.getLogger(__name__)
 
 from app.models import Organization
-from app.permissions_org import has_org_staff_access
+from app.permissions_org import has_event_staff_access, has_org_staff_access
 from events.constants import EventState, SignupStatus
 from events.models import (
     Event,
@@ -487,7 +487,7 @@ class EventViewSet(viewsets.ModelViewSet):
         from app.models import CustomUser
 
         event = self.get_object()
-        if not has_org_staff_access(request.user, event.organization):
+        if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         user_id = request.data.get("user_id")
         if not user_id:
@@ -511,7 +511,7 @@ class EventViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"])
     def open_signups(self, request, pk=None):
         event = self.get_object()
-        if not has_org_staff_access(request.user, event.organization):
+        if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             event.transition_state(EventState.SIGNUPS_OPEN)
@@ -526,7 +526,7 @@ class EventViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"])
     def start_roll_call(self, request, pk=None):
         event = self.get_object()
-        if not has_org_staff_access(request.user, event.organization):
+        if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             event.transition_state(EventState.ROLL_CALL)
@@ -536,10 +536,31 @@ class EventViewSet(viewsets.ModelViewSet):
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, methods=["post"])
+    def reopen_signups(self, request, pk=None):
+        """Corrective transition from ROLL_CALL back to SIGNUPS_OPEN.
+
+        Quiet: no Discord re-announcement, no signup-changed notify. Existing
+        confirmations and tournament additions are preserved.
+        """
+        from app.cache_utils import invalidate_after_commit
+
+        event = self.get_object()
+        if not has_event_staff_access(request.user, event):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        try:
+            with transaction.atomic():
+                event.transition_state(EventState.SIGNUPS_OPEN)
+                invalidate_after_commit(event)
+            qs = _annotate_event_qs(Event.objects.filter(pk=event.pk))
+            return Response(EventSerializer(qs.first()).data)
+        except ValueError as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=["post"])
     def start_tournament(self, request, pk=None):
         """Start the tournament (after roll call or directly)."""
         event = self.get_object()
-        if not has_org_staff_access(request.user, event.organization):
+        if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             if event.state == EventState.ROLL_CALL:
@@ -599,7 +620,7 @@ class EventViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"])
     def cancel(self, request, pk=None):
         event = self.get_object()
-        if not has_org_staff_access(request.user, event.organization):
+        if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             with transaction.atomic():
@@ -676,7 +697,7 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def approve(self, request, pk=None):
         signup = self.get_object()
-        if not has_org_staff_access(request.user, signup.event.organization):
+        if not has_event_staff_access(request.user, signup.event):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         # Optional MMR override from admin
@@ -719,7 +740,7 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def reject(self, request, pk=None):
         signup = self.get_object()
-        if not has_org_staff_access(request.user, signup.event.organization):
+        if not has_event_staff_access(request.user, signup.event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             return Response(EventSignupSerializer(reject_signup(signup)).data)
@@ -729,7 +750,7 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def confirm(self, request, pk=None):
         signup = self.get_object()
-        if not has_org_staff_access(request.user, signup.event.organization):
+        if not has_event_staff_access(request.user, signup.event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             return Response(EventSignupSerializer(confirm_signup(signup)).data)
@@ -739,8 +760,8 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def cancel_signup(self, request, pk=None):
         signup = self.get_object()
-        if signup.user != request.user and not has_org_staff_access(
-            request.user, signup.event.organization
+        if signup.user != request.user and not has_event_staff_access(
+            request.user, signup.event
         ):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
@@ -752,7 +773,7 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     def unconfirm(self, request, pk=None):
         """Revert a confirmed signup back to approved."""
         signup = self.get_object()
-        if not has_org_staff_access(request.user, signup.event.organization):
+        if not has_event_staff_access(request.user, signup.event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             return Response(EventSignupSerializer(unconfirm_signup(signup)).data)
@@ -763,7 +784,7 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     def demote(self, request, pk=None):
         """Move an active signup to the end of the waitlist."""
         signup = self.get_object()
-        if not has_org_staff_access(request.user, signup.event.organization):
+        if not has_event_staff_access(request.user, signup.event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             return Response(EventSignupSerializer(demote_to_waitlist(signup)).data)
@@ -774,8 +795,8 @@ class EventSignupViewSet(viewsets.ReadOnlyModelViewSet):
     def reinstate(self, request, pk=None):
         """Reinstate a cancelled signup (user can reinstate their own)."""
         signup = self.get_object()
-        if signup.user != request.user and not has_org_staff_access(
-            request.user, signup.event.organization
+        if signup.user != request.user and not has_event_staff_access(
+            request.user, signup.event
         ):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -89,7 +89,10 @@ def _attach_user_can_manage(payload, user):
     if not items:
         return payload
     events_by_pk = {
-        e.pk: e for e in Event.objects.filter(pk__in=[p["id"] for p in items])
+        e.pk: e
+        for e in Event.objects.filter(pk__in=[p["id"] for p in items]).select_related(
+            "organization", "tournament_league"
+        )
     }
     for p in items:
         ev = events_by_pk.get(p["id"])

--- a/backend/league/tests/__init__.py
+++ b/backend/league/tests/__init__.py
@@ -1,0 +1,7 @@
+"""Test package for the league app.
+
+Currently no tests live here directly; league behavior is exercised via
+app.tests (e.g. test_league*). This package exists so that test runners
+that ask for `league.tests` can resolve the module without a loader
+ImportError.
+"""

--- a/backend/org/tests/test_player_profiles.py
+++ b/backend/org/tests/test_player_profiles.py
@@ -57,7 +57,7 @@ class PlayerDotaProfileTest(TestCase):
 
         profile = PlayerDotaProfile.objects.create(
             org_user=self.org_user,
-            friend_id="123456789",
+            unverified_friend_id="123456789",
         )
         self.assertEqual(profile.unverified_friend_id, "123456789")
         # Verify it did NOT touch CustomUser.steam_account_id
@@ -98,6 +98,6 @@ class PlayerDeadlockProfileTest(TestCase):
 
         profile = PlayerDeadlockProfile.objects.create(
             org_user=self.org_user,
-            friend_id="987654321",
+            unverified_friend_id="987654321",
         )
         self.assertEqual(profile.unverified_friend_id, "987654321")

--- a/backend/tests/data/users.py
+++ b/backend/tests/data/users.py
@@ -114,6 +114,15 @@ LEAGUE_STAFF_USER: TestUser = TestUser(
     league_id=1,  # Staff of league 1
 )
 
+EVENT_LEAGUE_STAFF_USER: TestUser = TestUser(
+    pk=1032,
+    username="event_league_staff_tester",
+    nickname="Event League Staff Tester",
+    discord_id="100000000000000010",
+    steam_id_64=76561198012345684,
+    league_id=7,  # Staff of Events Test League (league 7)
+)
+
 # =============================================================================
 # Real Tournament 38 Users (pk=3000-3019, from production data)
 # These are real users with Steam IDs for testing Steam league sync
@@ -696,6 +705,7 @@ AUTH_TEST_USERS: list[TestUser] = [
     ORG_STAFF_USER,
     LEAGUE_ADMIN_USER,
     LEAGUE_STAFF_USER,
+    EVENT_LEAGUE_STAFF_USER,
 ]
 
 # Legacy alias

--- a/backend/tests/populate/events.py
+++ b/backend/tests/populate/events.py
@@ -184,6 +184,22 @@ def populate_events_data(force=False):
         ensure_org_user(site_admin, org, mmr=5000)
     invalidate_obj(org)
 
+    # 4b. Add event_league_staff_tester as staff of league 7 ONLY (never of org 7)
+    # This user is created in populate_test_auth_users (step 3); the league
+    # assignment is deferred to here because league pk=7 is created above.
+    from tests.data.users import EVENT_LEAGUE_STAFF_USER
+
+    event_league_staff = CustomUser.objects.filter(
+        pk=EVENT_LEAGUE_STAFF_USER.pk
+    ).first()
+    if event_league_staff:
+        if event_league_staff not in league.staff.all():
+            league.staff.add(event_league_staff)
+            print(
+                f"    Added {event_league_staff.username} as staff of {league.name}"
+            )
+        invalidate_obj(league)
+
     # 5. Create a sample EventRepeater + Event for E2E tests
     repeater, _ = EventRepeater.objects.update_or_create(
         organization=org,

--- a/backend/tests/populate/users.py
+++ b/backend/tests/populate/users.py
@@ -94,6 +94,7 @@ def populate_test_auth_users(force=False):
     from tests.data.users import (
         ADMIN_USER,
         CLAIMABLE_USER,
+        EVENT_LEAGUE_STAFF_USER,
         LEAGUE_ADMIN_USER,
         LEAGUE_STAFF_USER,
         ORG_ADMIN_USER,
@@ -187,6 +188,7 @@ def populate_test_auth_users(force=False):
     # Create league role users
     league_admin = create_user_with_pk(LEAGUE_ADMIN_USER)
     league_staff = create_user_with_pk(LEAGUE_STAFF_USER)
+    event_league_staff = create_user_with_pk(EVENT_LEAGUE_STAFF_USER)
 
     # Assign org/league roles
     # Org roles
@@ -208,5 +210,12 @@ def populate_test_auth_users(force=False):
         if league_staff not in league.staff.all():
             league.staff.add(league_staff)
             print(f"  Added {league_staff.username} as staff of {league.name}")
+
+    # Event-specific league staff (staff of league 7 ONLY, never of org 7)
+    events_league = League.objects.filter(pk=EVENT_LEAGUE_STAFF_USER.league_id).first()
+    if events_league:
+        if event_league_staff not in events_league.staff.all():
+            events_league.staff.add(event_league_staff)
+            print(f"  Added {event_league_staff.username} as staff of {events_league.name}")
 
     print(f"Test auth users created/updated successfully!")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -563,6 +563,27 @@ def login_league_staff(request):
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([AllowAny])
+def login_event_league_staff(request):
+    """Login as event-league-staff test user (staff of league 7)."""
+    if not isTestEnvironment(request):
+        return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+    from tests.data.users import EVENT_LEAGUE_STAFF_USER
+
+    user = CustomUser.objects.filter(pk=EVENT_LEAGUE_STAFF_USER.pk).first()
+    if not user:
+        return Response(
+            {"detail": "Test user not populated. Run db::populate first."},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+    return return_tokens(user)
+
+
+@csrf_exempt
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([AllowAny])
 def login_as_user(request):
     """
     TEST ONLY: Login as any user by primary key.

--- a/backend/tests/test_populate.py
+++ b/backend/tests/test_populate.py
@@ -1,0 +1,42 @@
+"""
+Populate guard regression tests.
+
+These tests assert invariants of the test-data populate pipeline that, if
+broken, would silently invalidate Playwright auth fixtures and event-staff
+permission specs.
+"""
+
+from django.test import TestCase
+
+from app.models import CustomUser, League, Organization
+from tests.data.leagues import EVENTS_LEAGUE
+from tests.data.organizations import EVENTS_ORG
+from tests.data.users import EVENT_LEAGUE_STAFF_USER
+
+
+class EventLeagueStaffIsolationTest(TestCase):
+    """Regression guard: event_league_staff must be staff of league 7 only,
+    never of org 7. Used by Playwright tests to assert league-staff-only
+    access on event pages.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from tests.populate.events import populate_events_data
+        from tests.populate.organizations import populate_organizations_and_leagues
+        from tests.populate.users import populate_test_auth_users
+
+        # Run populate dependencies in order. populate_events_data creates
+        # league pk=7 and is responsible for the league.staff assignment.
+        populate_organizations_and_leagues(force=True)
+        populate_test_auth_users(force=True)
+        populate_events_data(force=True)
+
+    def test_event_league_staff_isolation(self):
+        user = CustomUser.objects.get(pk=EVENT_LEAGUE_STAFF_USER.pk)
+        league = League.objects.get(pk=EVENTS_LEAGUE.pk)
+        org = Organization.objects.get(pk=EVENTS_ORG.pk)
+
+        assert user in league.staff.all(), "Should be staff of league 7"
+        assert user not in org.staff.all(), "MUST NOT be staff of org 7"
+        assert user not in org.admins.all(), "MUST NOT be admin of org 7"

--- a/backend/tests/urls.py
+++ b/backend/tests/urls.py
@@ -13,6 +13,7 @@ from .test_auth import (
     login_admin,
     login_as_discord_id,
     login_as_user,
+    login_event_league_staff,
     login_league_admin,
     login_league_staff,
     login_org_admin,
@@ -86,6 +87,12 @@ urlpatterns = [
         "login-league-staff/",
         login_league_staff,
         name="login-league-staff",
+    ),
+    # Event-only League Staff (staff of league 7, never of org 7)
+    path(
+        "login-event-league-staff/",
+        login_event_league_staff,
+        name="login-event-league-staff",
     ),
     path(
         "login-as/",

--- a/frontend/app/components/api/api.tsx
+++ b/frontend/app/components/api/api.tsx
@@ -133,6 +133,7 @@ export type { AddMemberPayload, AddUserResponse } from './types';
 export {
   getEvents, getEvent, createEvent, updateEvent, deleteEvent,
   rsvpForEvent, openSignups, startRollCall, startTournament, cancelEvent,
+  reopenSignups,
   restartTournament,
   getEventSignups, approveSignup, rejectSignup, confirmSignup, cancelSignup,
   unconfirmSignup, demoteSignup, reinstateSignup,

--- a/frontend/app/components/api/eventsAPI.ts
+++ b/frontend/app/components/api/eventsAPI.ts
@@ -56,6 +56,11 @@ export async function startRollCall(eventId: number): Promise<EventType> {
   return data;
 }
 
+export async function reopenSignups(eventId: number): Promise<EventType> {
+  const { data } = await axios.post<EventType>(`/events/${eventId}/reopen_signups/`);
+  return data;
+}
+
 export async function startTournament(eventId: number): Promise<EventType> {
   const { data } = await axios.post<EventType>(`/events/${eventId}/start_tournament/`);
   return data;
@@ -300,8 +305,14 @@ export async function tentativeForEvent(eventId: number): Promise<EventSignupTyp
   return data;
 }
 
-export async function adminAddSignup(eventId: number, userId: number) {
-  const { data } = await axios.post(`/events/${eventId}/admin-signup/`, { user_id: userId });
+export async function adminAddSignup(
+  eventId: number,
+  userId: number,
+): Promise<EventSignupType> {
+  const { data } = await axios.post<EventSignupType>(
+    `/events/${eventId}/admin-signup/`,
+    { user_id: userId },
+  );
   return data;
 }
 

--- a/frontend/app/components/events/EventAdminActions.tsx
+++ b/frontend/app/components/events/EventAdminActions.tsx
@@ -1,0 +1,227 @@
+import { CheckCircle2, Clock, Pencil, ShieldAlert, Trash2, Undo2, Users, XCircle } from 'lucide-react';
+import { useState } from 'react';
+
+import { ConfirmDialog } from '~/components/ui/dialogs/ConfirmDialog';
+import {
+  DestructiveButton,
+  PrimaryButton,
+  SecondaryButton,
+  WarningButton,
+} from '~/components/ui/buttons';
+import { BrandDropdownMenu, type BrandDropdownAction } from '~/components/ui/brand-dropdown-menu';
+import { EventState } from '~/components/events/schemas';
+import type { EventType } from '~/components/events/schemas';
+import type { useEventActionMutation } from '~/hooks/useEvent';
+
+type EventActions = Pick<
+  ReturnType<typeof useEventActionMutation>,
+  'openSignups' | 'startRollCall' | 'reopenSignups' | 'cancelEvent' | 'deleteEvent'
+>;
+
+interface EventAdminActionsProps {
+  event: EventType;
+  actions: EventActions;
+  onEditClick: () => void;
+  onStartRollCallClick: () => void;
+  onReopenSignupsClick: () => void;
+  onOpenRollCallClick: () => void;
+  onDeleteConfirmed: () => void;
+}
+
+export function EventAdminActions({
+  event,
+  actions,
+  onEditClick,
+  onStartRollCallClick,
+  onReopenSignupsClick,
+  onOpenRollCallClick,
+  onDeleteConfirmed,
+}: EventAdminActionsProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const isCancellable = event.state !== EventState.COMPLETED && event.state !== EventState.CANCELLED;
+
+  // Mobile dropdown actions — NO data-testid here (would collide with desktop).
+  // Tests reach mobile actions via the parent `event-admin-actions-mobile`.
+  const dropdownActions: BrandDropdownAction[] = [
+    {
+      key: 'edit',
+      icon: <Pencil className="h-4 w-4 mr-1.5" />,
+      label: 'Edit',
+      onClick: onEditClick,
+      variant: 'success',
+    },
+  ];
+
+  if (event.state === EventState.UPCOMING) {
+    dropdownActions.push({
+      key: 'open-signups',
+      icon: <Users className="h-4 w-4 mr-1.5" />,
+      label: 'Open Signups',
+      onClick: () => actions.openSignups.mutate(),
+      variant: 'primary',
+      disabled: actions.openSignups.isPending,
+    });
+  }
+
+  if (event.state === EventState.SIGNUPS_OPEN) {
+    dropdownActions.push({
+      key: 'start-rollcall',
+      icon: <Clock className="h-4 w-4 mr-1.5" />,
+      label: 'Start Roll Call',
+      onClick: onStartRollCallClick,
+      variant: 'primary',
+      disabled: actions.startRollCall.isPending,
+    });
+  }
+
+  if (event.state === EventState.ROLL_CALL) {
+    dropdownActions.push({
+      key: 'reopen-signups',
+      icon: <Undo2 className="h-4 w-4 mr-1.5" />,
+      label: 'Reopen Signups',
+      onClick: onReopenSignupsClick,
+      // BrandDropdownAction.variant doesn't currently include 'warning' — actual
+      // union is 'default' | 'primary' | 'success' | 'destructive'. Use 'destructive'
+      // as the closest semantic match; desktop WarningButton carries the on-brand
+      // orange treatment.
+      variant: 'destructive',
+      disabled: actions.reopenSignups.isPending,
+    });
+    dropdownActions.push({
+      key: 'open-rollcall',
+      icon: <CheckCircle2 className="h-4 w-4 mr-1.5" />,
+      label: 'Open Roll Call',
+      onClick: onOpenRollCallClick,
+      variant: 'primary',
+    });
+  }
+
+  if (isCancellable) {
+    dropdownActions.push({
+      key: 'cancel',
+      icon: <XCircle className="h-4 w-4 mr-1.5" />,
+      label: 'Cancel',
+      onClick: () => actions.cancelEvent.mutate(),
+      variant: 'destructive',
+      disabled: actions.cancelEvent.isPending,
+    });
+  }
+
+  dropdownActions.push({
+    key: 'delete',
+    icon: <Trash2 className="h-4 w-4 mr-1.5" />,
+    label: 'Delete',
+    onClick: () => setShowDeleteConfirm(true),
+    variant: 'destructive',
+    disabled: actions.deleteEvent.isPending,
+  });
+
+  return (
+    <>
+      {/* Desktop: button group — owns the canonical testids */}
+      <div className="hidden md:flex items-center gap-2">
+        <SecondaryButton
+          color="emerald"
+          size="sm"
+          onClick={onEditClick}
+          title="Edit settings"
+          aria-label="Edit event settings"
+          data-testid="event-edit-btn"
+        >
+          <Pencil className="h-4 w-4 mr-1.5" />
+          Edit
+        </SecondaryButton>
+
+        {event.state === EventState.UPCOMING && (
+          <SecondaryButton
+            color="emerald"
+            size="sm"
+            onClick={() => actions.openSignups.mutate()}
+            disabled={actions.openSignups.isPending}
+            data-testid="event-open-signups-btn"
+          >
+            Open Signups
+          </SecondaryButton>
+        )}
+
+        {event.state === EventState.SIGNUPS_OPEN && (
+          <SecondaryButton
+            color="orange"
+            size="sm"
+            onClick={onStartRollCallClick}
+            disabled={actions.startRollCall.isPending}
+            data-testid="event-start-rollcall-btn"
+          >
+            Start Roll Call
+          </SecondaryButton>
+        )}
+
+        {event.state === EventState.ROLL_CALL && (
+          <>
+            {/* Reopen is the corrective/secondary action — `depth={false}` flattens it
+                so PrimaryButton "Open Roll Call" wins visual primacy per THEMING-GUIDE
+                "Button Policy: one primary action per view/section". */}
+            <WarningButton
+              size="sm"
+              depth={false}
+              onClick={onReopenSignupsClick}
+              loading={actions.reopenSignups.isPending}
+              aria-label="Reopen signups for this event"
+              data-testid="event-reopen-signups-btn"
+            >
+              <Undo2 className="h-4 w-4 mr-1.5" />
+              Reopen Signups
+            </WarningButton>
+            <PrimaryButton size="sm" onClick={onOpenRollCallClick} data-testid="event-start-tournament-btn">
+              Open Roll Call
+            </PrimaryButton>
+          </>
+        )}
+
+        {isCancellable && (
+          <DestructiveButton
+            size="sm"
+            onClick={() => actions.cancelEvent.mutate()}
+            loading={actions.cancelEvent.isPending}
+            data-testid="event-cancel-btn"
+          >
+            <XCircle className="h-4 w-4 mr-1.5" />
+            Cancel
+          </DestructiveButton>
+        )}
+
+        <DestructiveButton
+          size="sm"
+          onClick={() => setShowDeleteConfirm(true)}
+          loading={actions.deleteEvent.isPending}
+          data-testid="event-delete-btn"
+        >
+          <Trash2 className="h-4 w-4 mr-1.5" />
+          Delete
+        </DestructiveButton>
+      </div>
+
+      {/* Mobile: labeled dropdown — testid lives on the wrapper, not on items */}
+      <div className="md:hidden">
+        <BrandDropdownMenu
+          label="Admin"
+          icon={<ShieldAlert className="h-4 w-4 mr-1.5" />}
+          actions={dropdownActions}
+          variant="admin"
+          data-testid="event-admin-actions-mobile"
+        />
+      </div>
+
+      {/* On-brand delete confirmation (replaces window.confirm) */}
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        title="Delete Event"
+        description={`Permanently delete "${event.name}"? This cannot be undone.`}
+        confirmLabel="Delete Event"
+        variant="destructive"
+        onConfirm={onDeleteConfirmed}
+      />
+    </>
+  );
+}

--- a/frontend/app/components/events/EventStateBadge.tsx
+++ b/frontend/app/components/events/EventStateBadge.tsx
@@ -20,10 +20,18 @@ const stateConfig: Record<string, { label: string; className: string }> = {
   [SignupStatus.REJECTED]: { label: 'Rejected', className: 'bg-error/20 text-error border-error/30' },
 };
 
-export function EventStateBadge({ state, className }: { state: string; className?: string }) {
+export function EventStateBadge({
+  state,
+  className,
+  'data-testid': dataTestId,
+}: {
+  state: string;
+  className?: string;
+  'data-testid'?: string;
+}) {
   const config = stateConfig[state] ?? { label: state, className: '' };
   return (
-    <Badge variant="outline" className={cn(config.className, className)}>
+    <Badge variant="outline" className={cn(config.className, className)} data-testid={dataTestId}>
       {config.label}
     </Badge>
   );

--- a/frontend/app/components/events/schemas.ts
+++ b/frontend/app/components/events/schemas.ts
@@ -27,7 +27,7 @@ export const eventSchema = z.object({
   description: z.string(),
   scheduled_at: z.string(),
   signups_open_at: z.string().nullable(),
-  state: z.string(),
+  state: z.nativeEnum(EventState),
   tournament: z.number().nullable(),
   created_by: z.number().nullable(),
   created_at: z.string(),
@@ -86,6 +86,7 @@ export const eventSchema = z.object({
   discord_require_rank_screenshot: z.boolean(),
   discord_require_battlecup_screenshot: z.boolean(),
   min_mmr: z.number().nullable(),
+  user_can_manage: z.boolean().default(false),
   _warning: z.string().optional(),
 });
 

--- a/frontend/app/hooks/useEvent.ts
+++ b/frontend/app/hooks/useEvent.ts
@@ -16,6 +16,7 @@ import {
   getEventRepeaters,
   getEventSignups,
   openSignups as openSignupsAPI,
+  reopenSignups as reopenSignupsAPI,
   rejectSignup as rejectSignupAPI,
   unconfirmSignup as unconfirmSignupAPI,
   demoteSignup as demoteSignupAPI,
@@ -103,6 +104,16 @@ export function useEventActionMutation(eventId: number) {
     startRollCall: useMutation({
       mutationFn: () => startRollCallAPI(eventId),
       onSuccess: (data) => queryClient.setQueryData(['event', eventId], data),
+    }),
+    reopenSignups: useMutation({
+      // Corrective transition; no optimistic update intentionally.
+      mutationFn: () => reopenSignupsAPI(eventId),
+      onSuccess: (data) => {
+        queryClient.setQueryData(['event', eventId], data);
+        // The events list filters by state — a regression from roll_call → signups_open
+        // changes which lists this event appears in.
+        queryClient.invalidateQueries({ queryKey: ['events'] });
+      },
     }),
     startTournament: useMutation({
       mutationFn: () => startTournamentAPI(eventId),

--- a/frontend/app/lib/apiError.ts
+++ b/frontend/app/lib/apiError.ts
@@ -1,0 +1,3 @@
+export function extractApiError(err: unknown): string | undefined {
+  return (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+}

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -92,7 +92,6 @@ import { adminAddSignup, subscribeToRepeater, unsubscribeFromRepeater } from '~/
 import { AddUserModal } from '~/components/user/AddUserModal';
 import { useResolvedUsers } from '~/hooks/useResolvedUsers';
 import { useOrganization } from '~/components/organization';
-import { useIsOrganizationStaff } from '~/hooks/usePermissions';
 import { usePageNav } from '~/hooks/usePageNav';
 import { useUserStore } from '~/store/userStore';
 import { ConfirmDialog } from '~/components/ui/dialogs';
@@ -115,9 +114,10 @@ export default function EventPage() {
   const [showCancelRsvpConfirm, setShowCancelRsvpConfirm] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
 
-  // Permission check - fetch the specific org for this event
+  // Fetch the specific org for this event (needed for org logo and discord server id)
   const { organization: eventOrg } = useOrganization(event?.organization ?? undefined);
-  const isAdmin = useIsOrganizationStaff(eventOrg);
+  // Permission check uses backend-derived flag (covers org staff AND league staff).
+  const isAdmin = event?.user_can_manage ?? false;
 
   // Mutations
   const queryClient = useQueryClient();

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -68,7 +68,7 @@ import { EventState, GameType } from '~/components/events/schemas';
 import { MmrApprovalModal } from '~/components/events/MmrApprovalModal';
 import { DiscordLogSection } from '~/components/events/DiscordLogSection';
 import { EditEventModal } from '~/components/events/EditEventModal';
-import type { EventSignupType } from '~/components/events/schemas';
+import type { EventSignupType, EventType } from '~/components/events/schemas';
 import { PrimaryButton, SecondaryButton, DestructiveButton, HighlightButton } from '~/components/ui/buttons';
 import { EventAdminActions } from '~/components/events/EventAdminActions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
@@ -488,6 +488,7 @@ export default function EventPage() {
               eventId={event.id}
               orgId={event.organization}
               hasDiscordServer={!!eventOrg?.discord_server_id}
+              state={event.state}
             />
           </TabsContent>
 
@@ -497,6 +498,7 @@ export default function EventPage() {
               isAdmin={isAdmin}
               signupActions={signupActions}
               gameType={event.game_type}
+              state={event.state}
             />
           </TabsContent>
 
@@ -506,6 +508,7 @@ export default function EventPage() {
               isAdmin={isAdmin}
               signupActions={signupActions}
               gameType={event.game_type}
+              state={event.state}
             />
           </TabsContent>
 
@@ -681,6 +684,7 @@ function SignupsTab({
   eventId,
   orgId,
   hasDiscordServer,
+  state,
 }: {
   signups: EventSignupType[];
   isAdmin: boolean;
@@ -689,6 +693,7 @@ function SignupsTab({
   eventId?: number;
   orgId?: number;
   hasDiscordServer?: boolean;
+  state: EventType['state'];
 }) {
   const [approvalSignup, setApprovalSignup] = useState<EventSignupType | null>(null);
   const [removeSignup, setRemoveSignup] = useState<{ signup: EventSignupType; name: string } | null>(null);
@@ -713,7 +718,7 @@ function SignupsTab({
 
   return (
     <div className="space-y-3">
-      {isAdmin && eventId && (
+      {isAdmin && eventId && (state === EventState.SIGNUPS_OPEN || state === EventState.ROLL_CALL) && (
         <div className="flex justify-end">
           <SecondaryButton
             size="sm"

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -50,13 +50,10 @@ import {
   Clock,
   CheckCircle2,
   XCircle,
-  Trash2,
   UserCheck,
   UserX,
-  Pencil,
   HelpCircle,
   Repeat,
-  ShieldAlert,
   ArrowDownToLine,
   Undo2,
   UserPlus,
@@ -73,7 +70,7 @@ import { DiscordLogSection } from '~/components/events/DiscordLogSection';
 import { EditEventModal } from '~/components/events/EditEventModal';
 import type { EventSignupType } from '~/components/events/schemas';
 import { PrimaryButton, SecondaryButton, DestructiveButton, HighlightButton } from '~/components/ui/buttons';
-import { BrandDropdownMenu, type BrandDropdownAction } from '~/components/ui/brand-dropdown-menu';
+import { EventAdminActions } from '~/components/events/EventAdminActions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { Card, CardContent, CardHeader } from '~/components/ui/card';
 import { UserEventStrip } from '~/components/user';
@@ -110,6 +107,7 @@ export default function EventPage() {
 
   const [activeTab, setActiveTab] = useState(tab || 'details');
   const [showRollCallConfirm, setShowRollCallConfirm] = useState(false);
+  const [showReopenConfirm, setShowReopenConfirm] = useState(false);
   const [showRsvpConfirm, setShowRsvpConfirm] = useState(false);
   const [showCancelRsvpConfirm, setShowCancelRsvpConfirm] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -239,86 +237,6 @@ export default function EventPage() {
 
   usePageNav(event ? pageNavOptions : null, activeTab, handleTabChange);
 
-  // Build admin actions for mobile dropdown — must be before early returns
-  const adminActions = useMemo((): BrandDropdownAction[] => {
-    if (!isAdmin || !event) return [];
-    const items: BrandDropdownAction[] = [
-      {
-        key: 'edit',
-        icon: <Pencil className="h-4 w-4 mr-1.5" />,
-        label: 'Edit',
-        onClick: () => setShowEditModal(true),
-        variant: 'success',
-        'data-testid': 'event-edit-btn',
-      },
-    ];
-
-    if (event.state === EventState.UPCOMING) {
-      items.push({
-        key: 'open-signups',
-        icon: <Users className="h-4 w-4 mr-1.5" />,
-        label: 'Open Signups',
-        onClick: () => actions.openSignups.mutate(),
-        variant: 'primary',
-        disabled: actions.openSignups.isPending,
-        'data-testid': 'event-open-signups-btn',
-      });
-    }
-
-    if (event.state === EventState.SIGNUPS_OPEN) {
-      items.push({
-        key: 'start-rollcall',
-        icon: <Clock className="h-4 w-4 mr-1.5" />,
-        label: 'Start Roll Call',
-        onClick: () => setShowRollCallConfirm(true),
-        variant: 'primary',
-        disabled: actions.startRollCall.isPending,
-        'data-testid': 'event-start-rollcall-btn',
-      });
-    }
-
-    if (event.state === EventState.ROLL_CALL) {
-      items.push({
-        key: 'open-rollcall',
-        icon: <CheckCircle2 className="h-4 w-4 mr-1.5" />,
-        label: 'Open Roll Call',
-        onClick: () => navigate(`/rollcall/${eventId}`),
-        variant: 'primary',
-        'data-testid': 'event-start-tournament-btn',
-      });
-    }
-
-    if (event.state !== EventState.COMPLETED && event.state !== EventState.CANCELLED) {
-      items.push({
-        key: 'cancel',
-        icon: <XCircle className="h-4 w-4 mr-1.5" />,
-        label: 'Cancel',
-        onClick: () => actions.cancelEvent.mutate(),
-        variant: 'destructive',
-        disabled: actions.cancelEvent.isPending,
-        'data-testid': 'event-cancel-btn',
-      });
-    }
-
-    items.push({
-      key: 'delete',
-      icon: <Trash2 className="h-4 w-4 mr-1.5" />,
-      label: 'Delete',
-      onClick: () => {
-        if (window.confirm('Are you sure you want to permanently delete this event? This cannot be undone.')) {
-          actions.deleteEvent.mutate(undefined, {
-            onSuccess: () => navigate('/events'),
-          });
-        }
-      },
-      variant: 'destructive',
-      disabled: actions.deleteEvent.isPending,
-      'data-testid': 'event-delete-btn',
-    });
-
-    return items;
-  }, [isAdmin, event?.state, event?.organization, actions, eventId, navigate]);
-
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -402,95 +320,17 @@ export default function EventPage() {
           <div className="flex items-center justify-between gap-3">
             {/* Admin actions — left side */}
             {isAdmin ? (
-              <>
-                {/* Desktop: button group */}
-                <div className="hidden md:flex items-center gap-2">
-                  <SecondaryButton
-                    color="emerald"
-                    size="sm"
-                    onClick={() => setShowEditModal(true)}
-                    title="Edit settings"
-                    data-testid="event-edit-btn"
-                  >
-                    <Pencil className="h-4 w-4 mr-1.5" />
-                    Edit
-                  </SecondaryButton>
-
-                  {event.state === EventState.UPCOMING && (
-                    <SecondaryButton
-                      color="green"
-                      size="sm"
-                      onClick={() => actions.openSignups.mutate()}
-                      disabled={actions.openSignups.isPending}
-                      data-testid="event-open-signups-btn"
-                    >
-                      Open Signups
-                    </SecondaryButton>
-                  )}
-
-                  {event.state === EventState.SIGNUPS_OPEN && (
-                    <SecondaryButton
-                      color="orange"
-                      size="sm"
-                      onClick={() => setShowRollCallConfirm(true)}
-                      disabled={actions.startRollCall.isPending}
-                      data-testid="event-start-rollcall-btn"
-                    >
-                      Start Roll Call
-                    </SecondaryButton>
-                  )}
-
-                  {event.state === EventState.ROLL_CALL && (
-                    <PrimaryButton
-                      size="sm"
-                      onClick={() => navigate(`/rollcall/${eventId}`)}
-                      data-testid="event-start-tournament-btn"
-                    >
-                      Open Roll Call
-                    </PrimaryButton>
-                  )}
-
-                  {event.state !== EventState.COMPLETED &&
-                    event.state !== EventState.CANCELLED && (
-                      <DestructiveButton
-                        size="sm"
-                        onClick={() => actions.cancelEvent.mutate()}
-                        loading={actions.cancelEvent.isPending}
-                        data-testid="event-cancel-btn"
-                      >
-                        <XCircle className="h-4 w-4 mr-1.5" />
-                        Cancel
-                      </DestructiveButton>
-                    )}
-
-                  <DestructiveButton
-                    size="sm"
-                    onClick={() => {
-                      if (window.confirm('Are you sure you want to permanently delete this event? This cannot be undone.')) {
-                        actions.deleteEvent.mutate(undefined, {
-                          onSuccess: () => navigate('/events'),
-                        });
-                      }
-                    }}
-                    loading={actions.deleteEvent.isPending}
-                    data-testid="event-delete-btn"
-                  >
-                    <Trash2 className="h-4 w-4 mr-1.5" />
-                    Delete
-                  </DestructiveButton>
-                </div>
-
-                {/* Mobile: labeled dropdown */}
-                <div className="md:hidden">
-                  <BrandDropdownMenu
-                    label="Admin"
-                    icon={<ShieldAlert className="h-4 w-4 mr-1.5" />}
-                    actions={adminActions}
-                    variant="admin"
-                    data-testid="event-admin-actions-mobile"
-                  />
-                </div>
-              </>
+              <EventAdminActions
+                event={event}
+                actions={actions}
+                onEditClick={() => setShowEditModal(true)}
+                onStartRollCallClick={() => setShowRollCallConfirm(true)}
+                onReopenSignupsClick={() => setShowReopenConfirm(true)}
+                onOpenRollCallClick={() => navigate(`/rollcall/${eventId}`)}
+                onDeleteConfirmed={() => {
+                  actions.deleteEvent.mutate(undefined, { onSuccess: () => navigate('/events') });
+                }}
+              />
             ) : (
               <div />
             )}

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -94,6 +94,7 @@ import { useUserStore } from '~/store/userStore';
 import { ConfirmDialog } from '~/components/ui/dialogs';
 import { EntityBreadcrumb, type BreadcrumbSegment } from '~/components/ui/entity-breadcrumb';
 import api from '~/components/api/axios';
+import { extractApiError } from '~/lib/apiError';
 
 export default function EventPage() {
   const { eventId, tab } = useParams<{ eventId: string; tab?: string }>();
@@ -308,7 +309,7 @@ export default function EventPage() {
 
         {/* Row 2: Status + Date */}
         <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2 text-muted-foreground">
-          <EventStateBadge state={event.state} />
+          <EventStateBadge state={event.state} data-testid="event-state-badge" />
           <Badge variant="secondary" className="flex items-center gap-1 w-fit">
             <Clock className="h-3 w-3" />
             {formattedDate}
@@ -568,6 +569,25 @@ export default function EventPage() {
             toast.success('RSVP cancelled');
           } catch {
             toast.error('Failed to cancel RSVP');
+          }
+        }}
+      />
+
+      <ConfirmDialog
+        open={showReopenConfirm}
+        onOpenChange={setShowReopenConfirm}
+        title="Reopen Signups"
+        description={`Reopen signups for "${event.name}" and allow new RSVPs? Existing confirmations will be kept and no announcement will be sent.`}
+        confirmLabel="Reopen Signups"
+        variant="warning"
+        isLoading={actions.reopenSignups.isPending}
+        onConfirm={async () => {
+          try {
+            await actions.reopenSignups.mutateAsync();
+            toast.success('Signups reopened');
+          } catch (err: unknown) {
+            const message = extractApiError(err);
+            toast.error(message || 'Failed to reopen signups');
           }
         }}
       />

--- a/frontend/tests/playwright/e2e/16-events/03-roll-call.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/03-roll-call.spec.ts
@@ -18,6 +18,7 @@ import {
   loginEventAdmin,
   loginEventPlayer,
   postWithCsrf,
+  verifyDiscordMessages,
   type EventInfo,
 } from '../../fixtures';
 
@@ -117,5 +118,54 @@ test.describe('Roll Call Flow (@cicd)', () => {
     // Click should navigate to roll call page
     await openRollCallBtn.click();
     await page.waitForURL(/\/rollcall\//);
+  });
+
+  test('staff can reopen signups from roll_call (@cicd)', async ({ page, context }) => {
+    await loginEventAdmin(context);
+
+    // Force the event into ROLL_CALL via the existing test API.
+    const startResp = await postWithCsrf(
+      context,
+      `${API_URL}/events/${eventInfo.pk}/start_roll_call/`,
+    );
+    expect(startResp.ok()).toBeTruthy();
+
+    // Snapshot the announcement message BEFORE reopen so we can assert it didn't change.
+    const beforeDiscord = await verifyDiscordMessages(context, eventInfo.pk);
+
+    // Route is /events/:eventId/:tab? — plural (see frontend/app/routes.tsx)
+    await visitAndWaitForHydration(page, `/events/${eventInfo.pk}`);
+    await expect(page.getByTestId('event-state-badge')).toHaveText(/Roll Call/i);
+
+    // Click Reopen Signups (desktop; mobile dropdown unreachable at 1280×720)
+    await page.getByTestId('event-reopen-signups-btn').click();
+
+    // Confirm dialog → click the WarningButton confirm
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/events/${eventInfo.pk}/reopen_signups/`) &&
+          r.request().method() === 'POST',
+      ),
+      page.getByRole('button', { name: /^Reopen Signups$/ }).last().click(),
+    ]);
+    expect(response.status()).toBe(200);
+
+    // Positive: state flipped, button is gone
+    await expect(page.getByTestId('event-state-badge')).toHaveText(/Signups Open/i);
+    await expect(page.getByTestId('event-reopen-signups-btn')).toHaveCount(0);
+
+    // Negative: no Discord re-announcement was posted.
+    const afterDiscord = await verifyDiscordMessages(context, eventInfo.pk);
+    expect(afterDiscord.announcement?.id ?? null).toBe(beforeDiscord.announcement?.id ?? null);
+  });
+
+  test('Reopen Signups button is hidden outside roll_call (@cicd)', async ({ page, context }) => {
+    await loginEventAdmin(context);
+
+    // The events test data leaves `eventInfo.pk` in SIGNUPS_OPEN by default after resetEventsData.
+    await visitAndWaitForHydration(page, `/events/${eventInfo.pk}`);
+    await expect(page.getByTestId('event-state-badge')).toHaveText(/Signups Open/i);
+    await expect(page.getByTestId('event-reopen-signups-btn')).toHaveCount(0);
   });
 });

--- a/frontend/tests/playwright/e2e/16-events/05-signup-management.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/05-signup-management.spec.ts
@@ -23,6 +23,7 @@ import {
 } from '../../fixtures';
 
 import { postWithCsrf } from '../../fixtures/events';
+import { waitForAddUserModal, searchAndAddUser, closeAddUserModal } from '../../helpers/add-user';
 
 const API_URL = 'https://localhost/api';
 
@@ -243,5 +244,39 @@ test.describe('Event Signup Management (@cicd)', () => {
 
     // Waitlist tab should show 2
     await expect(page.getByTestId('event-tab-waitlist')).toContainText('2');
+  });
+
+  test('staff can admin-add a user during roll_call (@cicd)', async ({ page, context }) => {
+    // Force the event into ROLL_CALL via the existing test API.
+    const startResp = await postWithCsrf(
+      context,
+      `${API_URL}/events/${eventInfo.pk}/start_roll_call/`,
+    );
+    expect(startResp.ok()).toBeTruthy();
+
+    // Route is /events/:eventId/:tab? — plural; navigate directly to the signups tab.
+    await visitAndWaitForHydration(page, `/events/${eventInfo.pk}/signups`);
+    await expect(page.getByTestId('event-state-badge')).toHaveText(/Roll Call/i);
+
+    // Open AddUserModal via canonical testid (gate widened to ROLL_CALL in Task 16).
+    await page.getByTestId('admin-add-signup-btn').click();
+    await waitForAddUserModal(page);
+
+    // Search for a seeded user, click their add button, and capture the admin-signup POST.
+    const targetUsername = 'event_player_1';
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/events/${eventInfo.pk}/admin-signup/`) &&
+          r.request().method() === 'POST',
+      ),
+      searchAndAddUser(page, targetUsername),
+    ]);
+    expect(response.status()).toBe(201);
+
+    // Close the modal so the underlying signup list is unobscured, then assert
+    // the newly added user (rendered by nickname in UserEventStrip) appears.
+    await closeAddUserModal(page);
+    await expect(page.getByText('EventPlayer1').first()).toBeVisible();
   });
 });

--- a/frontend/tests/playwright/e2e/16-events/09-event-staff-permissions.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/09-event-staff-permissions.spec.ts
@@ -1,0 +1,56 @@
+import {
+  expect,
+  getEventsTestData,
+  loginEventLeagueStaff,
+  postWithCsrf,
+  resetEventsData,
+  test,
+} from '../../fixtures';
+
+const DOCKER_HOST = process.env.DOCKER_HOST || 'localhost';
+const API_URL = `https://${DOCKER_HOST}/api`;
+
+test.describe('Event staff permissions — league staff @cicd', () => {
+  test.beforeEach(async ({ context }) => {
+    await resetEventsData(context);
+  });
+
+  test('league staff sees admin actions on Events Test League event', async ({ page, context }) => {
+    const eventInfo = await getEventsTestData(context);
+    await loginEventLeagueStaff(context);
+
+    await page.goto(`/events/${eventInfo.pk}`);
+
+    // Desktop admin row visible (state SIGNUPS_OPEN by default after resetEventsData)
+    await expect(page.getByTestId('event-edit-btn')).toBeVisible();
+    await expect(page.getByTestId('event-start-rollcall-btn')).toBeVisible();
+
+    // Admin-add button on the Signups tab
+    await page.getByRole('tab', { name: /signups/i }).click();
+    await expect(page.getByTestId('admin-add-signup-btn')).toBeVisible();
+  });
+
+  test('league staff can reopen signups from roll_call', async ({ page, context }) => {
+    const eventInfo = await getEventsTestData(context);
+    await loginEventLeagueStaff(context);
+
+    // Force the event into ROLL_CALL via the CSRF-aware helper.
+    await postWithCsrf(context, `${API_URL}/events/${eventInfo.pk}/start_roll_call/`);
+
+    await page.goto(`/events/${eventInfo.pk}`);
+    await expect(page.getByTestId('event-state-badge')).toHaveText(/Roll Call/i);
+
+    await page.getByTestId('event-reopen-signups-btn').click();
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/events/${eventInfo.pk}/reopen_signups/`) &&
+          r.request().method() === 'POST',
+      ),
+      page.getByRole('button', { name: /^Reopen Signups$/ }).last().click(),
+    ]);
+    expect(response.status()).toBe(200);
+    await expect(page.getByTestId('event-state-badge')).toHaveText(/Signups Open/i);
+  });
+});

--- a/frontend/tests/playwright/fixtures/auth.ts
+++ b/frontend/tests/playwright/fixtures/auth.ts
@@ -400,6 +400,36 @@ export async function loginLeagueStaff(context: BrowserContext): Promise<void> {
 }
 
 /**
+ * Login as event-league-staff (staff of league 7 ONLY, not org 7).
+ * Use to assert league-staff access on events tied to the Events Test League.
+ */
+export async function loginEventLeagueStaff(context: BrowserContext): Promise<void> {
+  const url = `${API_URL}/tests/login-event-league-staff/`;
+  console.log(`[auth] loginEventLeagueStaff: POST ${url}`);
+
+  const response = await context.request.post(url);
+
+  if (!response.ok()) {
+    const status = response.status();
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      body = '[could not read body]';
+    }
+    console.error(`[auth] loginEventLeagueStaff FAILED: ${status} - ${body}`);
+    throw new Error(`loginEventLeagueStaff failed: ${status} - ${body.slice(0, 500)}`);
+  }
+
+  console.log(`[auth] loginEventLeagueStaff: OK (${response.status()})`);
+
+  const cookies = response.headers()['set-cookie'];
+  if (cookies) {
+    await setSessionCookies(context, cookies);
+  }
+}
+
+/**
  * Parse and set session cookies from response headers.
  */
 async function setSessionCookies(

--- a/frontend/tests/playwright/fixtures/index.ts
+++ b/frontend/tests/playwright/fixtures/index.ts
@@ -20,6 +20,7 @@ export {
   loginOrgStaff,
   loginLeagueAdmin,
   loginLeagueStaff,
+  loginEventLeagueStaff,
   waitForHydration,
   visitAndWait,
   type UserInfo,


### PR DESCRIPTION
## Summary

Allow event staff (org **or** league) to add users during the `ROLL_CALL` stage, and to revert `ROLL_CALL → SIGNUPS_OPEN` quietly. Public RSVP behavior is unchanged — users still cannot self-signup during roll call.

### Backend

- **State machine:** new `ROLL_CALL → SIGNUPS_OPEN` reverse edge.
- **Service layer:** extracted `_create_signup` private helper from `process_rsvp`; new `staff_add_signup` wrapper accepts `SIGNUPS_OPEN` *or* `ROLL_CALL`. Cache-invalidate-before-notify ordering documented as an invariant.
- **Permissions:** new `has_event_staff_access(user, event)` helper (org staff OR league staff for the event's `tournament_league`). Applied across 14 sites in `EventViewSet` and `EventSignupViewSet` actions.
- **New action:** `reopen_signups` — `transaction.atomic` + explicit `invalidate_after_commit`, no Discord re-announcement, preserves existing confirmations.
- **`admin_signup` view** swapped to call `staff_add_signup` (now works during roll call).
- **`user_can_manage` field** on `EventSerializer`, computed cache-safely via a view-layer post-process helper (`_attach_user_can_manage`) so per-event cache stays user-agnostic. Three-round-trip cache-leak regression test included. `select_related` on the helper to avoid N+1 FK lookups.
- **Race test** for concurrent `staff_add_signup` using `TransactionTestCase` + `threading.Barrier(2)`.
- **Test populate:** new `event_league_staff_tester` user (staff of league 7 only, never of org 7), `EventLeagueStaffIsolationTest` populate guard, and `loginEventLeagueStaff` Playwright fixture.

### Frontend

- New `reopenSignups` API client + mutation hook (`setQueryData(['event', id])` + `invalidateQueries(['events'])`).
- `EventType.state` tightened from `z.string()` to `z.nativeEnum(EventState)`; new `user_can_manage: z.boolean().default(false)`.
- Swapped client-side `useIsOrganizationStaff` to backend-derived `event.user_can_manage` so league staff actually see the staff UI.
- Extracted `EventAdminActions` component owning the desktop button row + mobile dropdown. Brand-guide-aligned: `WarningButton(depth={false})` for Reopen Signups so `PrimaryButton "Open Roll Call"` keeps visual primacy; on-brand `ConfirmDialog(variant="destructive")` replacing `window.confirm` for delete; canonical `data-testid`s on the desktop branch only.
- Reopen `ConfirmDialog(variant="warning", isLoading=...)` in the parent route. Shared `extractApiError` helper hoisted to `~/lib/apiError`.
- `event-state-badge` testid on `EventStateBadge` (with prop forwarding).
- `SignupsTab` admin-add gate widened to include `ROLL_CALL`.

### Playwright tests

- `03-roll-call.spec.ts`: reopen happy-path + boundary tests (verifies `announcement.id` unchanged via `verifyDiscordMessages`).
- `05-signup-management.spec.ts`: sibling test for staff admin-add during roll-call (using `searchAndAddUser` helper).
- New `09-event-staff-permissions.spec.ts` — league-staff coverage end-to-end.

### Pre-existing bugs fixed along the way

While verifying tests, found and fixed several **real production bugs** that pre-dated this branch:

- **`app/internal_client.py`**: duplicate `get_event_signups` (second def shadowed first, returned raw `Response` → `'bytes' object has no attribute 'status'`); duplicate `search_message_logs` (positional caller in `events/tasks.py:395` would crash with the live kwargs-only definition); URL on first `get_event_signups` was 404. All cleaned up.
- **`app/views/csv_import.py`**: looked up users by 32-bit `steam_account_id` but CSV provides 64-bit `steamid`. New users now get `user.steamid = steam_id`.
- **`config/settings_celery.py`**: missing `TEST`, `RELEASE`, `TEST_DISCORD_USER_ID`, `DISCORD_BOT_TOKEN` — every Celery DM dispatch was crashing on `_get_headers` AttributeError. Test harness exposed this; the same crash was happening in production.
- Stale Discord tests rewritten to mock the post-internal-API-migration code path (`_rate_limited_request`, `sync_send_dm`, internal HTTP API calls patched via a `DiscordTestMixin` reading directly from the ORM).
- Various test contract drift fixes: tournament `date_played` non-null in setUp, `subscriber_dm` task folded into `signup_reminder`, organization create widened from superuser-only to authenticated, league admins now count as league staff, `friend_id` → `unverified_friend_id` field rename, `league/tests/__init__.py` stub.

## Test plan

- [x] Backend: `events.tests app.tests league.tests org.tests` → **509 pass, 0 fail, 7 skipped** (Discord-token-gated)
- [x] Playwright `16-events`: **43/43 pass** (incl. roll-call reopen + boundary, staff admin-add during roll-call, league-staff permission spec)
- [x] Frontend typecheck: pre-existing baseline (175 errors, all in `tests/playwright/*` and `vite.config.ts` — unchanged)
- [x] Race test for concurrent `staff_add_signup` (`TransactionTestCase` + `threading.Barrier`) confirmed non-flaky over 3 consecutive runs
- [x] Cache-leak regression test (3-round-trip: staff → unrelated → staff) confirmed non-flaky
- [ ] Manual UI walkthrough: start roll call → reopen → admin-add user during roll call → verify no Discord re-announcement
- [ ] Smoke as event-only league staff (`/api/tests/login-event-league-staff/`) → confirm admin actions visible on league-7 events