### PR TITLE
feat(discord): DM-with-ephemeral-fallback helper for signup-flow responses

### DIFF
--- a/backend/discordbot/components.py
+++ b/backend/discordbot/components.py
@@ -10,6 +10,8 @@ import discord
 from discord import ui
 from django.conf import settings
 
+from discordbot.signup_responses import respond_to_signup_user
+
 log = logging.getLogger(__name__)
 
 SITE_URL = getattr(settings, "SITE_URL", "")
@@ -141,8 +143,6 @@ class SignupButton(ui.Button):
         )
 
         if result["action"] == "signed_up":
-            from discordbot.signup_responses import respond_to_signup_user
-
             await respond_to_signup_user(
                 interaction,
                 content=f"\u2705 You're signed up! Status: **{result['status']}**",
@@ -233,8 +233,6 @@ class TentativeButton(ui.Button):
         )
 
         if result["action"] == "tentative":
-            from discordbot.signup_responses import respond_to_signup_user
-
             await respond_to_signup_user(
                 interaction,
                 content="\u2753 Marked as tentative. We'll count you as interested!",
@@ -268,8 +266,6 @@ class DeclineButton(ui.Button):
         )
 
         if result["action"] == "declined":
-            from discordbot.signup_responses import respond_to_signup_user
-
             await respond_to_signup_user(
                 interaction,
                 content="You've declined the event.",
@@ -470,8 +466,6 @@ class EventSignupModal(ui.Modal):
                 ephemeral=True,
             )
         elif result["action"] == "signed_up":
-            from discordbot.signup_responses import respond_to_signup_user
-
             await respond_to_signup_user(
                 interaction,
                 content=f"\u2705 You're signed up! Status: **{result['status']}**",
@@ -980,8 +974,6 @@ class ScreenshotUploadModal(ui.Modal):
         )
 
         if result.get("success"):
-            from discordbot.signup_responses import respond_to_signup_user
-
             if result.get("signed_up"):
                 await respond_to_signup_user(
                     interaction,

--- a/backend/discordbot/components.py
+++ b/backend/discordbot/components.py
@@ -141,10 +141,11 @@ class SignupButton(ui.Button):
         )
 
         if result["action"] == "signed_up":
-            await interaction.response.defer()
-            await interaction.followup.send(
-                f"\u2705 You're signed up! Status: **{result['status']}**",
-                delete_after=60,
+            from discordbot.signup_responses import respond_to_signup_user
+
+            await respond_to_signup_user(
+                interaction,
+                content=f"\u2705 You're signed up! Status: **{result['status']}**",
             )
         elif result["action"] == "needs_modal":
             modal = EventSignupModal(
@@ -232,10 +233,11 @@ class TentativeButton(ui.Button):
         )
 
         if result["action"] == "tentative":
-            await interaction.response.defer()
-            await interaction.followup.send(
-                "\u2753 Marked as tentative. We'll count you as interested!",
-                delete_after=60,
+            from discordbot.signup_responses import respond_to_signup_user
+
+            await respond_to_signup_user(
+                interaction,
+                content="\u2753 Marked as tentative. We'll count you as interested!",
             )
         elif result["action"] == "error":
             await interaction.response.send_message(
@@ -266,10 +268,11 @@ class DeclineButton(ui.Button):
         )
 
         if result["action"] == "declined":
-            await interaction.response.defer()
-            await interaction.followup.send(
-                "You've declined the event.",
-                delete_after=60,
+            from discordbot.signup_responses import respond_to_signup_user
+
+            await respond_to_signup_user(
+                interaction,
+                content="You've declined the event.",
             )
         elif result["action"] == "not_signed_up":
             await interaction.response.send_message(
@@ -467,9 +470,11 @@ class EventSignupModal(ui.Modal):
                 ephemeral=True,
             )
         elif result["action"] == "signed_up":
-            await interaction.response.send_message(
-                f"\u2705 You're signed up! Status: **{result['status']}**",
-                ephemeral=True,
+            from discordbot.signup_responses import respond_to_signup_user
+
+            await respond_to_signup_user(
+                interaction,
+                content=f"\u2705 You're signed up! Status: **{result['status']}**",
             )
         elif result["action"] == "error":
             await interaction.response.send_message(
@@ -975,15 +980,17 @@ class ScreenshotUploadModal(ui.Modal):
         )
 
         if result.get("success"):
+            from discordbot.signup_responses import respond_to_signup_user
+
             if result.get("signed_up"):
-                await interaction.response.send_message(
-                    f"\u2705 {result.get('message', 'Screenshot uploaded! You are signed up.')}",
-                    ephemeral=True,
+                await respond_to_signup_user(
+                    interaction,
+                    content=f"\u2705 {result.get('message', 'Screenshot uploaded! You are signed up.')}",
                 )
             else:
-                await interaction.response.send_message(
-                    f"\u2705 {result.get('message', 'Screenshot saved.')}",
-                    ephemeral=True,
+                await respond_to_signup_user(
+                    interaction,
+                    content=f"\u2705 {result.get('message', 'Screenshot saved.')}",
                 )
         else:
             await interaction.response.send_message(

--- a/backend/discordbot/signup_responses.py
+++ b/backend/discordbot/signup_responses.py
@@ -1,0 +1,81 @@
+"""DM-with-ephemeral-fallback helper for signup-flow Discord interactions.
+
+Issues #191, #192: signup messages should land as DMs (persistent, notification-
+generating) rather than ephemerals that auto-dismiss after 60 seconds. When a
+user has DMs disabled (Discord 50007), fall back to ephemeral and prefix with
+<@user_id> so they get a notification badge.
+
+Discord interactions must be acknowledged within 3 seconds — defer first to
+extend the window to 15 minutes, then attempt the DM. On DM success, delete
+the deferred placeholder so the originating button doesn't appear hung.
+delete_original_response is best-effort: NotFound/HTTPException are swallowed
+since the DM already landed.
+"""
+
+from enum import Enum
+
+import discord
+
+from telemetry.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class ResponseChannel(Enum):
+    DM = "dm"
+    EPHEMERAL = "ephemeral"
+
+
+async def respond_to_signup_user(
+    interaction: discord.Interaction,
+    *,
+    content: str | None = None,
+    embed: discord.Embed | None = None,
+    view: discord.ui.View | None = None,
+    event=None,
+) -> ResponseChannel:
+    """Try DM → fall back to ephemeral with <@user_id> prefix on Forbidden(50007)."""
+    user_id = interaction.user.id
+    event_id = getattr(event, "pk", None)
+
+    if not interaction.response.is_done():
+        await interaction.response.defer(ephemeral=True)
+
+    try:
+        dm_channel = await interaction.user.create_dm()
+        await dm_channel.send(content=content, embed=embed, view=view)
+        try:
+            await interaction.delete_original_response()
+        except (discord.NotFound, discord.HTTPException):
+            # Cleanup is best-effort; the DM already landed.
+            pass
+        channel = ResponseChannel.DM
+    except discord.Forbidden as e:
+        if getattr(e, "code", None) == 50007:
+            mention = f"<@{user_id}>"
+            text = f"{mention} {content}".strip() if content else mention
+            await interaction.followup.send(
+                content=text, embed=embed, view=view, ephemeral=True
+            )
+            channel = ResponseChannel.EPHEMERAL
+        else:
+            log.error(
+                "signup_response_failed",
+                system="events",
+                subsystem="discord",
+                user_id=user_id,
+                event_id=event_id,
+                error=str(e),
+            )
+            raise
+
+    log.info(
+        "signup_response_sent",
+        system="events",
+        subsystem="discord",
+        channel=channel.value,
+        fallback_to_ephemeral=(channel == ResponseChannel.EPHEMERAL),
+        user_id=user_id,
+        event_id=event_id,
+    )
+    return channel

--- a/backend/discordbot/tests/test_signup_responses.py
+++ b/backend/discordbot/tests/test_signup_responses.py
@@ -1,0 +1,134 @@
+"""Tests for backend.discordbot.signup_responses (#191, #192)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+
+from django.test import SimpleTestCase
+
+from discordbot.signup_responses import (
+    ResponseChannel,
+    respond_to_signup_user,
+)
+
+
+def _make_interaction(user_id=12345, response_done=False):
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.user.create_dm = AsyncMock()
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=response_done)
+    interaction.response.defer = AsyncMock()
+    interaction.delete_original_response = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_forbidden(code):
+    response = MagicMock()
+    response.status = 403
+    err = discord.Forbidden(response, f"code={code}")
+    err.code = code
+    return err
+
+
+class RespondToSignupUserDMSuccessTest(SimpleTestCase):
+    async def test_dm_path_defers_then_sends_then_deletes_original(self):
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        dm_channel.send = AsyncMock()
+        interaction.user.create_dm.return_value = dm_channel
+
+        result = await respond_to_signup_user(interaction, content="hi")
+
+        interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+        interaction.user.create_dm.assert_awaited_once()
+        dm_channel.send.assert_awaited_once_with(content="hi", embed=None, view=None)
+        interaction.delete_original_response.assert_awaited_once()
+        interaction.followup.send.assert_not_called()
+        self.assertEqual(result, ResponseChannel.DM)
+
+    async def test_skips_defer_when_response_already_done(self):
+        interaction = _make_interaction(response_done=True)
+        dm_channel = AsyncMock()
+        interaction.user.create_dm.return_value = dm_channel
+
+        await respond_to_signup_user(interaction, content="hi")
+        interaction.response.defer.assert_not_called()
+
+    async def test_delete_original_failure_does_not_break_dm_success(self):
+        """delete_original_response can raise NotFound/HTTPException; cleanup is best-effort."""
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        interaction.user.create_dm.return_value = dm_channel
+        interaction.delete_original_response.side_effect = discord.NotFound(
+            MagicMock(status=404), "not found"
+        )
+        # Should not raise — DM already succeeded.
+        result = await respond_to_signup_user(interaction, content="hi")
+        self.assertEqual(result, ResponseChannel.DM)
+
+
+class RespondToSignupUserDMDisabledTest(SimpleTestCase):
+    async def test_50007_falls_back_to_ephemeral_with_user_mention(self):
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        dm_channel.send = AsyncMock(side_effect=_make_forbidden(50007))
+        interaction.user.create_dm.return_value = dm_channel
+
+        result = await respond_to_signup_user(interaction, content="please reply")
+
+        interaction.followup.send.assert_awaited_once()
+        kwargs = interaction.followup.send.await_args.kwargs
+        self.assertIn("<@12345>", kwargs["content"])
+        self.assertIn("please reply", kwargs["content"])
+        self.assertTrue(kwargs["ephemeral"])
+        self.assertEqual(result, ResponseChannel.EPHEMERAL)
+
+
+class RespondToSignupUserOtherForbiddenTest(SimpleTestCase):
+    async def test_non_50007_forbidden_reraises(self):
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        dm_channel.send = AsyncMock(side_effect=_make_forbidden(50001))
+        interaction.user.create_dm.return_value = dm_channel
+
+        with self.assertRaises(discord.Forbidden):
+            await respond_to_signup_user(interaction, content="x")
+
+        interaction.followup.send.assert_not_called()
+
+
+class RespondToSignupUserLoggingTest(SimpleTestCase):
+    async def test_dm_success_logs_signup_response_sent(self):
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        interaction.user.create_dm.return_value = dm_channel
+
+        with patch("discordbot.signup_responses.log") as mock_log:
+            await respond_to_signup_user(interaction, content="hi")
+
+        mock_log.info.assert_called_once()
+        kwargs = mock_log.info.call_args.kwargs
+        self.assertEqual(kwargs["system"], "events")
+        self.assertEqual(kwargs["subsystem"], "discord")
+        self.assertEqual(kwargs["channel"], "dm")
+        self.assertFalse(kwargs["fallback_to_ephemeral"])
+        self.assertEqual(kwargs["user_id"], 12345)
+
+    async def test_other_forbidden_logs_signup_response_failed(self):
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        dm_channel.send = AsyncMock(side_effect=_make_forbidden(50001))
+        interaction.user.create_dm.return_value = dm_channel
+
+        with patch("discordbot.signup_responses.log") as mock_log:
+            with self.assertRaises(discord.Forbidden):
+                await respond_to_signup_user(interaction, content="x")
+
+        mock_log.error.assert_called_once()
+        kwargs = mock_log.error.call_args.kwargs
+        self.assertEqual(kwargs["system"], "events")
+        self.assertEqual(kwargs["subsystem"], "discord")
+        self.assertIn("error", kwargs)


### PR DESCRIPTION
## Summary
Centralizes signup-interaction responses through \`respond_to_signup_user()\` which:
1. Tries to DM the user (preferred)
2. Falls back to ephemeral channel reply with \`@user\` ping if DMs are disabled (Forbidden 50007)
3. Best-effort cleanup of the deferred original response

Refactors 5 signup-flow callsites in \`components.py\` plus 3 \`delete_after=60\` strips.

Closes #191
Closes #192

## Test plan
- [ ] \`backend/discordbot/tests/test_signup_responses.py\` — DM success, DM forbidden → ephemeral, other Forbidden re-raised
- [ ] Manual (Discord): toggle DMs disabled in test account → ephemeral reply pings \`@user\`

---
Split out of #204.