### PR TITLE
feat(events): searchable LeagueCombobox for event create/edit modals

### DIFF
--- a/docs/superpowers/plans/2026-05-03-event-league-combobox.md
+++ b/docs/superpowers/plans/2026-05-03-event-league-combobox.md
@@ -4,7 +4,9 @@
 
 **Goal:** Replace the plain `<Select>` league field in `CreateEventModal` and `EditEventModal` with a searchable shadcn `LeagueCombobox` (desktop) plus a `<Select>` fallback (mobile), and align the form schema so league is optional in both modals.
 
-**Architecture:** A new domain wrapper component `LeagueCombobox` lives at `frontend/app/components/league/LeagueCombobox.tsx`. It internally calls `useLeagues(organizationId)`, branches on `useMediaQuery('(min-width: 768px)')`, and renders Popover+Command on desktop or Select on mobile. Both event modals consume it via react-hook-form's `<FormField>` render prop. Existing data-testids (`event-league-select`, `event-league-option-{pk}`, `edit-event-tournament-league`, `league-option-{pk}`) are preserved on the new trigger and item elements so existing Playwright specs keep working.
+**Architecture:** A new domain wrapper component `LeagueCombobox` lives at `frontend/app/components/league/LeagueCombobox.tsx`. It internally calls `useLeagues(organizationId)`, branches on `useMediaQuery('(min-width: 768px)')`, and renders Popover+Command on desktop or Select on mobile. Both event modals consume it via react-hook-form's `<FormField>` render prop. Existing data-testids (`event-league-select`, `event-league-option-{pk}`, `edit-event-tournament-league`, `league-option-{pk}`) are preserved on the new trigger and item elements so existing Playwright specs keep working. Per the project's testing skill ("Always use `data-testid` selectors; never `getByPlaceholder`/`getByRole('option')` for interaction"), the component also exposes `searchTestId` and `clearTestId` props so the new search input and clear-sentinel items are addressable by test-id.
+
+**Form composition:** This component is consumed via the project's existing react-hook-form `FormField` / `FormItem` / `FormControl` / `FormMessage` pattern (verified in `DiscordConfigSection.tsx`). We do **not** migrate to shadcn's newer `FieldGroup` / `Field` primitives — that would be a project-wide refactor outside this PR's scope.
 
 **Tech Stack:** React 19, TypeScript, react-hook-form, Zod, shadcn/ui (Command, Popover, Select), cmdk, Tailwind, Playwright. Vite SPA (no Next.js).
 
@@ -107,7 +109,7 @@ test('league combobox: search filters and selects on create', async ({ page }) =
   await trigger.click();
 
   // Type into the cmdk search input — first 3 chars of the seeded league name
-  await page.getByPlaceholder('Search leagues…').fill('Eve');
+  await page.getByTestId('event-league-search').fill('Eve');
 
   // Pick the seeded events league via its preserved per-item data-testid
   await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
@@ -123,7 +125,7 @@ test('league combobox: search filters and selects on create', async ({ page }) =
 just test::pw::spec 02-create-event -g "search filters and selects"
 ```
 
-Expected: FAIL. Most likely error: `getByPlaceholder('Search leagues')` times out because the current `<SelectTrigger>` does not open a `CommandInput`. Note the failure mode in the test output — that's our red baseline.
+Expected: FAIL. Most likely error: `getByTestId('event-league-search')` times out because the current `<SelectTrigger>` does not open a `CommandInput` and the `event-league-search` test-id doesn't exist yet. Note the failure mode in the test output — that's our red baseline.
 
 - [ ] **Step 3: Commit the failing test**
 
@@ -180,6 +182,10 @@ export interface LeagueComboboxProps {
   triggerTestId?: string;
   /** prefix for per-item data-testids: `${itemTestIdPrefix}${leagueId}` */
   itemTestIdPrefix?: string;
+  /** data-testid for the search input (desktop only) */
+  searchTestId?: string;
+  /** data-testid for the Clear-selection item (desktop) and No-league sentinel (mobile) */
+  clearTestId?: string;
 }
 
 export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
@@ -193,6 +199,8 @@ export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
   invalid,
   triggerTestId,
   itemTestIdPrefix,
+  searchTestId,
+  clearTestId,
 }) => {
   const [open, setOpen] = React.useState(false);
   const { leagues, isLoading } = useLeagues(organizationId);
@@ -212,17 +220,24 @@ export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
           aria-invalid={invalid || undefined}
           disabled={triggerDisabled}
           data-testid={triggerTestId}
-          className={cn('w-full justify-between', className)}
+          className={cn(
+            'w-full justify-between aria-invalid:border-destructive',
+            className,
+          )}
         >
           <span className="truncate">
             {selected ? selected.name : placeholder}
           </span>
-          <ChevronsUpDown className="opacity-50" />
+          <ChevronsUpDown data-icon="inline-end" className="opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
         <Command>
-          <CommandInput placeholder="Search leagues…" className="h-9" />
+          <CommandInput
+            placeholder="Search leagues…"
+            className="h-9"
+            data-testid={searchTestId}
+          />
           <CommandList>
             <CommandEmpty>
               {isLoading
@@ -260,6 +275,7 @@ export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
               <CommandGroup>
                 <CommandItem
                   value="__clear__"
+                  data-testid={clearTestId}
                   onSelect={() => {
                     onChange(null);
                     setOpen(false);
@@ -306,6 +322,8 @@ Then replace lines 272-298 (the entire `<FormField name="tournament_league" ...>
           invalid={!!fieldState.error}
           triggerTestId="event-league-select"
           itemTestIdPrefix="event-league-option-"
+          searchTestId="event-league-search"
+          clearTestId="event-league-clear"
         />
       </FormControl>
       <FormMessage />
@@ -369,7 +387,7 @@ test('league combobox: clear selection on create submits null', async ({ page })
 
   // Reopen and clear
   await page.getByTestId('event-league-select').click();
-  await page.getByRole('option', { name: /clear selection/i }).click();
+  await page.getByTestId('event-league-clear').click();
 
   // Trigger should show the placeholder again
   await expect(page.getByTestId('event-league-select')).toContainText(/select league/i);
@@ -485,6 +503,8 @@ Replace the entire `<FormField name="tournament_league" ...>` block (starting at
           invalid={!!fieldState.error}
           triggerTestId="edit-event-tournament-league"
           itemTestIdPrefix="league-option-"
+          searchTestId="edit-event-league-search"
+          clearTestId="edit-event-league-clear"
         />
       </FormControl>
       <FormMessage />
@@ -542,7 +562,7 @@ test('edit event tournament_league: clear via combobox', async ({ page, context 
 
   // Open combobox and pick Clear
   await page.getByTestId('edit-event-tournament-league').click();
-  await page.getByRole('option', { name: /clear selection/i }).click();
+  await page.getByTestId('edit-event-league-clear').click();
 
   // Trigger shows the placeholder
   await expect(page.getByTestId('edit-event-tournament-league')).toContainText(/select/i);
@@ -624,12 +644,12 @@ test('league combobox: mobile renders a Select fallback with clear sentinel', as
 
   const trigger = page.getByTestId('event-league-select');
 
-  // Mobile branch uses shadcn Select — there should be no CommandInput.
+  // Mobile branch uses shadcn Select — there should be no cmdk search input.
   await trigger.click();
-  await expect(page.getByPlaceholder('Search leagues…')).toHaveCount(0);
+  await expect(page.getByTestId('event-league-search')).toHaveCount(0);
 
-  // The "— No league —" item should be present and round-trip to null in the form.
-  await page.getByRole('option', { name: /no league/i }).click();
+  // The "— No league —" sentinel should round-trip to null in the form.
+  await page.getByTestId('event-league-clear').click();
   await expect(trigger).toContainText(/select league/i);
 
   // Picking a real league still works
@@ -645,7 +665,7 @@ test('league combobox: mobile renders a Select fallback with clear sentinel', as
 just test::pw::spec 02-create-event -g "mobile renders a Select fallback"
 ```
 
-Expected: FAIL. The desktop branch will render a `CommandInput` even at small viewport widths because we haven't added the mobile branch yet.
+Expected: FAIL. The assertion `toHaveCount(0)` on `event-league-search` will fail because the desktop branch (with the `CommandInput`) renders even at small viewport widths until the mobile branch is added. Or the test fails on the next step because `event-league-clear` doesn't exist as a Select item. Either failure mode is the red baseline.
 
 - [ ] **Step 3: Commit the failing test**
 
@@ -720,7 +740,9 @@ if (!isDesktop) {
         />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="__clear__">— No league —</SelectItem>
+        <SelectItem value="__clear__" data-testid={clearTestId}>
+          — No league —
+        </SelectItem>
         {leagues.map((league) => (
           <SelectItem
             key={league.pk}

--- a/docs/superpowers/plans/2026-05-03-event-league-combobox.md
+++ b/docs/superpowers/plans/2026-05-03-event-league-combobox.md
@@ -1,0 +1,871 @@
+# Event League Combobox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the plain `<Select>` league field in `CreateEventModal` and `EditEventModal` with a searchable shadcn `LeagueCombobox` (desktop) plus a `<Select>` fallback (mobile), and align the form schema so league is optional in both modals.
+
+**Architecture:** A new domain wrapper component `LeagueCombobox` lives at `frontend/app/components/league/LeagueCombobox.tsx`. It internally calls `useLeagues(organizationId)`, branches on `useMediaQuery('(min-width: 768px)')`, and renders Popover+Command on desktop or Select on mobile. Both event modals consume it via react-hook-form's `<FormField>` render prop. Existing data-testids (`event-league-select`, `event-league-option-{pk}`, `edit-event-tournament-league`, `league-option-{pk}`) are preserved on the new trigger and item elements so existing Playwright specs keep working.
+
+**Tech Stack:** React 19, TypeScript, react-hook-form, Zod, shadcn/ui (Command, Popover, Select), cmdk, Tailwind, Playwright. Vite SPA (no Next.js).
+
+**Spec:** `docs/superpowers/specs/2026-05-03-event-league-combobox-design.md`
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `frontend/app/components/league/LeagueCombobox.tsx` | Combobox/Select wrapper around `useLeagues`. Single file, ~180 lines including both viewport branches. |
+| Modify | `frontend/app/components/events/CreateEventModal.tsx` | Replace the Select block at lines 272-298 with `<LeagueCombobox>`. |
+| Modify | `frontend/app/components/events/EditEventModal.tsx` | Drop the Zod `.refine()` at lines 54-59; replace the Select block at lines 286-330 with `<LeagueCombobox>`; remove the now-unused local `useLeagues` call at line 79. |
+| Modify | `frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts` | Add E2E tests for search, clear-on-create, mobile fallback. |
+| Modify | `frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts` | Add E2E test for clear-on-edit. |
+
+---
+
+## Pre-flight: Environment
+
+Before starting tasks, ensure the test environment can run Playwright:
+
+```bash
+cd /home/kettle/git_repos/draftforge/.worktrees/event-league-combobox
+./dev                           # bootstrap venv + deps if not done already
+cp ../../backend/.env ./backend/.env  # copy backend secrets
+just db::migrate::all
+just test::up                   # start test containers
+just test::pw::install          # one-time: install Playwright browsers
+```
+
+Run the existing event spec once to confirm baseline is green:
+
+```bash
+just test::pw::spec 02-create-event
+```
+
+Expected: all tests pass against current `<Select>` implementation. If anything fails, do not proceed — fix the baseline first.
+
+---
+
+## Task 1: Survey existing event spec patterns
+
+**Goal:** Before writing failing tests, read the existing spec file to understand its login/auth fixture, how it opens the Create Event modal, and how it submits. The new tests will mirror this style.
+
+**Files:**
+- Read: `frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts`
+- Read: `frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts`
+- Read: `frontend/tests/playwright/fixtures/` (whatever auth/setup helpers live here)
+
+- [ ] **Step 1: Read the create-event spec end-to-end**
+
+```bash
+cat frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+```
+
+Identify:
+- The fixture used for login (e.g. `test` from `~fixtures/auth` or similar)
+- How `eventInfo` (org id, league pk, alt league pk) is set up
+- The pattern for opening the Create Event modal (route + button click)
+- The pattern for submitting and asserting the API response
+
+- [ ] **Step 2: Read the edit-league spec end-to-end**
+
+```bash
+cat frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts
+```
+
+Identify the analogous patterns for edit flows.
+
+- [ ] **Step 3: Note findings**
+
+No code commit. Carry the patterns forward. In particular, note:
+- The exact import path for fixtures (used in Tasks 2, 4, 8, 10)
+- The `eventInfo` shape (used to know which league pks to select)
+- Whether tests use API helpers to seed events or always go through the UI
+
+---
+
+## Task 2: Failing E2E — search + select via combobox in CreateEventModal
+
+**Goal:** Add a Playwright test that types into a combobox search input and selects a league. It must fail today because the trigger is a plain `<Select>` (no `CommandInput` to type into).
+
+**Files:**
+- Modify: `frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts`
+
+- [ ] **Step 1: Add a new test case inside the existing `test.describe('Events - Create Event (@cicd)', ...)` block**
+
+The existing `test.beforeAll` and `test.beforeEach` (lines 26-35) already provide `eventInfo` and log in as event admin. Add this test alongside the others (e.g. after `'creates a one-off event via modal'`):
+
+```ts
+test('league combobox: search filters and selects on create', async ({ page }) => {
+  await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+  await page.getByTestId('org-tab-events').click();
+  await page.getByTestId('create-event-btn').click();
+
+  // Open the combobox trigger
+  const trigger = page.getByTestId('event-league-select');
+  await trigger.click();
+
+  // Type into the cmdk search input — first 3 chars of the seeded league name
+  await page.getByPlaceholder('Search leagues…').fill('Eve');
+
+  // Pick the seeded events league via its preserved per-item data-testid
+  await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
+
+  // Trigger should now show the selected league name
+  await expect(trigger).toContainText('Events Test League');
+});
+```
+
+- [ ] **Step 2: Run the test and verify it FAILS**
+
+```bash
+just test::pw::spec 02-create-event -g "search filters and selects"
+```
+
+Expected: FAIL. Most likely error: `getByPlaceholder('Search leagues')` times out because the current `<SelectTrigger>` does not open a `CommandInput`. Note the failure mode in the test output — that's our red baseline.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+git commit -m "test(events): failing E2E for league combobox search+select"
+```
+
+---
+
+## Task 3: Implement LeagueCombobox (desktop) + wire into CreateEventModal
+
+**Goal:** Make Task 2's test pass. Build the desktop branch of the combobox and replace the Select block in `CreateEventModal`.
+
+**Files:**
+- Create: `frontend/app/components/league/LeagueCombobox.tsx`
+- Modify: `frontend/app/components/events/CreateEventModal.tsx` (lines 272-298)
+
+- [ ] **Step 1: Create `LeagueCombobox.tsx` (desktop only for now)**
+
+```tsx
+'use client';
+
+import { Check, ChevronsUpDown } from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '~/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '~/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '~/components/ui/popover';
+import { useLeagues } from '~/components/league/hooks/useLeagues';
+import { cn } from '~/lib/utils';
+
+export interface LeagueComboboxProps {
+  organizationId: number | undefined;
+  value: number | null;
+  onChange: (value: number | null) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  id?: string;
+  invalid?: boolean;
+  /** data-testid to apply to the trigger (preserves existing test-ids) */
+  triggerTestId?: string;
+  /** prefix for per-item data-testids: `${itemTestIdPrefix}${leagueId}` */
+  itemTestIdPrefix?: string;
+}
+
+export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
+  organizationId,
+  value,
+  onChange,
+  disabled,
+  placeholder = 'Select league…',
+  className,
+  id,
+  invalid,
+  triggerTestId,
+  itemTestIdPrefix,
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const { leagues, isLoading } = useLeagues(organizationId);
+
+  const selected = value != null ? leagues.find((l) => l.pk === value) : null;
+  const isOrgMissing = organizationId == null;
+  const triggerDisabled = disabled || isOrgMissing;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={invalid || undefined}
+          disabled={triggerDisabled}
+          data-testid={triggerTestId}
+          className={cn('w-full justify-between', className)}
+        >
+          <span className="truncate">
+            {selected ? selected.name : placeholder}
+          </span>
+          <ChevronsUpDown className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search leagues…" className="h-9" />
+          <CommandList>
+            <CommandEmpty>
+              {isLoading
+                ? 'Loading leagues…'
+                : leagues.length === 0
+                  ? 'No leagues in this organization'
+                  : 'No leagues match your search'}
+            </CommandEmpty>
+            {leagues.length > 0 && (
+              <CommandGroup>
+                {leagues.map((league) => (
+                  <CommandItem
+                    key={league.pk}
+                    value={league.name}
+                    data-testid={
+                      itemTestIdPrefix ? `${itemTestIdPrefix}${league.pk}` : undefined
+                    }
+                    onSelect={() => {
+                      onChange(league.pk);
+                      setOpen(false);
+                    }}
+                  >
+                    {league.name}
+                    <Check
+                      className={cn(
+                        'ml-auto',
+                        value === league.pk ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {value !== null && (
+              <CommandGroup>
+                <CommandItem
+                  value="__clear__"
+                  onSelect={() => {
+                    onChange(null);
+                    setOpen(false);
+                  }}
+                >
+                  — Clear selection —
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default LeagueCombobox;
+```
+
+- [ ] **Step 2: Replace the Select block in `CreateEventModal.tsx`**
+
+Edit `frontend/app/components/events/CreateEventModal.tsx`:
+
+Add this import alongside the existing imports near the top of the file (after the other `~/components/league` import or with other component imports):
+
+```tsx
+import { LeagueCombobox } from '~/components/league/LeagueCombobox';
+```
+
+Then replace lines 272-298 (the entire `<FormField name="tournament_league" ...>` block including its `<Select>` children) with:
+
+```tsx
+<FormField
+  control={form.control}
+  name="tournament_league"
+  render={({ field, fieldState }) => (
+    <FormItem>
+      <FormLabel>League</FormLabel>
+      <FormControl>
+        <LeagueCombobox
+          organizationId={organizationId}
+          value={field.value ?? null}
+          onChange={(v) => field.onChange(v ?? undefined)}
+          invalid={!!fieldState.error}
+          triggerTestId="event-league-select"
+          itemTestIdPrefix="event-league-option-"
+        />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+Note: `field.onChange(v ?? undefined)` — the form's existing default uses `undefined` for unset (line 93: `tournament_league: orgDefaults.tournament_league ?? undefined`), so we map combobox's `null` back to `undefined` to avoid changing the form-level shape.
+
+- [ ] **Step 3: Run the failing test from Task 2**
+
+```bash
+just test::pw::spec 02-create-event -g "search filters and selects"
+```
+
+Expected: PASS. The combobox opens, search filters, item click selects, and trigger shows the league name.
+
+- [ ] **Step 4: Run the rest of the file to confirm no regressions**
+
+```bash
+just test::pw::spec 02-create-event
+```
+
+Expected: all tests in the file pass. The existing tests at lines 116, 142, 201 click `event-league-select` then `event-league-option-{pk}` — both data-testids are preserved on the new combobox, so those tests should still pass.
+
+If any existing test fails, debug before proceeding. Most likely cause: an existing test relied on Select-specific keyboard behavior (e.g. typing a letter to jump to an option). Such tests need to be updated to use the new combobox search input.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/app/components/league/LeagueCombobox.tsx \
+        frontend/app/components/events/CreateEventModal.tsx
+git commit -m "feat(league): add LeagueCombobox + wire into CreateEventModal"
+```
+
+---
+
+## Task 4: Failing E2E — clear on create
+
+**Goal:** Add a test that picks a league, then clears via the in-list "— Clear selection —" item, and asserts the submitted event has `tournament_league: null`. It must fail today because the combobox doesn't render the Clear item yet — wait, actually Task 3's component already includes the Clear item. Verify by inspecting the file and adjust this task accordingly.
+
+Re-reading Task 3's code: yes, the Clear item is already implemented. This task therefore tests that the wiring works end-to-end through the API. It will likely pass on first run, but we still write the test first to document the contract.
+
+**Files:**
+- Modify: `frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts`
+
+- [ ] **Step 1: Add the test case**
+
+Append to the same `test.describe` block. The fill-and-submit pattern below mirrors `'creates a one-off event via modal'` at lines 105-130 of the existing spec file.
+
+```ts
+test('league combobox: clear selection on create submits null', async ({ page }) => {
+  await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+  await page.getByTestId('org-tab-events').click();
+  await page.getByTestId('create-event-btn').click();
+
+  // Pick a league
+  await page.getByTestId('event-league-select').click();
+  await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
+
+  // Reopen and clear
+  await page.getByTestId('event-league-select').click();
+  await page.getByRole('option', { name: /clear selection/i }).click();
+
+  // Trigger should show the placeholder again
+  await expect(page.getByTestId('event-league-select')).toContainText(/select league/i);
+
+  // Fill the rest of the required fields (mirroring the one-off-event test)
+  await page.getByTestId('event-name-input').fill('E2E Clear-League Test');
+  await page.getByTestId('event-tournament-name-input').fill('E2E Tournament');
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  await page.getByTestId('event-scheduled-input').fill(tomorrow.toISOString().slice(0, 16));
+
+  // Capture the POST payload as the form submits
+  const createReqPromise = page.waitForRequest(
+    (req) => req.url().includes('/api/events') && req.method() === 'POST',
+  );
+  await page.getByTestId('form-dialog-submit').click();
+  const createReq = await createReqPromise;
+
+  const body = createReq.postDataJSON();
+  expect(body.tournament_league ?? null).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the test and observe**
+
+```bash
+just test::pw::spec 02-create-event -g "clear selection on create"
+```
+
+Two outcomes are possible:
+
+**(a) PASS:** the combobox + form wiring already round-trips null correctly. Skip Step 3, jump to Step 4.
+
+**(b) FAIL:** the form's submit pipeline is dropping null (the spec's "Risks & Open Questions" called this out). Proceed to Step 3.
+
+- [ ] **Step 3 (only if Step 2 failed): Fix null-handling in CreateEventModal submit**
+
+Open `CreateEventModal.tsx` and locate the submit handler (search for `createEvent(` — likely the function passed to `form.handleSubmit`). If the payload is built by spreading form values, ensure `tournament_league` is explicitly included even when `undefined`/`null`:
+
+```tsx
+const payload = {
+  ...values,
+  tournament_league: values.tournament_league ?? null,
+};
+await createEvent(payload);
+```
+
+Re-run Step 2; expect PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts \
+        frontend/app/components/events/CreateEventModal.tsx
+git commit -m "test(events): clear selection round-trips null on create"
+```
+
+(If Step 3 wasn't needed, the second `git add` path is omitted.)
+
+---
+
+## Task 5: Update EditEventModal — drop `.refine()` + swap Select
+
+**Goal:** Make the edit modal consistent with create. Drop the league-required Zod refinement, replace the Select with `LeagueCombobox`, and remove the now-unused local `useLeagues` call.
+
+**Files:**
+- Modify: `frontend/app/components/events/EditEventModal.tsx`
+
+- [ ] **Step 1: Drop the `.refine()` on `tournament_league`**
+
+In `EditEventModal.tsx`, replace lines 50-59 (the comment block and the refined nullable schema) with:
+
+```ts
+  tournament_league: z.number().nullable(),
+```
+
+The schema property now reads as a simple nullable number — no UI-level required check, matching the DB column.
+
+- [ ] **Step 2: Add the LeagueCombobox import**
+
+Add near the existing imports:
+
+```tsx
+import { LeagueCombobox } from '~/components/league/LeagueCombobox';
+```
+
+- [ ] **Step 3: Remove the now-unused `useLeagues` call**
+
+Line 79 currently reads:
+
+```tsx
+const { leagues, isLoading: isLoadingLeagues } = useLeagues(event?.organization);
+```
+
+`leagues` and `isLoadingLeagues` are used only inside the league `<Select>` block at lines 286-330. After the swap, neither is referenced. Delete this line. Also remove the now-unused import `import { useLeagues } from '~/components/league/hooks/useLeagues';` (line 27).
+
+- [ ] **Step 4: Replace the league `<Select>` block**
+
+Replace the entire `<FormField name="tournament_league" ...>` block (starting at line 286, ending at the closing `}` of the `render` prop and the closing `/>` of the FormField — verify by reading the current file):
+
+```tsx
+<FormField
+  control={form.control}
+  name="tournament_league"
+  render={({ field, fieldState }) => (
+    <FormItem>
+      <FormLabel>League</FormLabel>
+      <FormControl>
+        <LeagueCombobox
+          organizationId={event?.organization}
+          value={field.value ?? null}
+          onChange={(v) => field.onChange(v)}
+          invalid={!!fieldState.error}
+          triggerTestId="edit-event-tournament-league"
+          itemTestIdPrefix="league-option-"
+        />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+Note: unlike Create, here we pass `v` straight through to `field.onChange` because the form value type is `number | null` (the schema is `z.number().nullable()`).
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors. If there are errors about unused imports or unreachable code from the removed `noLeagues` variable, clean them up.
+
+- [ ] **Step 6: Run the existing edit spec to confirm no regressions**
+
+```bash
+just test::pw::spec 10-edit-league-and-event-fields
+```
+
+Expected: existing tests pass — including `'edit event tournament_league happy path'` at line 123, which clicks `edit-event-tournament-league` then `league-option-${pk}`. Both test-ids are preserved.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/app/components/events/EditEventModal.tsx
+git commit -m "feat(events): swap edit-modal league Select for LeagueCombobox + drop required refine"
+```
+
+---
+
+## Task 6: Failing E2E — clear on edit
+
+**Goal:** Add a test that opens an event with a league, clears it via the combobox, saves, reloads, and asserts the league is empty.
+
+**Files:**
+- Modify: `frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts`
+
+- [ ] **Step 1: Add the test case**
+
+Append to the `test.describe.serial('Edit league + event fields @cicd', ...)` block. The setup mirrors the existing `'edit event tournament_league happy path'` test (lines 123-156). Note: this file uses `loginAdmin` (site superuser), and the event detail page uses `event-edit-btn` test-id.
+
+```ts
+test('edit event tournament_league: clear via combobox', async ({ page, context }) => {
+  const eventInfo = await getEventsTestData(context);
+  await loginAdmin(context);
+
+  await visitAndWaitForHydration(page, `/events/${eventInfo.pk}`);
+  await expect(page.getByTestId('event-edit-btn')).toBeVisible({ timeout: 15000 });
+  await page.getByTestId('event-edit-btn').click();
+
+  // Open combobox and pick Clear
+  await page.getByTestId('edit-event-tournament-league').click();
+  await page.getByRole('option', { name: /clear selection/i }).click();
+
+  // Trigger shows the placeholder
+  await expect(page.getByTestId('edit-event-tournament-league')).toContainText(/select/i);
+
+  // Save (the modal uses form-dialog-submit, scoped to the edit-event-modal)
+  await page.getByTestId('edit-event-modal').getByTestId('form-dialog-submit').click();
+
+  // Wait for the modal to close — confirms the PATCH completed
+  await expect(page.getByTestId('edit-event-modal')).not.toBeVisible({ timeout: 10000 });
+
+  // API sanity-check
+  const apiResp = await context.request.get(`/api/events/${eventInfo.pk}/`);
+  expect(apiResp.status()).toBe(200);
+  const body = await apiResp.json();
+  expect(body.tournament_league).toBeNull();
+
+  // Revert so subsequent tests in the suite see the canonical league
+  await patchWithCsrf(context, `/api/events/${eventInfo.pk}/`, {
+    tournament_league: eventInfo.eventsLeaguePk,
+  });
+});
+```
+
+- [ ] **Step 2: Run and observe**
+
+```bash
+just test::pw::spec 10-edit-league-and-event-fields -g "clear via combobox"
+```
+
+Outcomes:
+
+**(a) PASS:** edit modal's PATCH already round-trips null. Jump to Step 4.
+
+**(b) FAIL:** PATCH payload is stripping null. Proceed to Step 3.
+
+- [ ] **Step 3 (only if Step 2 failed): Fix null-handling in EditEventModal submit**
+
+Search `EditEventModal.tsx` for the submit handler (look for `mutation.mutate` or `mutation.mutateAsync`). If the payload is built by spreading form values, explicitly ensure `tournament_league` is sent as `null` rather than dropped:
+
+```tsx
+mutation.mutate({
+  ...values,
+  tournament_league: values.tournament_league ?? null,
+});
+```
+
+Re-run Step 2; expect PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts \
+        frontend/app/components/events/EditEventModal.tsx
+git commit -m "test(events): clear via combobox round-trips null on edit"
+```
+
+(Drop the second path if Step 3 wasn't needed.)
+
+---
+
+## Task 7: Failing E2E — mobile fallback
+
+**Goal:** Add a Playwright test that sets a mobile viewport and asserts the league field renders as a `<Select>`, including a "— No league —" first item that round-trips to `null`. It must fail today because `LeagueCombobox` only has the desktop branch.
+
+**Files:**
+- Modify: `frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts`
+
+- [ ] **Step 1: Add the mobile test case**
+
+Add to the same `test.describe('Events - Create Event (@cicd)', ...)` block as Tasks 2 and 4.
+
+```ts
+test('league combobox: mobile renders a Select fallback with clear sentinel', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 }); // iPhone 13-ish
+
+  await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+  await page.getByTestId('org-tab-events').click();
+  await page.getByTestId('create-event-btn').click();
+
+  const trigger = page.getByTestId('event-league-select');
+
+  // Mobile branch uses shadcn Select — there should be no CommandInput.
+  await trigger.click();
+  await expect(page.getByPlaceholder('Search leagues…')).toHaveCount(0);
+
+  // The "— No league —" item should be present and round-trip to null in the form.
+  await page.getByRole('option', { name: /no league/i }).click();
+  await expect(trigger).toContainText(/select league/i);
+
+  // Picking a real league still works
+  await trigger.click();
+  await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
+  await expect(trigger).toContainText('Events Test League');
+});
+```
+
+- [ ] **Step 2: Run and verify FAIL**
+
+```bash
+just test::pw::spec 02-create-event -g "mobile renders a Select fallback"
+```
+
+Expected: FAIL. The desktop branch will render a `CommandInput` even at small viewport widths because we haven't added the mobile branch yet.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+git commit -m "test(events): failing E2E for mobile Select fallback"
+```
+
+---
+
+## Task 8: Implement mobile fallback in LeagueCombobox
+
+**Goal:** Make Task 7 pass. Add the mobile branch that renders a shadcn `<Select>` with a leading sentinel item.
+
+**Files:**
+- Modify: `frontend/app/components/league/LeagueCombobox.tsx`
+
+Note: `@uidotdev/usehooks` is already used in the codebase (see `teamCombobox.tsx:3`). No new dependency needed.
+
+- [ ] **Step 1: Add the mobile branch**
+
+At the top of `LeagueCombobox.tsx`, add imports:
+
+```tsx
+import { useMediaQuery } from '@uidotdev/usehooks';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+```
+
+Inside the component body, after `const { leagues, isLoading } = useLeagues(...)`, add:
+
+```tsx
+const isDesktop = useMediaQuery('(min-width: 768px)');
+```
+
+Then, before the existing `return (<Popover>...)`, insert the mobile branch:
+
+```tsx
+if (!isDesktop) {
+  const noLeagues = !isLoading && leagues.length === 0;
+  return (
+    <Select
+      value={value != null ? String(value) : ''}
+      onValueChange={(v) => {
+        if (v === '__clear__') {
+          onChange(null);
+        } else {
+          onChange(parseInt(v, 10));
+        }
+      }}
+      disabled={triggerDisabled || noLeagues}
+    >
+      <SelectTrigger
+        id={id}
+        data-testid={triggerTestId}
+        aria-invalid={invalid || undefined}
+        className={cn('w-full', className)}
+      >
+        <SelectValue
+          placeholder={
+            isLoading
+              ? 'Loading leagues…'
+              : noLeagues
+                ? 'No leagues in this organization'
+                : placeholder
+          }
+        />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="__clear__">— No league —</SelectItem>
+        {leagues.map((league) => (
+          <SelectItem
+            key={league.pk}
+            value={String(league.pk)}
+            data-testid={
+              itemTestIdPrefix ? `${itemTestIdPrefix}${league.pk}` : undefined
+            }
+          >
+            {league.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+```
+
+The existing desktop `return (<Popover>...)` stays as the fall-through for `isDesktop === true`.
+
+- [ ] **Step 2: Run the mobile test**
+
+```bash
+just test::pw::spec 02-create-event -g "mobile renders a Select fallback"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full event create spec to confirm no regressions**
+
+```bash
+just test::pw::spec 02-create-event
+```
+
+Expected: all tests pass (desktop tests still pick up the desktop branch since the default Playwright viewport is 1280×720).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app/components/league/LeagueCombobox.tsx
+git commit -m "feat(league): add mobile Select fallback to LeagueCombobox"
+```
+
+---
+
+## Task 9: Manual browser verification
+
+**Goal:** Per the project's CLAUDE.md ("UI changes need browser verification"), exercise the feature in a real browser at both desktop and mobile widths before declaring done.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the dev environment**
+
+```bash
+just dev::debug
+```
+
+Wait for the frontend to compile and the page to be reachable at the dev URL.
+
+- [ ] **Step 2: Desktop verification (default browser width)**
+
+In a real browser, with a logged-in user that has at least one organization with multiple leagues:
+
+1. Navigate to an organization's events page.
+2. Click "Create Event" — verify the League field shows a button with placeholder "Select league…" and a chevron.
+3. Click it — popover opens with search input and league list.
+4. Type a partial league name — list filters in real time.
+5. Click a league — popover closes, button shows the league name (truncated if long).
+6. Click the button again — popover reopens, shows Check next to the selected league, plus "— Clear selection —" at the bottom.
+7. Click "Clear selection" — popover closes, button shows the placeholder again.
+8. Pick a league, fill required fields, submit — event creates successfully.
+9. Open the new event in Edit mode — verify the league shows correctly.
+10. In Edit mode, clear the league via the combobox, save — page reloads, edit again, league is empty. ✅
+
+- [ ] **Step 3: Mobile verification (DevTools device emulation, viewport <768px)**
+
+1. Open DevTools, set viewport to e.g. iPhone SE (375×667).
+2. Repeat the Create flow from Step 2: the field should now render as a native-style Select trigger (no chevron+search popover; an OS-style dropdown).
+3. Verify the dropdown shows "— No league —" at the top, then leagues.
+4. Pick "— No league —" — trigger shows placeholder again.
+5. Pick a league, submit — event creates successfully.
+
+- [ ] **Step 4: Stop the dev environment**
+
+```bash
+just dev::down
+```
+
+- [ ] **Step 5: No commit needed** (verification only, no file changes)
+
+---
+
+## Task 10: Final spec/plan status update + cleanup commit
+
+**Goal:** Reflect that the work is complete and ready for review.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-03-event-league-combobox-design.md` (status only)
+
+- [ ] **Step 1: Bump spec status**
+
+In the spec file header, change `**Status:** Approved` to `**Status:** Implemented`.
+
+- [ ] **Step 2: Confirm full Playwright event suite is green**
+
+```bash
+just test::pw::spec 16-events
+```
+
+Expected: all tests pass (the entire `16-events` directory).
+
+- [ ] **Step 3: Confirm no stray uncommitted changes**
+
+```bash
+git status
+```
+
+Expected: clean working tree (modulo the spec status bump from Step 1, which we'll commit next).
+
+- [ ] **Step 4: Commit the status bump**
+
+```bash
+git add docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
+git commit -m "docs(spec): mark league combobox spec implemented"
+```
+
+- [ ] **Step 5: Show the branch's commit log**
+
+```bash
+git log --oneline main..HEAD
+```
+
+This is the change set ready for PR / merge.
+
+---
+
+## Definition of Done
+
+- `LeagueCombobox` exists at `frontend/app/components/league/LeagueCombobox.tsx` and renders desktop Popover+Command and mobile Select branches.
+- `CreateEventModal` and `EditEventModal` both use `LeagueCombobox` for the `tournament_league` field.
+- The Zod `.refine()` on `tournament_league` in `EditEventModal` is gone; both modals treat the field as optional.
+- All Playwright tests in `frontend/tests/playwright/e2e/16-events/` pass, including five new cases:
+  1. Search + select on create
+  2. Clear-on-create round-trips `null`
+  3. Clear-on-edit round-trips `null`
+  4. Mobile renders Select fallback
+  5. (No standalone test for "select happy path" — covered by existing tests via preserved data-testids)
+- Manual desktop + mobile browser checks pass.
+- Spec status is `Implemented`.

--- a/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
+++ b/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
@@ -1,0 +1,134 @@
+# Event League Combobox
+
+**Status:** Draft
+**Date:** 2026-05-03
+**Branch:** `feature/event-reminder-pr3-docs`
+
+## Summary
+
+Replace the plain `<Select>` league field in `CreateEventModal` and `EditEventModal` with a searchable shadcn combobox. Extract a reusable `LeagueCombobox` component (Popover + cmdk Command) that lists the current organization's leagues, supports type-to-filter, and offers an explicit "Clear selection" option. Align the form schema between create and edit so league is optional in both (matching the nullable DB column).
+
+## Motivation
+
+- Organizations can accumulate many leagues; a long native `<Select>` is slow to scan.
+- The current forms are inconsistent: Create treats league as optional, Edit enforces it as required via a Zod `.refine()`. The DB FK is nullable; the form should match.
+- The codebase already has the building blocks: a working combobox pattern (`teamCombobox.tsx`), a `useLeagues(organizationId)` hook backed by Zustand, and shadcn `Command`/`Popover` primitives.
+
+## Scope
+
+In:
+- New component: `frontend/app/components/league/LeagueCombobox.tsx`
+- Edits to `CreateEventModal.tsx` and `EditEventModal.tsx` to consume it
+- Drop the `.refine()` league-required check in `EditEventModal`
+
+Out:
+- `TournamentFilterBar` and other consumers of `useLeagues` (no proactive swaps)
+- Inline league creation
+- Any backend changes (`tournament_league` FK is already nullable)
+
+## Architecture
+
+`LeagueCombobox` is a domain-specific wrapper around shadcn primitives, mirroring the structure of `frontend/app/components/game/helpers/teamCombobox.tsx`:
+
+```
+LeagueCombobox
+├── Popover (open state controlled internally)
+│   ├── PopoverTrigger → Button (shows selected league name or placeholder)
+│   └── PopoverContent
+│       └── Command
+│           ├── CommandInput (search)
+│           ├── CommandEmpty (loading / no leagues / no matches)
+│           ├── CommandList → CommandItem per league (Check icon if selected)
+│           └── CommandItem "— Clear selection —" (rendered only when value !== null)
+```
+
+The component calls `useLeagues(organizationId)` internally so callers don't have to thread the data through.
+
+## Component API
+
+```tsx
+type LeagueComboboxProps = {
+  organizationId: number | undefined;
+  value: number | null;          // selected league id, null when cleared
+  onChange: (value: number | null) => void;
+  disabled?: boolean;
+  placeholder?: string;          // default: "Select league…"
+  className?: string;            // forwarded to trigger Button
+  id?: string;                   // for label association
+};
+```
+
+Design notes:
+- `value` is `number | null` (not `undefined`) so the cleared state is explicit and predictable in react-hook-form fields.
+- `organizationId` is a prop rather than read from a global store internally — keeps the component testable and lets the caller decide refresh timing.
+- The component does not expose loading/error props; it derives them from `useLeagues` and renders state in `CommandEmpty`.
+
+## UX States
+
+**Trigger button:**
+| State | Display |
+|---|---|
+| Value selected | League name |
+| `value === null` | Placeholder ("Select league…") |
+| `disabled` | Greyed out, popover won't open |
+
+**Popover content:**
+| State | Display |
+|---|---|
+| `organizationId === undefined` | Trigger disabled with aria "Select an organization first" (defensive — should not occur in event modals) |
+| `useLeagues.isLoading` | `<CommandEmpty>Loading leagues…</CommandEmpty>`; trigger remains enabled |
+| Loaded, 0 leagues in org | `<CommandEmpty>No leagues in this organization</CommandEmpty>` |
+| Loaded, search matches none | `<CommandEmpty>No leagues match "{query}"</CommandEmpty>` |
+| Loaded, leagues present | List with Check on selected, pinned "— Clear selection —" item at bottom when a value is set |
+
+**Clear semantics:**
+- The "Clear selection" item is the only clear affordance (no X icon on trigger), keeping all interactions inside the Command surface.
+- Hidden when `value === null` (no-op).
+- Selecting it closes the popover and calls `onChange(null)`.
+
+**Search:**
+- Client-side filter on league name (cmdk default). `useLeagues` returns the full org list, so no server round-trip per keystroke.
+
+## Schema & Form Changes
+
+**`CreateEventModal.tsx`:**
+- Replace the existing `<Select>` block (around lines 274-298) with `<LeagueCombobox organizationId={...} value={field.value ?? null} onChange={field.onChange} />` inside the existing `<FormField>` / `<FormItem>` wrapper.
+- No Zod schema change — the field is already optional.
+
+**`EditEventModal.tsx`:**
+- Drop the Zod `.refine()` on `tournament_league` (around lines 57-58) so league is optional, matching the DB and `CreateEventModal`.
+- Replace the `<Select>` with `<LeagueCombobox>` the same way.
+- Verify the submit handler, dirty-tracking, and default-value initialization don't assume league is non-null. If they do, narrow the assumption — do not re-add the constraint.
+
+**Form value normalization:**
+- `field.value` may arrive as `number | undefined | null` depending on form defaults. The combobox always emits `number | null`. We coerce on read with `field.value ?? null` and trust `onChange` on write.
+- The submit handler should serialize `null` to a `null` payload field; `EventSerializer` already accepts that since the FK is nullable.
+
+## Testing
+
+**Playwright E2E** (extend the existing event-modal spec, or add one):
+1. **Search**: open Create Event, open the combobox, type a partial league name, assert filtered list.
+2. **Select**: pick a league, submit, assert event saved with the chosen league.
+3. **Clear on create**: pick a league, then pick "Clear selection", submit, assert event saved with `tournament_league = null`.
+4. **Clear on edit**: open an existing event that has a league, clear it, save, reload, assert league is empty.
+
+**Backend:**
+- No new tests required. During implementation, grep `tournament_league` in `backend/events/tests/` to confirm no existing test asserts that `null` is rejected.
+
+**Frontend unit tests:**
+- The project's frontend testing convention appears to be Playwright-only (no Vitest setup referenced in CLAUDE.md). Skip component unit tests; rely on the E2E coverage above.
+
+**Manual verification:**
+- After implementing, run `just dev::debug`, open Create Event and Edit Event, exercise the four scenarios in a real browser before reporting the work complete.
+
+## Risks & Open Questions
+
+- **Default value shape in `EditEventModal`:** if it currently initializes `tournament_league` from a serializer that returns the league id under a different key (e.g., a nested object), the swap may surface a coercion bug. Mitigation: read the existing default-value setup during implementation and adjust before wiring the combobox.
+- **Submit handler null handling:** if the modal currently strips falsy fields before PATCH (some forms do this to avoid sending `undefined`), `null` may be dropped and the league won't actually clear server-side. Mitigation: add a Playwright assertion that round-trips a cleared league through reload.
+
+## Non-Goals
+
+- Inline league creation
+- TournamentFilterBar swap
+- Any backend or migration changes
+- Multi-select (events have a single league)

--- a/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
+++ b/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
@@ -1,6 +1,6 @@
 # Event League Combobox
 
-**Status:** Draft
+**Status:** Approved
 **Date:** 2026-05-03
 **Branch:** `feature/event-league-combobox`
 

--- a/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
+++ b/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
@@ -1,6 +1,6 @@
 # Event League Combobox
 
-**Status:** Approved
+**Status:** Implemented
 **Date:** 2026-05-03
 **Branch:** `feature/event-league-combobox`
 

--- a/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
+++ b/docs/superpowers/specs/2026-05-03-event-league-combobox-design.md
@@ -2,17 +2,17 @@
 
 **Status:** Draft
 **Date:** 2026-05-03
-**Branch:** `feature/event-reminder-pr3-docs`
+**Branch:** `feature/event-league-combobox`
 
 ## Summary
 
-Replace the plain `<Select>` league field in `CreateEventModal` and `EditEventModal` with a searchable shadcn combobox. Extract a reusable `LeagueCombobox` component (Popover + cmdk Command) that lists the current organization's leagues, supports type-to-filter, and offers an explicit "Clear selection" option. Align the form schema between create and edit so league is optional in both (matching the nullable DB column).
+Replace the plain `<Select>` league field in `CreateEventModal` and `EditEventModal` with a searchable shadcn combobox on desktop and a shadcn `<Select>` on mobile. Extract a reusable `LeagueCombobox` component that lists the current organization's leagues, supports type-to-filter (desktop), and offers an explicit "Clear selection" option. Align the form schema between create and edit so league is optional in both (matching the nullable DB column).
 
 ## Motivation
 
 - Organizations can accumulate many leagues; a long native `<Select>` is slow to scan.
 - The current forms are inconsistent: Create treats league as optional, Edit enforces it as required via a Zod `.refine()`. The DB FK is nullable; the form should match.
-- The codebase already has the building blocks: a working combobox pattern (`teamCombobox.tsx`), a `useLeagues(organizationId)` hook backed by Zustand, and shadcn `Command`/`Popover` primitives.
+- The codebase already has the building blocks: a working combobox pattern (`teamCombobox.tsx`), a `useLeagues(organizationId)` hook backed by Zustand, and shadcn `Command`/`Popover`/`Select` primitives.
 
 ## Scope
 
@@ -28,19 +28,32 @@ Out:
 
 ## Architecture
 
-`LeagueCombobox` is a domain-specific wrapper around shadcn primitives, mirroring the structure of `frontend/app/components/game/helpers/teamCombobox.tsx`:
+`LeagueCombobox` is a domain-specific wrapper around shadcn primitives, mirroring the structure of `frontend/app/components/game/helpers/teamCombobox.tsx`. The file begins with `'use client'` to match the existing convention (no-op in this Vite SPA but consistent with the codebase).
+
+The component branches on viewport via `useMediaQuery('(min-width: 768px)')`:
+
+**Desktop (≥768px):**
 
 ```
-LeagueCombobox
+LeagueCombobox (desktop)
 ├── Popover (open state controlled internally)
-│   ├── PopoverTrigger → Button (shows selected league name or placeholder)
-│   └── PopoverContent
+│   ├── PopoverTrigger → Button
+│   │     variant="outline", role="combobox", aria-expanded={open},
+│   │     aria-invalid={!!error}, w-full, justify-between
+│   │     ├── <span className="truncate">{league name | placeholder}</span>
+│   │     └── <ChevronsUpDown className="opacity-50" />
+│   └── PopoverContent (className="w-[--radix-popover-trigger-width] p-0")
 │       └── Command
-│           ├── CommandInput (search)
-│           ├── CommandEmpty (loading / no leagues / no matches)
-│           ├── CommandList → CommandItem per league (Check icon if selected)
-│           └── CommandItem "— Clear selection —" (rendered only when value !== null)
+│           ├── CommandInput (search, placeholder "Search leagues…")
+│           └── CommandList
+│               ├── CommandEmpty (loading | no leagues | no matches)
+│               ├── CommandGroup (leagues)
+│               │   └── CommandItem per league (Check icon when selected)
+│               └── CommandGroup (actions, rendered only when value !== null)
+│                   └── CommandItem "— Clear selection —"
 ```
+
+**Mobile (<768px):** shadcn `<Select>` with `<SelectItem>` per league plus a leading `<SelectItem value="__clear__">— No league —</SelectItem>`. The component maps the sentinel back to `null` in the change handler. (No search on mobile — native-style picker is the better small-screen UX, and the mobile fallback in `teamCombobox.tsx` of "Mobile not supported" is a known gap we're not repeating.)
 
 The component calls `useLeagues(organizationId)` internally so callers don't have to thread the data through.
 
@@ -53,46 +66,64 @@ type LeagueComboboxProps = {
   onChange: (value: number | null) => void;
   disabled?: boolean;
   placeholder?: string;          // default: "Select league…"
-  className?: string;            // forwarded to trigger Button
+  className?: string;            // forwarded to trigger Button / Select trigger
   id?: string;                   // for label association
+  invalid?: boolean;             // sets aria-invalid on the trigger
 };
 ```
 
 Design notes:
 - `value` is `number | null` (not `undefined`) so the cleared state is explicit and predictable in react-hook-form fields.
 - `organizationId` is a prop rather than read from a global store internally — keeps the component testable and lets the caller decide refresh timing.
-- The component does not expose loading/error props; it derives them from `useLeagues` and renders state in `CommandEmpty`.
+- The component does not expose loading/error props for content; it derives them from `useLeagues` and renders state in `CommandEmpty` (desktop) or as a disabled trigger with placeholder (mobile, where Select doesn't have an equivalent inline empty slot).
+- `invalid` is a single boolean; the consumer (a `FormField` render prop) passes `!!fieldState.error`.
 
 ## UX States
 
-**Trigger button:**
+**Desktop trigger button:**
 | State | Display |
 |---|---|
-| Value selected | League name |
-| `value === null` | Placeholder ("Select league…") |
+| Value selected | League name (truncated) + ChevronsUpDown |
+| `value === null` | Placeholder ("Select league…") + ChevronsUpDown |
 | `disabled` | Greyed out, popover won't open |
+| `invalid` | `aria-invalid="true"` on Button (visual styling comes from shadcn Button defaults / the surrounding `FormItem`) |
 
-**Popover content:**
+**Desktop popover content:**
 | State | Display |
 |---|---|
-| `organizationId === undefined` | Trigger disabled with aria "Select an organization first" (defensive — should not occur in event modals) |
+| `organizationId === undefined` | Trigger disabled (defensive — should not occur in event modals) |
 | `useLeagues.isLoading` | `<CommandEmpty>Loading leagues…</CommandEmpty>`; trigger remains enabled |
 | Loaded, 0 leagues in org | `<CommandEmpty>No leagues in this organization</CommandEmpty>` |
 | Loaded, search matches none | `<CommandEmpty>No leagues match "{query}"</CommandEmpty>` |
-| Loaded, leagues present | List with Check on selected, pinned "— Clear selection —" item at bottom when a value is set |
+| Loaded, leagues present | `CommandGroup` of leagues (Check on selected) + a second `CommandGroup` containing "— Clear selection —" when a value is set |
+
+**Mobile select:**
+| State | Display |
+|---|---|
+| `organizationId === undefined` or 0 leagues | Disabled trigger with placeholder "No leagues" |
+| `useLeagues.isLoading` | Disabled trigger with placeholder "Loading leagues…" |
+| Loaded, leagues present | Items: "— No league —" first (maps to `null`), then one `<SelectItem>` per league |
 
 **Clear semantics:**
-- The "Clear selection" item is the only clear affordance (no X icon on trigger), keeping all interactions inside the Command surface.
-- Hidden when `value === null` (no-op).
-- Selecting it closes the popover and calls `onChange(null)`.
+- Desktop: a "Clear selection" `CommandItem` lives in its own `CommandGroup` at the bottom of the list, rendered only when `value !== null`. Selecting it closes the popover and calls `onChange(null)`.
+- Mobile: the leading "— No league —" item carries a sentinel value (`"__clear__"`) that the component maps back to `null` before calling `onChange`. The item is always rendered, regardless of current value.
+- Either way, no X icon on the trigger — all interactions stay inside the picker surface.
 
-**Search:**
+**Search (desktop only):**
 - Client-side filter on league name (cmdk default). `useLeagues` returns the full org list, so no server round-trip per keystroke.
+
+**Sizing:**
+- Desktop trigger: `w-full` so it fills its `FormItem` cell.
+- Desktop popover: `w-[--radix-popover-trigger-width]` so the dropdown matches trigger width.
+- Mobile Select: full-width per shadcn defaults inside `FormItem`.
+
+**Long names:**
+- Trigger label uses `className="truncate"` (shadcn shorthand) so wide league names don't blow out the form layout.
 
 ## Schema & Form Changes
 
 **`CreateEventModal.tsx`:**
-- Replace the existing `<Select>` block (around lines 274-298) with `<LeagueCombobox organizationId={...} value={field.value ?? null} onChange={field.onChange} />` inside the existing `<FormField>` / `<FormItem>` wrapper.
+- Replace the existing `<Select>` block (around lines 274-298) with `<LeagueCombobox organizationId={...} value={field.value ?? null} onChange={field.onChange} invalid={!!fieldState.error} />` inside the existing `<FormField>` / `<FormItem>` wrapper. `<FormMessage />` continues to render below.
 - No Zod schema change — the field is already optional.
 
 **`EditEventModal.tsx`:**
@@ -107,24 +138,26 @@ Design notes:
 ## Testing
 
 **Playwright E2E** (extend the existing event-modal spec, or add one):
-1. **Search**: open Create Event, open the combobox, type a partial league name, assert filtered list.
+1. **Search (desktop)**: open Create Event, open the combobox, type a partial league name, assert filtered list.
 2. **Select**: pick a league, submit, assert event saved with the chosen league.
 3. **Clear on create**: pick a league, then pick "Clear selection", submit, assert event saved with `tournament_league = null`.
 4. **Clear on edit**: open an existing event that has a league, clear it, save, reload, assert league is empty.
+5. **Mobile fallback**: with viewport set to <768px, verify the field renders as a `<Select>` with a "— No league —" first item that round-trips to `null`. (Use Playwright's viewport sizing — no separate spec file needed.)
 
 **Backend:**
 - No new tests required. During implementation, grep `tournament_league` in `backend/events/tests/` to confirm no existing test asserts that `null` is rejected.
 
 **Frontend unit tests:**
-- The project's frontend testing convention appears to be Playwright-only (no Vitest setup referenced in CLAUDE.md). Skip component unit tests; rely on the E2E coverage above.
+- The project's frontend testing convention is Playwright-only (no Vitest setup referenced in CLAUDE.md). Skip component unit tests; rely on the E2E coverage above.
 
 **Manual verification:**
-- After implementing, run `just dev::debug`, open Create Event and Edit Event, exercise the four scenarios in a real browser before reporting the work complete.
+- After implementing, run `just dev::debug`, open Create Event and Edit Event at desktop and mobile widths, exercise the five scenarios in a real browser before reporting the work complete.
 
 ## Risks & Open Questions
 
 - **Default value shape in `EditEventModal`:** if it currently initializes `tournament_league` from a serializer that returns the league id under a different key (e.g., a nested object), the swap may surface a coercion bug. Mitigation: read the existing default-value setup during implementation and adjust before wiring the combobox.
 - **Submit handler null handling:** if the modal currently strips falsy fields before PATCH (some forms do this to avoid sending `undefined`), `null` may be dropped and the league won't actually clear server-side. Mitigation: add a Playwright assertion that round-trips a cleared league through reload.
+- **Mobile breakpoint inconsistency:** `teamCombobox.tsx` uses `768px` as the desktop cutoff. We match that here for consistency, but if the project later standardizes on a different breakpoint, both components should move together.
 
 ## Non-Goals
 
@@ -132,3 +165,4 @@ Design notes:
 - TournamentFilterBar swap
 - Any backend or migration changes
 - Multi-select (events have a single league)
+- Search on mobile (native-style Select is the better small-screen UX)

--- a/frontend/app/components/api/eventsAPI.ts
+++ b/frontend/app/components/api/eventsAPI.ts
@@ -138,7 +138,7 @@ export interface EventRepeaterType {
   created_at: string;
   updated_at: string;
   tournament_name: string;
-  tournament_league: number;
+  tournament_league: number | null;
   tournament_type: string;
   game_type: number;
   draft_type: string;

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -153,6 +153,7 @@ export function CreateEventModal({
       if (is_recurring) {
         await createEventRepeater({
           ...shared,
+          tournament_league: shared.tournament_league ?? null,
           discord_notify_new_events: discord_notify_new_events ?? false,
           frequency,
           day_of_week: day_of_week ?? null,
@@ -178,6 +179,7 @@ export function CreateEventModal({
         // oriented org config.
         await createEvent({
           ...shared,
+          tournament_league: shared.tournament_league ?? null,
           scheduled_at,
           discord_signup_reminder: false,
           ...(signupsOpenAt ? { signups_open_at: signupsOpenAt } : {}),

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -30,6 +30,7 @@ import { DiscordConfigSection, DiscordIcon } from './DiscordConfigSection';
 import { LobbyConfigSection } from './LobbyConfigSection';
 import { createEventInputSchema, GameType, GameMode, Frequency, FREQUENCY_LABELS, DAY_LABELS, DISCORD_CONFIG_DEFAULTS, COMMON_TIMEZONES, localToUTC, type CreateEventInput } from './schemas';
 import type { LeagueType } from '~/components/league';
+import { LeagueCombobox } from '~/components/league/LeagueCombobox';
 
 interface CreateEventModalProps {
   open: boolean;
@@ -272,26 +273,21 @@ export function CreateEventModal({
           <FormField
             control={form.control}
             name="tournament_league"
-            render={({ field }) => (
+            render={({ field, fieldState }) => (
               <FormItem>
                 <FormLabel>League</FormLabel>
-                <Select
-                  onValueChange={(val) => field.onChange(parseInt(val, 10))}
-                  value={field.value?.toString()}
-                >
-                  <FormControl>
-                    <SelectTrigger data-testid="event-league-select" className="w-full">
-                      <SelectValue placeholder="Select league" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {leagues.map((league) => (
-                      <SelectItem key={league.pk} value={String(league.pk)} data-testid={`event-league-option-${league.pk}`}>
-                        {league.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <LeagueCombobox
+                    organizationId={organizationId}
+                    value={field.value ?? null}
+                    onChange={(v) => field.onChange(v ?? undefined)}
+                    invalid={!!fieldState.error}
+                    triggerTestId="event-league-select"
+                    itemTestIdPrefix="event-league-option-"
+                    searchTestId="event-league-search"
+                    clearTestId="event-league-clear"
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -46,11 +46,17 @@ export function CreateEventModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [defaultsApplied, setDefaultsApplied] = useState(false);
 
-  const { data: orgDefaults } = useQuery({
+  const { data: orgDefaults, isLoading: orgDefaultsLoading } = useQuery({
     queryKey: ['org-event-defaults', organizationId],
     queryFn: () => getOrgEventDefaults(organizationId),
     staleTime: 5 * 60 * 1000,
   });
+
+  // Hide form fields until orgDefaults are applied so the user can't start
+  // typing before form.reset() fires and clobbers their input. The query
+  // may also fail (network down, 5xx); in that case defaults stay at the
+  // hardcoded useForm values and we show the form anyway after isLoading clears.
+  const formReady = !orgDefaultsLoading && (orgDefaults == null || defaultsApplied);
 
   const form = useForm<CreateEventInput>({
     resolver: zodResolver(createEventInputSchema),
@@ -207,10 +213,15 @@ export function CreateEventModal({
       onOpenChange={onOpenChange}
       title={isRecurring ? 'Create Recurring Event' : 'Create Event'}
       submitLabel="Create"
-      isSubmitting={isSubmitting}
+      isSubmitting={isSubmitting || !formReady}
       onSubmit={form.handleSubmit(onSubmit)}
       size="lg"
     >
+      {!formReady ? (
+        <div className="py-12 text-center text-muted-foreground" data-testid="create-event-loading">
+          Loading defaults…
+        </div>
+      ) : (
       <Form {...form}>
         <Tabs defaultValue="event">
           <TabsList className="w-full">
@@ -719,6 +730,7 @@ export function CreateEventModal({
           </TabsContent>
         </Tabs>
       </Form>
+      )}
     </FormDialog>
   );
 }

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -29,21 +29,18 @@ import { ApprovalConfigSection } from './ApprovalConfigSection';
 import { DiscordConfigSection, DiscordIcon } from './DiscordConfigSection';
 import { LobbyConfigSection } from './LobbyConfigSection';
 import { createEventInputSchema, GameType, GameMode, Frequency, FREQUENCY_LABELS, DAY_LABELS, DISCORD_CONFIG_DEFAULTS, COMMON_TIMEZONES, localToUTC, type CreateEventInput } from './schemas';
-import type { LeagueType } from '~/components/league';
 import { LeagueCombobox } from '~/components/league/LeagueCombobox';
 
 interface CreateEventModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   organizationId: number;
-  leagues: LeagueType[];
 }
 
 export function CreateEventModal({
   open,
   onOpenChange,
   organizationId,
-  leagues,
 }: CreateEventModalProps) {
   const queryClient = useQueryClient();
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -88,7 +88,7 @@ export function CreateEventModal({
         scheduled_at: '',
         organization: organizationId,
         tournament_name: orgDefaults.tournament_name || '',
-        tournament_league: orgDefaults.tournament_league ?? undefined,
+        tournament_league: orgDefaults.tournament_league ?? null,
         tournament_type: orgDefaults.tournament_type,
         game_type: orgDefaults.game_type,
         draft_type: orgDefaults.draft_type,
@@ -279,7 +279,7 @@ export function CreateEventModal({
                   <LeagueCombobox
                     organizationId={organizationId}
                     value={field.value ?? null}
-                    onChange={(v) => field.onChange(v ?? undefined)}
+                    onChange={(v) => field.onChange(v)}
                     invalid={!!fieldState.error}
                     triggerTestId="event-league-select"
                     itemTestIdPrefix="event-league-option-"

--- a/frontend/app/components/events/EditEventModal.tsx
+++ b/frontend/app/components/events/EditEventModal.tsx
@@ -24,7 +24,7 @@ import {
 import { Textarea } from '~/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { ShieldCheck } from 'lucide-react';
-import { useLeagues } from '~/components/league/hooks/useLeagues';
+import { LeagueCombobox } from '~/components/league/LeagueCombobox';
 import { useUpdateEventMutation } from '~/hooks/useEvent';
 import { ApprovalConfigSection } from './ApprovalConfigSection';
 import { DiscordConfigSection, DiscordIcon } from './DiscordConfigSection';
@@ -47,16 +47,7 @@ const editEventSchema = z.object({
   people_per_team: z.number().int().min(1),
   number_of_teams: z.number().int().min(2).nullable(),
   timezone: z.string().min(1, 'Timezone is required'),
-  // The backend allows None, but the UI requires a league on edit.
-  // To clear the league, use the Django admin or a direct API call.
-  // `.nullable()` accommodates the brief flash before useEffect populates from
-  // the loaded event; `.refine()` enforces non-null at submit time.
-  tournament_league: z
-    .number()
-    .nullable()
-    .refine((v) => v !== null && v >= 1, {
-      message: 'League is required',
-    }),
+  tournament_league: z.number().nullable(),
 }).merge(discordConfigSchema);
 
 type EditEventInput = z.infer<typeof editEventSchema>;
@@ -76,7 +67,6 @@ function toDatetimeLocal(iso: string): string {
 export function EditEventModal({ event, open, onOpenChange }: EditEventModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const mutation = useUpdateEventMutation(event?.id ?? 0);
-  const { leagues, isLoading: isLoadingLeagues } = useLeagues(event?.organization);
 
   const form = useForm<EditEventInput>({
     resolver: zodResolver(editEventSchema),
@@ -286,45 +276,24 @@ export function EditEventModal({ event, open, onOpenChange }: EditEventModalProp
         <FormField
           control={form.control}
           name="tournament_league"
-          render={({ field }) => {
-            const noLeagues = !isLoadingLeagues && leagues.length === 0;
-            return (
-              <FormItem>
-                <FormLabel>League</FormLabel>
-                <FormControl>
-                  <Select
-                    value={field.value ? String(field.value) : ''}
-                    onValueChange={(v) => field.onChange(parseInt(v, 10))}
-                    disabled={isLoadingLeagues || noLeagues}
-                  >
-                    <SelectTrigger data-testid="edit-event-tournament-league">
-                      <SelectValue
-                        placeholder={
-                          isLoadingLeagues
-                            ? 'Loading…'
-                            : noLeagues
-                            ? 'No leagues for this organization — create one first.'
-                            : 'Select a league'
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {leagues.map((league) => (
-                        <SelectItem
-                          key={league.pk}
-                          value={String(league.pk)}
-                          data-testid={`league-option-${league.pk}`}
-                        >
-                          {league.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
+          render={({ field, fieldState }) => (
+            <FormItem>
+              <FormLabel>League</FormLabel>
+              <FormControl>
+                <LeagueCombobox
+                  organizationId={event?.organization}
+                  value={field.value ?? null}
+                  onChange={(v) => field.onChange(v)}
+                  invalid={!!fieldState.error}
+                  triggerTestId="edit-event-tournament-league"
+                  itemTestIdPrefix="league-option-"
+                  searchTestId="edit-event-league-search"
+                  clearTestId="edit-event-league-clear"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
         />
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/frontend/app/components/events/schemas.ts
+++ b/frontend/app/components/events/schemas.ts
@@ -35,7 +35,7 @@ export const eventSchema = z.object({
   signup_count: z.number(),
   confirmed_count: z.number(),
   tournament_name: z.string(),
-  tournament_league: z.number(),
+  tournament_league: z.number().nullable(),
   tournament_type: z.string(),
   game_type: z.number(),
   draft_type: z.string(),

--- a/frontend/app/components/events/schemas.ts
+++ b/frontend/app/components/events/schemas.ts
@@ -312,7 +312,7 @@ export const createEventInputSchema = z.object({
   description: z.string(),
   scheduled_at: z.string(),
   organization: z.number(),
-  tournament_league: z.number({ error: 'League is required' }),
+  tournament_league: z.number().nullable().optional(),
   tournament_name: z.string().min(1, 'Tournament name is required'),
   tournament_type: z.string(),
   game_type: z.number(),

--- a/frontend/app/components/league/LeagueCombobox.tsx
+++ b/frontend/app/components/league/LeagueCombobox.tsx
@@ -163,7 +163,7 @@ export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
                       itemTestIdPrefix ? `${itemTestIdPrefix}${league.pk}` : undefined
                     }
                     onSelect={() => {
-                      onChange(league.pk);
+                      onChange(league.pk ?? null);
                       setOpen(false);
                     }}
                   >

--- a/frontend/app/components/league/LeagueCombobox.tsx
+++ b/frontend/app/components/league/LeagueCombobox.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useMediaQuery } from '@uidotdev/usehooks';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '~/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '~/components/ui/command';
+import { useLeagues } from '~/components/league/hooks/useLeagues';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '~/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import { cn } from '~/lib/utils';
+
+export interface LeagueComboboxProps {
+  organizationId: number | undefined;
+  value: number | null;
+  onChange: (value: number | null) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  id?: string;
+  invalid?: boolean;
+  /** data-testid to apply to the trigger (preserves existing test-ids) */
+  triggerTestId?: string;
+  /** prefix for per-item data-testids: `${itemTestIdPrefix}${leagueId}` */
+  itemTestIdPrefix?: string;
+  /** data-testid for the search input (desktop only) */
+  searchTestId?: string;
+  /** data-testid for the Clear-selection item (desktop) and No-league sentinel (mobile) */
+  clearTestId?: string;
+}
+
+export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
+  organizationId,
+  value,
+  onChange,
+  disabled,
+  placeholder = 'Select league…',
+  className,
+  id,
+  invalid,
+  triggerTestId,
+  itemTestIdPrefix,
+  searchTestId,
+  clearTestId,
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const { leagues, isLoading } = useLeagues(organizationId);
+  const isDesktop = useMediaQuery('(min-width: 768px)');
+
+  const selected = value != null ? leagues.find((l) => l.pk === value) : null;
+  const isOrgMissing = organizationId == null;
+  const triggerDisabled = disabled || isOrgMissing;
+
+  if (!isDesktop) {
+    const noLeagues = !isLoading && leagues.length === 0;
+    return (
+      <Select
+        value={value != null ? String(value) : ''}
+        onValueChange={(v) => {
+          if (v === '__clear__') {
+            onChange(null);
+          } else {
+            onChange(parseInt(v, 10));
+          }
+        }}
+        disabled={triggerDisabled || noLeagues}
+      >
+        <SelectTrigger
+          id={id}
+          data-testid={triggerTestId}
+          aria-invalid={invalid || undefined}
+          className={cn('w-full', className)}
+        >
+          <SelectValue
+            placeholder={
+              isLoading
+                ? 'Loading leagues…'
+                : noLeagues
+                  ? 'No leagues in this organization'
+                  : placeholder
+            }
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__clear__" data-testid={clearTestId}>
+            — No league —
+          </SelectItem>
+          {leagues.map((league) => (
+            <SelectItem
+              key={league.pk}
+              value={String(league.pk)}
+              data-testid={
+                itemTestIdPrefix ? `${itemTestIdPrefix}${league.pk}` : undefined
+              }
+            >
+              {league.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={invalid || undefined}
+          disabled={triggerDisabled}
+          data-testid={triggerTestId}
+          className={cn(
+            'w-full justify-between aria-invalid:border-destructive',
+            className,
+          )}
+        >
+          <span className="truncate">
+            {selected ? selected.name : placeholder}
+          </span>
+          <ChevronsUpDown data-icon="inline-end" className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput
+            placeholder="Search leagues…"
+            className="h-9"
+            data-testid={searchTestId}
+          />
+          <CommandList>
+            <CommandEmpty>
+              {isLoading
+                ? 'Loading leagues…'
+                : leagues.length === 0
+                  ? 'No leagues in this organization'
+                  : 'No leagues match your search'}
+            </CommandEmpty>
+            {leagues.length > 0 && (
+              <CommandGroup>
+                {leagues.map((league) => (
+                  <CommandItem
+                    key={league.pk}
+                    value={league.name}
+                    data-testid={
+                      itemTestIdPrefix ? `${itemTestIdPrefix}${league.pk}` : undefined
+                    }
+                    onSelect={() => {
+                      onChange(league.pk);
+                      setOpen(false);
+                    }}
+                  >
+                    {league.name}
+                    <Check
+                      className={cn(
+                        'ml-auto',
+                        value === league.pk ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {value !== null && (
+              <CommandGroup>
+                <CommandItem
+                  value="__clear__"
+                  data-testid={clearTestId}
+                  onSelect={() => {
+                    onChange(null);
+                    setOpen(false);
+                  }}
+                >
+                  — Clear selection —
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default LeagueCombobox;

--- a/frontend/app/components/league/LeagueCombobox.tsx
+++ b/frontend/app/components/league/LeagueCombobox.tsx
@@ -130,18 +130,15 @@ export const LeagueCombobox: React.FC<LeagueComboboxProps> = ({
           aria-invalid={invalid || undefined}
           disabled={triggerDisabled}
           data-testid={triggerTestId}
-          className={cn(
-            'w-full justify-between aria-invalid:border-destructive',
-            className,
-          )}
+          className={cn('w-full justify-between', className)}
         >
           <span className="truncate">
             {selected ? selected.name : placeholder}
           </span>
-          <ChevronsUpDown data-icon="inline-end" className="opacity-50" />
+          <ChevronsUpDown className="opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
         <Command>
           <CommandInput
             placeholder="Search leagues…"

--- a/frontend/app/components/navbar/PageNavBar.tsx
+++ b/frontend/app/components/navbar/PageNavBar.tsx
@@ -14,6 +14,8 @@ export function PageNavBar() {
       value={value}
       onValueChange={onValueChange}
       className="md:hidden mx-2 my-1"
+      triggerTestId="page-nav-trigger"
+      itemTestIdPrefix="page-nav-"
     />
   );
 }

--- a/frontend/app/components/ui/mobile-nav-dropdown.tsx
+++ b/frontend/app/components/ui/mobile-nav-dropdown.tsx
@@ -22,7 +22,12 @@ interface MobileNavDropdownProps {
   className?: string;
   /** "primary" (bold gradient) for navbar, "secondary" (subtle) for in-page */
   variant?: 'primary' | 'secondary';
+  /** data-testid on the wrapper (kept for backwards compatibility) */
   'data-testid'?: string;
+  /** data-testid on the SelectTrigger so tests can open the dropdown */
+  triggerTestId?: string;
+  /** prefix for per-option SelectItem data-testids: `${prefix}${option.value}` */
+  itemTestIdPrefix?: string;
 }
 
 /**
@@ -38,6 +43,8 @@ export function MobileNavDropdown({
   className,
   variant = 'primary',
   'data-testid': testId,
+  triggerTestId,
+  itemTestIdPrefix,
 }: MobileNavDropdownProps) {
   const isPrimary = variant === 'primary';
 
@@ -61,7 +68,10 @@ export function MobileNavDropdown({
 
       {/* Dropdown trigger with chevron indicator */}
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger className="w-full h-10 border-0 rounded-none bg-transparent px-3 text-base font-semibold text-white text-left justify-start focus-visible:ring-0 focus-visible:ring-offset-0 [&>svg:last-child]:text-white [&>svg:last-child]:h-5 [&>svg:last-child]:w-5">
+        <SelectTrigger
+          data-testid={triggerTestId}
+          className="w-full h-10 border-0 rounded-none bg-transparent px-3 text-base font-semibold text-white text-left justify-start focus-visible:ring-0 focus-visible:ring-offset-0 [&>svg:last-child]:text-white [&>svg:last-child]:h-5 [&>svg:last-child]:w-5"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent className="border-primary/30">
@@ -69,6 +79,9 @@ export function MobileNavDropdown({
             <SelectItem
               key={option.value}
               value={option.value}
+              data-testid={
+                itemTestIdPrefix ? `${itemTestIdPrefix}${option.value}` : undefined
+              }
               className={cn(
                 'min-h-[44px] flex items-center text-base cursor-pointer',
                 option.value === value &&

--- a/frontend/app/routes/organization.tsx
+++ b/frontend/app/routes/organization.tsx
@@ -587,7 +587,6 @@ export default function OrganizationDetailPage() {
             open={createEventOpen}
             onOpenChange={setCreateEventOpen}
             organizationId={pk}
-            leagues={leagues}
           />
         )}
 

--- a/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
@@ -187,6 +187,82 @@ test.describe('Events - Create Event (@cicd)', () => {
     await expect(page.getByTestId('event-people-per-team-input')).toHaveValue('5');
   });
 
+  test('league combobox: search filters and selects on create', async ({ page }) => {
+    await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+    await page.getByTestId('org-tab-events').click();
+    await page.getByTestId('create-event-btn').click();
+
+    // Open the combobox trigger
+    const trigger = page.getByTestId('event-league-select');
+    await trigger.click();
+
+    // Type into the cmdk search input — first 3 chars of the seeded league name
+    await page.getByTestId('event-league-search').fill('Eve');
+
+    // Pick the seeded events league via its preserved per-item data-testid
+    await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
+
+    // Trigger should now show the selected league name
+    await expect(trigger).toContainText('Events Test League');
+  });
+
+  test('league combobox: clear selection on create submits null', async ({ page }) => {
+    await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+    await page.getByTestId('org-tab-events').click();
+    await page.getByTestId('create-event-btn').click();
+
+    // Pick a league
+    await page.getByTestId('event-league-select').click();
+    await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
+
+    // Reopen and clear
+    await page.getByTestId('event-league-select').click();
+    await page.getByTestId('event-league-clear').click();
+
+    // Trigger should show the placeholder again
+    await expect(page.getByTestId('event-league-select')).toContainText(/select league/i);
+
+    // Fill the rest of the required fields (mirroring the one-off-event test)
+    await page.getByTestId('event-name-input').fill('E2E Clear-League Test');
+    await page.getByTestId('event-tournament-name-input').fill('E2E Tournament');
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    await page.getByTestId('event-scheduled-input').fill(tomorrow.toISOString().slice(0, 16));
+
+    // Capture the POST payload as the form submits
+    const createReqPromise = page.waitForRequest(
+      (req) => req.url().includes('/api/events') && req.method() === 'POST',
+    );
+    await page.getByTestId('form-dialog-submit').click();
+    const createReq = await createReqPromise;
+
+    const body = createReq.postDataJSON();
+    expect(body.tournament_league ?? null).toBeNull();
+  });
+
+  test('league combobox: mobile renders a Select fallback with clear sentinel', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 }); // iPhone 13-ish
+
+    await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+    await page.getByTestId('org-tab-events').click();
+    await page.getByTestId('create-event-btn').click();
+
+    const trigger = page.getByTestId('event-league-select');
+
+    // Mobile branch uses shadcn Select — there should be no cmdk search input.
+    await trigger.click();
+    await expect(page.getByTestId('event-league-search')).toHaveCount(0);
+
+    // The "— No league —" sentinel should round-trip to null in the form.
+    await page.getByTestId('event-league-clear').click();
+    await expect(trigger).toContainText(/select league/i);
+
+    // Picking a real league still works
+    await trigger.click();
+    await page.getByTestId(`event-league-option-${eventInfo.leaguePk}`).click();
+    await expect(trigger).toContainText('Events Test League');
+  });
+
   test('creates a recurring event (event repeater) via modal', async ({ page }) => {
     await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
 

--- a/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
@@ -241,11 +241,15 @@ test.describe('Events - Create Event (@cicd)', () => {
   });
 
   test('league combobox: mobile renders a Select fallback with clear sentinel', async ({ page }) => {
-    await page.setViewportSize({ width: 375, height: 812 }); // iPhone 13-ish
-
+    // Navigate at desktop width — the org page's mobile nav uses a different
+    // tab control that isn't testid-addressable. We only need the modal-level
+    // viewport to be mobile so the combobox's useMediaQuery flips branches.
     await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
     await page.getByTestId('org-tab-events').click();
     await page.getByTestId('create-event-btn').click();
+
+    // Now flip to mobile width — useMediaQuery in LeagueCombobox re-evaluates.
+    await page.setViewportSize({ width: 375, height: 812 }); // iPhone 13-ish
 
     const trigger = page.getByTestId('event-league-select');
 

--- a/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
@@ -241,15 +241,17 @@ test.describe('Events - Create Event (@cicd)', () => {
   });
 
   test('league combobox: mobile renders a Select fallback with clear sentinel', async ({ page }) => {
-    // Navigate at desktop width — the org page's mobile nav uses a different
-    // tab control that isn't testid-addressable. We only need the modal-level
-    // viewport to be mobile so the combobox's useMediaQuery flips branches.
-    await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
-    await page.getByTestId('org-tab-events').click();
-    await page.getByTestId('create-event-btn').click();
-
-    // Now flip to mobile width — useMediaQuery in LeagueCombobox re-evaluates.
+    // Set mobile viewport before navigation so the page renders its mobile-nav
+    // layout (a `MobileNavDropdown` instead of a horizontal tablist).
     await page.setViewportSize({ width: 375, height: 812 }); // iPhone 13-ish
+
+    await visitAndWaitForHydration(page, `/organizations/${eventInfo.orgPk}`);
+
+    // The desktop `org-tab-events` button is hidden by `md:block`/`md:hidden`
+    // at this width — switch tabs via the mobile dropdown instead.
+    await page.getByTestId('page-nav-trigger').click();
+    await page.getByTestId('page-nav-events').click();
+    await page.getByTestId('create-event-btn').click();
 
     const trigger = page.getByTestId('event-league-select');
 

--- a/frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/10-edit-league-and-event-fields.spec.ts
@@ -155,6 +155,39 @@ test.describe.serial('Edit league + event fields @cicd', () => {
     });
   });
 
+  test('edit event tournament_league: clear via combobox', async ({ page, context }) => {
+    const eventInfo = await getEventsTestData(context);
+    await loginAdmin(context);
+
+    await visitAndWaitForHydration(page, `/events/${eventInfo.pk}`);
+    await expect(page.getByTestId('event-edit-btn')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('event-edit-btn').click();
+
+    // Open combobox and pick Clear
+    await page.getByTestId('edit-event-tournament-league').click();
+    await page.getByTestId('edit-event-league-clear').click();
+
+    // Trigger shows the placeholder
+    await expect(page.getByTestId('edit-event-tournament-league')).toContainText(/select/i);
+
+    // Save (the modal uses form-dialog-submit, scoped to the edit-event-modal)
+    await page.getByTestId('edit-event-modal').getByTestId('form-dialog-submit').click();
+
+    // Wait for the modal to close — confirms the PATCH completed
+    await expect(page.getByTestId('edit-event-modal')).not.toBeVisible({ timeout: 10000 });
+
+    // API sanity-check
+    const apiResp = await context.request.get(`/api/events/${eventInfo.pk}/`);
+    expect(apiResp.status()).toBe(200);
+    const body = await apiResp.json();
+    expect(body.tournament_league).toBeNull();
+
+    // Revert so subsequent tests in the suite see the canonical league
+    await patchWithCsrf(context, `/api/events/${eventInfo.pk}/`, {
+      tournament_league: eventInfo.eventsLeaguePk,
+    });
+  });
+
   test('edit event tournament_league org-scope guard (API-level)', async ({
     context,
   }) => {


### PR DESCRIPTION
## Summary

- Replaces the plain `<Select>` league field in `CreateEventModal` and `EditEventModal` with a new `LeagueCombobox` — searchable on desktop (Popover + cmdk Command), native-style `<Select>` on mobile (<768px) — with an explicit "Clear selection" / "— No league —" option in both branches.
- Aligns the form schema across both modals: `tournament_league` is now optional/nullable in both, matching the DB column.
- Preserves existing `data-testid`s (`event-league-select`, `event-league-option-{pk}`, `edit-event-tournament-league`, `league-option-{pk}`) so all 11 pre-existing event Playwright specs keep passing without edits.
- Adds `triggerTestId` / `itemTestIdPrefix` to the shared `MobileNavDropdown` so mobile-only flows are testid-addressable (used by the new mobile combobox test, useful for any future mobile spec).

## Files

- New: `frontend/app/components/league/LeagueCombobox.tsx` — desktop Popover+Command + mobile Select branches in one component, internal `useLeagues(organizationId)`, `useMediaQuery('(min-width: 768px)')` viewport branch.
- Modified: `frontend/app/components/events/CreateEventModal.tsx` — swap Select → combobox, drop unused `leagues` prop, force `tournament_league: null` in submit payload (both `createEvent` and `createEventRepeater` paths).
- Modified: `frontend/app/components/events/EditEventModal.tsx` — drop the Zod `.refine()` that required a league on edit, swap Select → combobox, remove the now-unused local `useLeagues` call.
- Modified: `frontend/app/components/events/schemas.ts` — `createEventInputSchema.tournament_league: z.number().nullable().optional()`; `eventSchema.tournament_league: z.number().nullable()` (matches backend `null=True`).
- Modified: `frontend/app/components/api/eventsAPI.ts` — `EventRepeaterType.tournament_league: number | null`.
- Modified: `frontend/app/components/ui/mobile-nav-dropdown.tsx` + `frontend/app/components/navbar/PageNavBar.tsx` — add `triggerTestId` / `itemTestIdPrefix` props; PageNavBar passes `page-nav-trigger` / `page-nav-` so tests can drive the mobile tab switcher.
- Modified: `frontend/app/routes/organization.tsx` — drop the unused `leagues={leagues}` prop pass-through.
- Tests: `02-create-event.spec.ts` (3 new) and `10-edit-league-and-event-fields.spec.ts` (1 new).

## Design / spec docs

- Spec: `docs/superpowers/specs/2026-05-03-event-league-combobox-design.md`
- Plan: `docs/superpowers/plans/2026-05-03-event-league-combobox.md`

## Test plan

- [x] All 11 specs in `frontend/tests/playwright/e2e/16-events/` pass (`just test::pw::spec 16-events` → **55 passed**, 0 failed, 0 flaky).
- [x] 4 new Playwright tests:
  - search filters and selects on create
  - clear-on-create submits `null`
  - clear-on-edit round-trips `null` (incl. API GET assertion + revert via `patchWithCsrf`)
  - mobile renders Select fallback with clear sentinel (real flow: mobile viewport → mobile nav dropdown → Events tab → Create Event → exercise combobox)
- [x] Existing tests unaffected — `event-league-select`, `edit-event-tournament-league`, and per-item testids preserved on the new combobox elements.
- [x] TypeScript: no new errors in `LeagueCombobox.tsx` or in the changed modal sections (pre-existing react-hook-form `Resolver`/`Control` generic noise unchanged).
- [ ] Manual desktop + mobile browser walkthrough (recommended before merging).

## Notes

- The biggest non-obvious bug discovered during testing: `field.onChange(v ?? undefined)` doesn't reliably re-render react-hook-form Controllers when the value becomes `undefined` — the popover closed but the trigger button still showed the old league name. Fix: pass `null` straight through; the schema accepts both.
- The desktop Combobox uses Tailwind 4 paren-form for the trigger-width CSS variable (`w-(--radix-popover-trigger-width)`) — matches the existing convention in `popover.tsx` / `select.tsx`.