### PR TITLE
feat(events): series row-level fixes + frontend cleanup (PR-2)

### DIFF
--- a/backend/events/serializers.py
+++ b/backend/events/serializers.py
@@ -325,6 +325,27 @@ class EventSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {"game_mode": f"{game_mode} is only available for Dota 2."}
             )
+
+        # Single events have no subscriber list — discord_signup_reminder DMs
+        # subscribed users, which is a series-level concept on EventRepeater.
+        # Reject signup_reminder=True on events without a repeater.
+        repeater = data.get(
+            "event_repeater",
+            self.instance.event_repeater if self.instance else None,
+        )
+        signup_reminder = data.get(
+            "discord_signup_reminder",
+            self.instance.discord_signup_reminder if self.instance else False,
+        )
+        if repeater is None and signup_reminder:
+            raise serializers.ValidationError(
+                {
+                    "discord_signup_reminder": (
+                        "Signup reminder DMs require a recurring event series — "
+                        "single events have no subscribers."
+                    )
+                }
+            )
         return data
 
 

--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -660,26 +660,48 @@ def generate_events_for_repeater(repeater):
 
 
 @transaction.atomic
-def sync_future_events(repeater):
+def sync_future_events(repeater, *, realign_schedule=False):
     """Propagate repeater changes to all upcoming events in the series.
 
     Only updates events that haven't progressed past 'upcoming' state
     (i.e. signups haven't opened yet), so in-progress events are untouched.
 
-    Returns the list of touched Event instances so callers can chain a
-    single invalidate_after_commit at the end of the request — necessary
-    because cacheops post_save signals defer invalidation until commit
-    inside @transaction.atomic, but the explicit batched call ensures
-    the children are invalidated even if signal handlers race.
+    If realign_schedule=True (caller detected a day_of_week / time_of_day /
+    timezone / starts_at / frequency change), UPCOMING rows whose
+    scheduled_at is no longer in the repeater's new occurrence set are
+    DELETED, and any new occurrences not already present are INSERTED via
+    generate_events_for_repeater. This eliminates the duplicate-occurrence
+    problem where the next hourly generation produced new rows at the
+    new schedule alongside the stale ones.
 
-    The cascade iterates DISCORD_CONFIG_FIELDS, which is auto-built from
-    DiscordEventConfigMixin._meta.get_fields() (services.py:536-538), so
-    every reminder field defined on the mixin is automatically copied.
-    The CI guardrail RegistryMixinCoverageTest enforces that registry
-    fields stay on the mixin — so this function never silently misses a
-    registered reminder.
+    Returns the list of touched Event instances so callers can chain a
+    single invalidate_after_commit at the end of the request.
+
+    The field cascade iterates DISCORD_CONFIG_FIELDS, which is auto-built
+    from DiscordEventConfigMixin._meta.get_fields(), so every reminder
+    field defined on the mixin is automatically copied. The CI guardrail
+    RegistryMixinCoverageTest enforces that registry fields stay on the
+    mixin.
     """
     from app.cache_utils import invalidate_after_commit
+
+    if realign_schedule:
+        # Compute the new occurrence set using the same helper that
+        # generate_events_for_repeater uses — guarantees timestamp equality
+        # between regenerated and pre-existing rows.
+        today = _today()
+        to_date = today + timedelta(days=repeater.generate_days_ahead)
+        new_occurrences = set(_get_next_occurrences(repeater, today, to_date))
+
+        # Delete UPCOMING rows that don't match the new occurrence set
+        Event.objects.filter(
+            event_repeater=repeater,
+            state=EventState.UPCOMING,
+        ).exclude(scheduled_at__in=new_occurrences).delete()
+
+        # Generate any missing occurrences. The existing helper handles
+        # the "row already exists" check via its pre-insert filter.
+        generate_events_for_repeater(repeater)
 
     future_events = list(
         Event.objects.filter(

--- a/backend/events/tests/test_event_validation_single.py
+++ b/backend/events/tests/test_event_validation_single.py
@@ -1,0 +1,62 @@
+"""EventSerializer rejects discord_signup_reminder=True on single events.
+
+Single events have no subscriber list (subscriptions are a series-level
+concept on EventRepeater), so the signup_reminder DM fields have no
+honest meaning for them. Backend rejection is the source of truth — the
+frontend conditional render in Task 2.3 is UX, but a client that bypasses
+it should still get a 400.
+"""
+
+from django.test import TestCase
+
+from events.serializers import EventSerializer
+from events.tests.test_discord_tasks import _DiscordTaskTestCase
+
+
+class EventSingleEventSignupReminderRejectionTest(_DiscordTaskTestCase):
+    def test_signup_reminder_rejected_when_event_repeater_is_none(self):
+        # Use the existing self.event (no event_repeater) and try to enable
+        # discord_signup_reminder via a partial update
+        serializer = EventSerializer(
+            self.event,
+            data={"discord_signup_reminder": True},
+            partial=True,
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("discord_signup_reminder", serializer.errors)
+
+    def test_signup_reminder_accepted_when_event_repeater_set(self):
+        from datetime import time, timedelta
+        from django.utils import timezone
+
+        from events.models import EventRepeater
+
+        repeater = EventRepeater.objects.create(
+            organization=self.event.organization,
+            name="Test Repeater",
+            frequency="weekly",
+            day_of_week=1,
+            time_of_day=time(20, 0),
+            timezone="UTC",
+            starts_at=timezone.now().date() - timedelta(days=1),
+        )
+        # Re-attach the event to the repeater so the validator sees it
+        self.event.event_repeater = repeater
+        self.event.save()
+
+        serializer = EventSerializer(
+            self.event,
+            data={"discord_signup_reminder": True},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_signup_reminder_false_accepted_on_single_events(self):
+        # Setting it explicitly False on a single event is fine — there's
+        # nothing to reject.
+        serializer = EventSerializer(
+            self.event,
+            data={"discord_signup_reminder": False},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)

--- a/backend/events/tests/test_sync_future_events_realign.py
+++ b/backend/events/tests/test_sync_future_events_realign.py
@@ -1,0 +1,111 @@
+"""sync_future_events realigns occurrences when the repeater's schedule changes.
+
+Pre-PR-2 behavior: editing a repeater's day_of_week left existing UPCOMING
+events on their old days, while the next hourly generate_events_for_repeater
+created NEW events at the new schedule — admins saw duplicate occurrences.
+
+PR-2 fix: when the caller signals realign_schedule=True, delete UPCOMING
+rows whose scheduled_at is no longer in the new occurrence set, then
+generate_events_for_repeater fills in any missing ones.
+"""
+
+from datetime import datetime, time, timedelta, timezone as dt_tz
+from unittest.mock import patch
+
+from events.models import Event, EventRepeater
+from events.services import sync_future_events
+from events.tests.test_discord_tasks import _DiscordTaskTestCase
+
+
+class SyncFutureEventsRealignTest(_DiscordTaskTestCase):
+    def _make_repeater(self, day_of_week=1, time_of_day=time(20, 0)):
+        # starts_at must be today or earlier — generate_events_for_repeater
+        # uses _today() as its from_date and won't generate events before that
+        from django.utils import timezone
+
+        return EventRepeater.objects.create(
+            organization=self.event.organization,
+            name="Realign Test Repeater",
+            frequency="weekly",
+            day_of_week=day_of_week,
+            time_of_day=time_of_day,
+            timezone="UTC",
+            starts_at=timezone.now().date() - timedelta(days=1),
+            generate_days_ahead=14,
+            is_active=True,
+        )
+
+    def test_realign_false_preserves_existing_scheduled_at(self):
+        repeater = self._make_repeater()
+        original_at = datetime(2099, 1, 5, 20, 0, tzinfo=dt_tz.utc)
+        ev = Event.objects.create(
+            organization=self.event.organization,
+            event_repeater=repeater,
+            name="Future",
+            scheduled_at=original_at,
+            state="upcoming",
+            discord_announcement_channel_id="ch_1",
+        )
+        sync_future_events(repeater, realign_schedule=False)
+        ev.refresh_from_db()
+        self.assertEqual(ev.scheduled_at, original_at)
+
+    def test_realign_true_deletes_stale_occurrence_outside_new_set(self):
+        # day_of_week=1 (Monday in Sunday=0 convention)
+        repeater = self._make_repeater(day_of_week=1)
+        # Stale row at a date that won't match the new occurrence set
+        # (a fixed historical date the generator won't produce)
+        stale_at = datetime(2099, 1, 5, 20, 0, tzinfo=dt_tz.utc)
+        stale_event = Event.objects.create(
+            organization=self.event.organization,
+            event_repeater=repeater,
+            name="Stale",
+            scheduled_at=stale_at,
+            state="upcoming",
+            discord_announcement_channel_id="ch_1",
+        )
+        # Repeater is now-aligned; realign=True should delete the stale row
+        # and regenerate the correct occurrences.
+        sync_future_events(repeater, realign_schedule=True)
+        self.assertFalse(Event.objects.filter(pk=stale_event.pk).exists())
+
+    def test_realign_true_keeps_rows_already_in_new_set(self):
+        # Use today's _today() helper so we know what generate_events_for_repeater
+        # will produce. Pick day_of_week to match next-week's weekday so
+        # generate_events_for_repeater will produce a row 7 days from today.
+        from events.services import _get_next_occurrences, _today
+
+        repeater = self._make_repeater(day_of_week=1)
+        today = _today()
+        to_date = today + timedelta(days=repeater.generate_days_ahead)
+        new_occurrences = list(_get_next_occurrences(repeater, today, to_date))
+        if not new_occurrences:
+            self.skipTest("No occurrences in the test window — adjust generate_days_ahead")
+
+        # Pre-create a row at the FIRST occurrence — realign should keep it
+        kept_event = Event.objects.create(
+            organization=self.event.organization,
+            event_repeater=repeater,
+            name="Already aligned",
+            scheduled_at=new_occurrences[0],
+            state="upcoming",
+            discord_announcement_channel_id="ch_1",
+        )
+        sync_future_events(repeater, realign_schedule=True)
+        # The kept row should still be there
+        self.assertTrue(Event.objects.filter(pk=kept_event.pk).exists())
+
+    def test_realign_false_default_no_regeneration(self):
+        # If sync_future_events is called without realign_schedule (default False),
+        # generate_events_for_repeater should NOT be invoked — rows stay as-is.
+        repeater = self._make_repeater()
+        with patch("events.services.generate_events_for_repeater") as mock_gen:
+            sync_future_events(repeater)
+            mock_gen.assert_not_called()
+
+    def test_realign_true_calls_generate_events_for_repeater(self):
+        repeater = self._make_repeater()
+        with patch("events.services.generate_events_for_repeater") as mock_gen:
+            mock_gen.return_value = []
+            sync_future_events(repeater, realign_schedule=True)
+            mock_gen.assert_called_once_with(repeater)

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -190,8 +190,26 @@ class EventRepeaterViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         from app.cache_utils import invalidate_after_commit
 
+        # Snapshot schedule fields before save so we can detect a change
+        # and tell sync_future_events to realign occurrences. Without this,
+        # editing day_of_week leaves stale UPCOMING rows on the old day
+        # while generate_events_for_repeater creates new rows on the new
+        # day — admins see duplicates.
+        schedule_fields = (
+            "day_of_week",
+            "time_of_day",
+            "timezone",
+            "starts_at",
+            "frequency",
+        )
+        before = {f: getattr(serializer.instance, f) for f in schedule_fields}
         repeater = serializer.save()
-        future_events = sync_future_events(repeater)
+        schedule_changed = any(
+            before[f] != getattr(repeater, f) for f in schedule_fields
+        )
+        future_events = sync_future_events(
+            repeater, realign_schedule=schedule_changed
+        )
         # Single batched invalidation — repeater + every cascaded child
         invalidate_after_commit(repeater, *future_events)
 

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -170,9 +170,15 @@ export function CreateEventModal({
           signupsOpenAt = eventDate.toISOString();
         }
 
+        // Single events have no subscriber list — force signup_reminder
+        // off regardless of org defaults so the backend validator (which
+        // rejects discord_signup_reminder=true on single events) doesn't
+        // 400 a submission whose default carried over from a repeater-
+        // oriented org config.
         await createEvent({
           ...shared,
           scheduled_at,
+          discord_signup_reminder: false,
           ...(signupsOpenAt ? { signups_open_at: signupsOpenAt } : {}),
         }, signup_mode === 'immediate');
 

--- a/frontend/app/components/events/DiscordConfigSection.tsx
+++ b/frontend/app/components/events/DiscordConfigSection.tsx
@@ -185,16 +185,18 @@ export function DiscordConfigSection({ control, watch, isRepeater, organizationI
         )}
       </div>
 
-      {/* Signup reminder */}
-      <div className="rounded-md border border-border p-3 space-y-3">
-        <CheckboxField control={control} name="discord_signup_reminder"
-          label="Send signup reminder"
-          description="DM users who haven't signed up yet before the event starts"
-        />
-        {signupReminder && (
-          <HoursSelect control={control} name="discord_signup_reminder_hours" label="Hours before event" />
-        )}
-      </div>
+      {/* Signup reminder — repeater-only (single events have no subscriber list) */}
+      {isRepeater && (
+        <div className="rounded-md border border-border p-3 space-y-3">
+          <CheckboxField control={control} name="discord_signup_reminder"
+            label="Send signup reminder"
+            description="DM users who haven't signed up yet before the event starts"
+          />
+          {signupReminder && (
+            <HoursSelect control={control} name="discord_signup_reminder_hours" label="Hours before event" />
+          )}
+        </div>
+      )}
 
       {/* Profile reminder */}
       <div className="rounded-md border border-border p-3 space-y-3">

--- a/frontend/app/components/events/EditEventModal.tsx
+++ b/frontend/app/components/events/EditEventModal.tsx
@@ -124,8 +124,15 @@ export function EditEventModal({ event, open, onOpenChange }: EditEventModalProp
         discord_event_title: event.discord_event_title,
         discord_event_description: event.discord_event_description,
         discord_event_info: event.discord_event_info,
-        discord_signup_reminder: event.discord_signup_reminder,
-        discord_signup_reminder_hours: event.discord_signup_reminder_hours,
+        // Single events have no subscriber list — force signup_reminder off
+        // for them so the superRefine in eventSchema doesn't reject.
+        // Repeater-occurrence events keep the persisted value.
+        discord_signup_reminder:
+          event.event_repeater != null ? event.discord_signup_reminder : false,
+        discord_signup_reminder_hours:
+          event.event_repeater != null
+            ? event.discord_signup_reminder_hours
+            : 24,
         discord_confirm_attendance: event.discord_confirm_attendance,
         discord_confirm_attendance_hours: event.discord_confirm_attendance_hours,
         discord_profile_reminder: event.discord_profile_reminder,

--- a/frontend/app/components/events/EditEventModal.tsx
+++ b/frontend/app/components/events/EditEventModal.tsx
@@ -476,7 +476,7 @@ export function EditEventModal({ event, open, onOpenChange }: EditEventModalProp
             <DiscordConfigSection
               control={form.control}
               watch={form.watch}
-              isRepeater={false}
+              isRepeater={event?.event_repeater != null}
               organizationId={event?.organization ?? 0}
             />
           </TabsContent>

--- a/frontend/app/components/events/__tests__/schemas-signup-reminder.test.ts
+++ b/frontend/app/components/events/__tests__/schemas-signup-reminder.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { eventSchema } from '~/components/events/schemas'
+
+const baseEvent = (overrides = {}) => ({
+  id: 1,
+  organization: 1,
+  organization_name: 'Org',
+  name: 'Test Event',
+  description: '',
+  scheduled_at: '2026-12-01T20:00:00Z',
+  signups_open_at: '2026-11-25T20:00:00Z',
+  tournament: 1,
+  created_by: 1,
+  created_at: '2026-11-01T00:00:00Z',
+  updated_at: '2026-11-01T00:00:00Z',
+  state: 'upcoming',
+  game_type: 1,
+  game_mode: 'normal',
+  custom_game_name: '',
+  captains_draft_time: 60,
+  lobby_steam_league_id: 0,
+  tournament_date: '2026-12-01T20:00:00Z',
+  timezone: 'America/New_York',
+  tournament_league: 1,
+  tournament_name: '',
+  tournament_type: 'single_elimination',
+  draft_type: 'snake',
+  people_per_team: 5,
+  number_of_teams: null,
+  min_players: 10,
+  max_players: 20,
+  signup_deadline_hours: 24,
+  allow_team_signups: true,
+  allow_user_signups: true,
+  auto_approve: false,
+  auto_confirm: false,
+  require_mmr_verified: false,
+  require_steam_id: false,
+  require_profile_complete: false,
+  roll_call_enabled: false,
+  roll_call_mode: 'manual',
+  allow_active_mmr: true,
+  allow_previous_rank: true,
+  allow_battlecup_rating: true,
+  signup_count: 0,
+  confirmed_count: 0,
+  event_repeater: null,
+  event_repeater_name: null,
+  discord_create_event: false,
+  discord_sync_signups: false,
+  discord_event_title: '',
+  discord_event_description: '',
+  discord_event_info: '',
+  discord_mark_interested: false,
+  discord_post_signups: false,
+  discord_post_signups_channel_id: '',
+  discord_announcement: false,
+  discord_announcement_channel_id: '',
+  discord_announcement_hours: 24,
+  discord_signup_reminder: false,
+  discord_signup_reminder_hours: 24,
+  discord_confirm_attendance: false,
+  discord_confirm_attendance_hours: 2,
+  discord_profile_reminder: false,
+  discord_profile_reminder_hours: 24,
+  discord_notify_new_events: false,
+  discord_require_rank_screenshot: false,
+  discord_require_battlecup_screenshot: false,
+  min_mmr: null,
+  user_can_manage: false,
+  ...overrides,
+})
+
+describe('eventSchema — single-event signup_reminder rejection', () => {
+  it('rejects discord_signup_reminder=true when event_repeater is null', () => {
+    const bad = baseEvent({
+      event_repeater: null,
+      discord_signup_reminder: true,
+    })
+    expect(() => eventSchema.parse(bad)).toThrow(/signup reminder.*subscribers/i)
+  })
+
+  it('accepts discord_signup_reminder=false on single events', () => {
+    const ok = baseEvent({
+      event_repeater: null,
+      discord_signup_reminder: false,
+    })
+    expect(() => eventSchema.parse(ok)).not.toThrow()
+  })
+
+  it('accepts discord_signup_reminder=true when event_repeater is set', () => {
+    const ok = baseEvent({
+      event_repeater: 42,
+      event_repeater_name: 'Weekly Series',
+      discord_signup_reminder: true,
+    })
+    expect(() => eventSchema.parse(ok)).not.toThrow()
+  })
+})

--- a/frontend/app/components/events/schemas.ts
+++ b/frontend/app/components/events/schemas.ts
@@ -88,6 +88,18 @@ export const eventSchema = z.object({
   min_mmr: z.number().nullable(),
   user_can_manage: z.boolean().default(false),
   _warning: z.string().optional(),
+}).superRefine((val, ctx) => {
+  // Single events have no subscriber list — discord_signup_reminder DMs
+  // subscribed users, which is a series-level concept on EventRepeater.
+  // Mirrors the backend EventSerializer.validate rejection (Task 2.2).
+  if (val.event_repeater === null && val.discord_signup_reminder === true) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['discord_signup_reminder'],
+      message:
+        'Signup reminder DMs require a recurring event series — single events have no subscribers.',
+    });
+  }
 });
 
 export type EventType = z.infer<typeof eventSchema>;

--- a/frontend/app/hooks/useEvent.ts
+++ b/frontend/app/hooks/useEvent.ts
@@ -189,6 +189,11 @@ export function useUpdateEventMutation(eventId: number) {
     onSuccess: (data) => {
       queryClient.setQueryData(['event', eventId], data);
       queryClient.invalidateQueries({ queryKey: ['events'] });
+      // The Activity Log + Task Schedule panels poll on their own
+      // cadences; invalidate them here so reminder-timing edits surface
+      // immediately instead of after the next 15s poll.
+      queryClient.invalidateQueries({ queryKey: ['event-discord', eventId] });
+      queryClient.invalidateQueries({ queryKey: ['event-task-schedule', eventId] });
     },
   });
 }

--- a/frontend/tests/playwright/e2e/16-events/07-notification-dm.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/07-notification-dm.spec.ts
@@ -66,8 +66,11 @@ test.describe('Event Notification DM (@cicd)', () => {
       discord_announcement_channel_id: '1482767177063858216',
       discord_post_signups: true,
       discord_post_signups_channel_id: '1482767709279096893',
-      discord_subscriber_dm: true,
-      discord_subscriber_dm_hours: 24,
+      // discord_signup_reminder is the actual subscriber-DM toggle on
+      // EventRepeater. Each subscriber gets a DM signup_reminder_hours
+      // before scheduled_at (default 24).
+      discord_signup_reminder: true,
+      discord_signup_reminder_hours: 24,
     });
     expect(repeaterResp.ok()).toBeTruthy();
 


### PR DESCRIPTION
## Summary

PR-2 of 3 in the event-reminder-scheduling work (PR-0 + PR-1 already shipped). Backend row-level fixes for series schedule edits + frontend cleanup so single events can't accidentally enable signup-reminder DMs.

## Why

After PR-1, the registry handles reminder fires correctly — but two bugs remained on the row-level / UI side:

1. **Editing a series's day-of-week left duplicate occurrences.** `sync_future_events` cascaded fields onto upcoming events but didn't recompute `scheduled_at`. The next hourly `generate_events_for_repeater` then created NEW rows on the new day alongside the stale ones on the old day. Admins saw "10 events" when they should have seen 5.
2. **Single events could be configured with `discord_signup_reminder=true`** even though there's no subscriber list — single events have no repeater. The field was a UX trap with no honest meaning.

## Changes

### Backend

- **`sync_future_events` realigns occurrences when schedule fields change** (`backend/events/services.py`)
  - New keyword param `realign_schedule`. When True, deletes UPCOMING rows whose `scheduled_at` is no longer in the repeater's new occurrence set, then calls `generate_events_for_repeater` to fill gaps. Uses the same `_get_next_occurrences` helper the generator uses, so timestamps line up perfectly.
  - `EventRepeaterViewSet.perform_update` snapshots `(day_of_week, time_of_day, timezone, starts_at, frequency)` before save and passes `realign_schedule=True` if any changed.
- **EventSerializer rejects `discord_signup_reminder=true` on single events** (`backend/events/serializers.py`)
  - 400 response with a clear message — backend is the source of truth even if a client bypasses the UI conditional.

### Frontend

- **`DiscordConfigSection` hides signup-reminder fields on single events** — gated on the existing `isRepeater` prop.
- **Fixed `EditEventModal`'s hardcoded `isRepeater={false}`** → `event?.event_repeater != null`. Without this fix, the signup-reminder UI would have stayed hidden even for repeater-occurrence edits.
- **Zod `superRefine` cross-field rule on `eventSchema`** rejects single events with `discord_signup_reminder=true` at parse time. Mirrors the backend rejection.
- **`EditEventModal.reset()` forces `discord_signup_reminder=false` on single-event reads** so the form state doesn't carry a stuck-true value into a hidden field.
- **`useUpdateEventMutation` invalidates `event-discord` and `event-task-schedule` queries** on success — without this, the Activity Log + Task Schedule UI panels stayed up-to-15s stale on their own poll cadences after reminder-timing edits.
- **Playwright spec retargeted** — `07-notification-dm.spec.ts` referenced the dropped `discord_subscriber_dm{,_hours}` fields; now uses `discord_signup_reminder` (the actual subscriber-DM toggle).

## Test plan

- [x] Backend: 26 tests green across `test_sync_future_events_realign`, `test_sync_future_events_cascade`, `test_event_validation_single`, `test_scheduling_registry`, `test_idempotency`, `test_serializers`
- [x] Frontend unit (vitest): 5 tests green in `app/components/events/__tests__/`
- [x] `tsc --noEmit` baseline parity (189 pre/post — zero new errors)
- [ ] **Manual on staging:** edit a recurring series's `day_of_week`, verify upcoming occurrences move to the new day and there are NO duplicate rows
- [ ] **Manual on staging:** create/edit a single event, verify the signup-reminder UI is hidden
- [ ] **Manual on staging:** attempt to PATCH a single event with `discord_signup_reminder=true` via API — expect 400
- [ ] **Playwright:** `just test::pw::spec 16-events` — full event suite

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-30-event-reminder-scheduling-registry-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-event-reminder-scheduling-registry.md` — 7 commits map to plan tasks 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7

## Depends on

- PR-1 (already merged) — this PR builds on the registry + lease infrastructure