### PR TITLE
fix(captains): correct Cpatain → Captain typo on non-staff button

### DIFF
--- a/frontend/app/components/tournament/captains/UpdateCaptainButton.tsx
+++ b/frontend/app/components/tournament/captains/UpdateCaptainButton.tsx
@@ -58,7 +58,7 @@ export const UpdateCaptainButton: React.FC<{ user: UserType }> = ({ user }) => {
     });
   };
   const dialogBG = () => (isCaptain ? 'bg-red-900' : 'bg-green-900');
-  if (!isStaff()) return <AdminOnlyButton buttonTxt="Change Cpatain" />;
+  if (!isStaff()) return <AdminOnlyButton buttonTxt="Change Captain" />;
 
   return (
     <div


### PR DESCRIPTION
## Summary
One-character typo fix on the non-staff "Change Captain" button label.

Closes #197

## Test plan
- [ ] Visual check: tournament captains view shows "Change Captain" (not "Cpatain") for non-staff users

---
Split out of #204.