### PR TITLE
fix(tournament-edit): show org MMR field when tournament is org-scoped without league

### DIFF
--- a/frontend/app/pages/tournament/hasErrors.test.tsx
+++ b/frontend/app/pages/tournament/hasErrors.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { deriveEditScope } from './hasErrors';
+
+import type { LeagueType } from '~/components/league/schemas';
+import type { OrganizationType } from '~/components/organization/schemas';
+
+describe('deriveEditScope', () => {
+  const org: OrganizationType = { pk: 7, name: 'Events Test Org' } as OrganizationType;
+  const league: LeagueType = { pk: 7, name: 'Events Test League', organization: org } as LeagueType;
+
+  it('returns league scope when a league is present', () => {
+    expect(deriveEditScope({ league, currentOrg: org })).toEqual({
+      kind: 'league',
+      league,
+    });
+  });
+
+  it('returns org scope when only an org is present (the #195 case)', () => {
+    expect(deriveEditScope({ league: null, currentOrg: org })).toEqual({
+      kind: 'org',
+      organization: org,
+    });
+  });
+
+  it('returns global scope when neither org nor league is loaded', () => {
+    expect(deriveEditScope({ league: null, currentOrg: null })).toEqual({
+      kind: 'global',
+    });
+  });
+
+  it('prefers league when both are present (league > org > global)', () => {
+    expect(deriveEditScope({ league, currentOrg: org })).toEqual({
+      kind: 'league',
+      league,
+    });
+  });
+});

--- a/frontend/app/pages/tournament/hasErrors.tsx
+++ b/frontend/app/pages/tournament/hasErrors.tsx
@@ -1,4 +1,6 @@
 import { useMemo } from 'react';
+import type { LeagueType } from '~/components/league/schemas';
+import type { OrganizationType } from '~/components/organization/schemas';
 import type { UserClassType, UserType } from '~/components/user';
 import { brandErrorBg, brandErrorCard } from '~/components/ui/buttons';
 import UserEditModal from '~/components/user/userCard/editModal';
@@ -6,10 +8,29 @@ import type { EditUserScope } from '~/components/user/userCard/editUserSchema';
 import { getLogger } from '~/lib/logger';
 import { cn } from '~/lib/utils';
 import { useLeagueStore } from '~/store/leagueStore';
+import { useOrgStore } from '~/store/orgStore';
 import type { UserEntry } from '~/store/userCacheTypes';
 import { useUserCacheStore } from '~/store/userCacheStore';
 import { useUserStore } from '~/store/userStore';
 const log = getLogger('hasErrors');
+
+/**
+ * Derive the EditUserModal scope for the tournament-edit panel.
+ * Order: league > org > global. Falls back to global only when neither
+ * is loaded — callers should ensure currentOrg is populated before render
+ * (TournamentDetailPage calls getOrganization in a useEffect on mount).
+ */
+export function deriveEditScope({
+  league,
+  currentOrg,
+}: {
+  league: LeagueType | null;
+  currentOrg: OrganizationType | null;
+}): EditUserScope {
+  if (league) return { kind: 'league', league };
+  if (currentOrg) return { kind: 'org', organization: currentOrg };
+  return { kind: 'global' };
+}
 
 interface UserIssue {
   user: UserClassType;
@@ -45,12 +66,11 @@ export const hasErrors = () => {
 
   const orgId = tournament?.organization_pk ?? undefined;
 
+  const currentOrg = useOrgStore((state) => state.currentOrg);
+
   const editScope = useMemo<EditUserScope>(
-    () =>
-      league
-        ? { kind: 'league', league }
-        : { kind: 'global' },
-    [league?.pk],
+    () => deriveEditScope({ league, currentOrg }),
+    [league?.pk, currentOrg?.pk],
   );
 
   // Resolve users from entity cache — the single source of truth

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    include: ['app/**/*.test.ts', 'tests/unit/**/*.test.ts'],
+    include: ['app/**/*.test.ts', 'app/**/*.test.tsx', 'tests/unit/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
Tournament edit modal was hiding the MMR field when no league was selected. Adds \`deriveEditScope({league, currentOrg})\` with priority \`league > org > global\` so org-scoped tournaments still surface the MMR field. Wires \`useOrgStore.currentOrg\` into the page.

Closes #195

## Test plan
- [ ] \`frontend/app/pages/tournament/hasErrors.test.tsx\` — 4 unit tests covering scope priority
- [ ] Manual: tournament edit page with no league, currentOrg set → MMR field renders

---
Split out of #204.