### PR TITLE
feat(discord-embeds): show up to 40 signups, auto-split fields over 1024 chars

### DIFF
--- a/backend/events/discord/embeds.py
+++ b/backend/events/discord/embeds.py
@@ -44,7 +44,7 @@ def _signup_counts(event):
     return len(active), len(confirmed)
 
 
-def _user_list(signups, max_items=20):
+def _user_list(signups, max_items=40):
     """Build a newline-separated list of user display names from signups."""
     lines = []
     for s in signups[:max_items]:
@@ -55,7 +55,7 @@ def _user_list(signups, max_items=20):
     return "\n".join(lines) if lines else "*None yet*"
 
 
-def _user_list_quoted(signups, max_items=20, numbered=True):
+def _user_list_quoted(signups, max_items=40, numbered=True):
     """Build a blockquoted numbered list of user display names from signups."""
     lines = []
     for i, s in enumerate(signups[:max_items], 1):
@@ -68,6 +68,64 @@ def _user_list_quoted(signups, max_items=20, numbered=True):
     if remaining > 0:
         lines.append(f"> *and {remaining} more...*")
     return "\n".join(lines) if lines else "> *—*"
+
+
+EMBED_FIELD_VALUE_LIMIT = 1024  # Discord per-field char limit
+
+
+class _IconStrip:
+    """Wraps a signup object with an icon prefix prepended to display_name."""
+
+    def __init__(self, s, icon):
+        self._s = s
+        self.display_name = f"{icon} {s.display_name}"
+        self.status = s.status
+
+
+def build_user_list_fields(signups, *, name, inline=True, max_items=40, numbered=False):
+    """Build one or more embed fields for a signup list.
+
+    Returns a list of {name, value, inline} dicts. Splits into a 'cont.' field
+    when the joined line set would exceed Discord's 1024-char per-field limit.
+    Empty input returns a single field with '*None yet*'.
+    """
+    if not signups:
+        return [{"name": name, "value": "*None yet*", "inline": inline}]
+
+    capped = signups[:max_items]
+    remaining = len(signups) - max_items
+
+    lines = []
+    for i, s in enumerate(capped, 1):
+        line = f"> {i}. {s.display_name}" if numbered else s.display_name
+        lines.append(line)
+    if remaining > 0:
+        lines.append(f"*and {remaining} more...*")
+
+    fields = []
+    bucket: list = []
+    bucket_len = 0
+    for line in lines:
+        added = len(line) + (1 if bucket else 0)  # +1 for "\n" separator
+        if bucket_len + added > EMBED_FIELD_VALUE_LIMIT:
+            fields.append({
+                "name": name if not fields else f"{name} (cont.)",
+                "value": "\n".join(bucket),
+                "inline": inline,
+            })
+            bucket = [line]
+            bucket_len = len(line)
+        else:
+            bucket.append(line)
+            bucket_len += added
+
+    if bucket:
+        fields.append({
+            "name": name if not fields else f"{name} (cont.)",
+            "value": "\n".join(bucket),
+            "inline": inline,
+        })
+    return fields
 
 
 def build_announcement_embeds(event):
@@ -118,22 +176,19 @@ def build_announcement_embeds(event):
     all_signups = get_event_signups(event.pk)
 
     active = [s for s in all_signups if s.status not in INACTIVE_STATUSES]
-    active_lines = []
-    for s in active[:20]:
-        icon = "\u2705" if s.status in CONFIRMED_STATUSES else "\u23f3"
-        active_lines.append(f"{icon} {s.display_name}")
-    if len(active) > 20:
-        active_lines.append(f"*and {len(active) - 20} more...*")
     count = len(active)
     max_display = str(event.max_players) if event.max_players else "\u221e"
 
-    participant_fields = [
-        {
-            "name": f"\u2705 Signed Up ({count}/{max_display})",
-            "value": "\n".join(active_lines) if active_lines else "*None yet*",
-            "inline": True,
-        },
+    icon_signups = [
+        _IconStrip(s, "\u2705" if s.status in CONFIRMED_STATUSES else "\u23f3")
+        for s in active
     ]
+    participant_fields = build_user_list_fields(
+        icon_signups,
+        name=f"\u2705 Signed Up ({count}/{max_display})",
+        inline=True,
+        numbered=False,
+    )
 
     declined = [s for s in all_signups if s.status in DECLINED_STATUSES]
     participant_fields.append(
@@ -233,23 +288,27 @@ def build_announcement_v2(event):
 
     # Signed Up
     active = [s for s in all_signups if s.status not in INACTIVE_STATUSES]
-    active_lines = []
-    for i, s in enumerate(active[:20], 1):
-        if s.status in CONFIRMED_STATUSES:
-            active_lines.append(f"> {i}. {s.display_name}")
-        else:
-            active_lines.append(f"> {i}. *{s.display_name} (pending)*")
-    if len(active) > 20:
-        active_lines.append(f"> *and {len(active) - 20} more...*")
     count = len(active)
     max_display = str(event.max_players) if event.max_players else "\u221e"
-    fields.append(
-        {
-            "name": f"\u2705 Signed Up ({count}/{max_display})",
-            "value": "\n".join(active_lines) if active_lines else "> *None yet*",
-            "inline": True,
-        }
-    )
+
+    class _PendingStrip:
+        """Wraps signup with blockquote + pending suffix for non-confirmed."""
+
+        def __init__(self, s, idx):
+            self.status = s.status
+            if s.status in CONFIRMED_STATUSES:
+                self.display_name = f"> {idx}. {s.display_name}"
+            else:
+                self.display_name = f"> {idx}. *{s.display_name} (pending)*"
+
+    pending_signups = [_PendingStrip(s, i) for i, s in enumerate(active, 1)]
+    for field in build_user_list_fields(
+        pending_signups,
+        name=f"\u2705 Signed Up ({count}/{max_display})",
+        inline=True,
+        numbered=False,
+    ):
+        fields.append(field)
 
     # Declined
     declined = [s for s in all_signups if s.status in DECLINED_STATUSES]

--- a/backend/events/tests/test_embeds_user_list.py
+++ b/backend/events/tests/test_embeds_user_list.py
@@ -1,0 +1,63 @@
+"""Issue #194 — show up to 40 users, splitting fields on >1024-char overflow."""
+
+from unittest.mock import MagicMock
+from django.test import TestCase
+
+
+def _mock_signup(name, status="confirmed"):
+    s = MagicMock()
+    s.display_name = name
+    s.status = status
+    return s
+
+
+class UserListSplitTest(TestCase):
+    """40-cap and 1024-char auto-split."""
+
+    def test_under_40_short_names_single_field(self):
+        from events.discord.embeds import _user_list
+        signups = [_mock_signup(f"player{i}") for i in range(35)]
+        result = _user_list(signups)
+        # Single field: newline-joined, no "and N more"
+        self.assertNotIn("and ", result)
+        self.assertEqual(result.count("\n"), 34)
+
+    def test_exactly_40_short_names_single_field_no_truncation(self):
+        from events.discord.embeds import _user_list
+        signups = [_mock_signup(f"player{i}") for i in range(40)]
+        result = _user_list(signups)
+        self.assertNotIn("and ", result)
+        self.assertEqual(result.count("\n"), 39)
+
+    def test_over_40_truncates_to_first_40(self):
+        from events.discord.embeds import _user_list
+        signups = [_mock_signup(f"player{i}") for i in range(45)]
+        result = _user_list(signups)
+        self.assertIn("and 5 more", result)
+
+    def test_long_names_split_into_two_fields(self):
+        """Field value can't exceed 1024 chars — overflow goes to a continuation field."""
+        from events.discord.embeds import build_user_list_fields
+        # 40 × ~32-char Discord usernames = ~1280 chars > 1024
+        long = "a" * 30
+        signups = [_mock_signup(f"{long}{i:02}") for i in range(40)]
+        fields = build_user_list_fields(signups, name="Signed Up", inline=True)
+
+        self.assertEqual(len(fields), 2)
+        self.assertEqual(fields[0]["name"], "Signed Up")
+        self.assertEqual(fields[1]["name"], "Signed Up (cont.)")
+        self.assertLessEqual(len(fields[0]["value"]), 1024)
+        self.assertLessEqual(len(fields[1]["value"]), 1024)
+
+    def test_short_names_dont_split(self):
+        from events.discord.embeds import build_user_list_fields
+        signups = [_mock_signup(f"p{i:02}") for i in range(40)]
+        fields = build_user_list_fields(signups, name="Signed Up", inline=True)
+        self.assertEqual(len(fields), 1)
+        self.assertEqual(fields[0]["name"], "Signed Up")
+
+    def test_empty_input_returns_none_yet(self):
+        from events.discord.embeds import build_user_list_fields
+        fields = build_user_list_fields([], name="Signed Up", inline=True)
+        self.assertEqual(len(fields), 1)
+        self.assertEqual(fields[0]["value"], "*None yet*")


### PR DESCRIPTION
## Summary
Raises the Discord signup-embed user-list cap from 20 → 40, and auto-splits at the 1024-char Discord embed field limit into \`(cont.)\` continuation fields so long lists don't truncate.

Closes #194

## Test plan
- [ ] \`backend/events/tests/test_embeds_user_list.py\` — field split at 1024-char boundary
- [ ] Manual: event with 25+ signups → embed renders cleanly across split fields

---
Split out of #204.