### PR TITLE
fix(events): start_tournament self-heals missing tournament + bulk-adds approved/confirmed users

### DIFF
--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -549,10 +549,14 @@ def ensure_tournament_with_signups(event):
         status__in=[SignupStatus.APPROVED, SignupStatus.CONFIRMED],
     ).select_related("user")
 
+    added_users = []
     for signup in confirmed_or_approved:
         tournament.users.add(signup.user)
+        added_users.append(signup.user)
 
-    invalidate_after_commit(tournament, event)
+    # M2M change invalidates both sides: tournament.users.all() AND user.tournament_set.all().
+    # cacheops doesn't auto-track M2M, so we invalidate every user we touched.
+    invalidate_after_commit(tournament, event, *added_users)
     return tournament
 
 

--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -527,6 +527,35 @@ def restart_event_tournament(event):
     return tournament
 
 
+@transaction.atomic
+def ensure_tournament_with_signups(event):
+    """Self-heal: create event.tournament if missing, bulk-add APPROVED + CONFIRMED users.
+
+    Issue #200 — start_tournament previously silently no-op'd when event.tournament
+    was None (legacy events created before perform_create wired create_tournament_for_event).
+    Idempotent: safe to call multiple times; M2M add() is a no-op for existing users.
+
+    Cache invalidation deferred to commit so the tournament UI reflects the bulk-add
+    immediately rather than after the cacheops 1-hour TTL — Django M2M does NOT
+    auto-invalidate cacheops.
+    """
+    if event.tournament is None:
+        create_tournament_for_event(event)
+        event.refresh_from_db()
+
+    tournament = event.tournament
+    confirmed_or_approved = EventSignup.objects.filter(
+        event=event,
+        status__in=[SignupStatus.APPROVED, SignupStatus.CONFIRMED],
+    ).select_related("user")
+
+    for signup in confirmed_or_approved:
+        tournament.users.add(signup.user)
+
+    invalidate_after_commit(tournament, event)
+    return tournament
+
+
 # ---------------------------------------------------------------------------
 # Event generation
 # ---------------------------------------------------------------------------

--- a/backend/events/tests/test_start_tournament_idempotent.py
+++ b/backend/events/tests/test_start_tournament_idempotent.py
@@ -73,16 +73,22 @@ class EnsureTournamentWithSignupsTest(TestCase):
     def test_invalidates_cacheops_after_m2m_add(self):
         """M2M add does not auto-invalidate cacheops; ensure_tournament_with_signups must.
 
-        Mock invalidate_after_commit and assert it's called with the tournament
-        and event after the M2M add. This is more deterministic than measuring a
-        live cache state, and captures the actual invariant we care about: 'the
-        M2M path goes through invalidate_after_commit'.
+        The M2M change affects both sides of the relation — tournament.users.all()
+        AND user.tournament_set.all() — so we invalidate the tournament, the event,
+        AND every user we added. Mocking invalidate_after_commit is more deterministic
+        than measuring live cache state and captures the actual invariant.
         """
         from unittest.mock import patch
 
         self._make_signup(self.users[0], "approved")
+        self._make_signup(self.users[1], "confirmed")
         with patch("events.services.invalidate_after_commit") as mock_inv:
             ensure_tournament_with_signups(self.event)
 
         self.event.refresh_from_db()
-        mock_inv.assert_called_with(self.event.tournament, self.event)
+        mock_inv.assert_called_once()
+        args = mock_inv.call_args.args
+        self.assertEqual(args[0], self.event.tournament)
+        self.assertEqual(args[1], self.event)
+        # Both added users must be in the invalidation set
+        self.assertEqual(set(args[2:]), {self.users[0], self.users[1]})

--- a/backend/events/tests/test_start_tournament_idempotent.py
+++ b/backend/events/tests/test_start_tournament_idempotent.py
@@ -1,0 +1,88 @@
+"""Tests for events.services.ensure_tournament_with_signups (#200)."""
+
+from django.test import TestCase
+from django.utils import timezone as tz
+
+from app.models import CustomUser, Organization, PositionsModel
+from events.models import Event, EventSignup
+from events.services import ensure_tournament_with_signups
+
+
+class EnsureTournamentWithSignupsTest(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Start Tournament Org")
+        self.event = Event.objects.create(
+            name="Start Test Event",
+            organization=self.org,
+            scheduled_at=tz.now(),
+            timezone="UTC",
+            roll_call_enabled=True,
+        )
+        self.users = []
+        for i in range(5):
+            u = CustomUser.objects.create(
+                username=f"st_user_{i}",
+                positions=PositionsModel.objects.create(),
+            )
+            self.users.append(u)
+
+    def _make_signup(self, user, status):
+        return EventSignup.objects.create(event=self.event, user=user, status=status)
+
+    def test_creates_tournament_when_missing(self):
+        self.assertIsNone(self.event.tournament)
+        self._make_signup(self.users[0], "approved")
+        ensure_tournament_with_signups(self.event)
+        self.event.refresh_from_db()
+        self.assertIsNotNone(self.event.tournament)
+        self.assertEqual(self.event.tournament.users.count(), 1)
+
+    def test_adds_only_approved_and_confirmed_users(self):
+        self._make_signup(self.users[0], "approved")
+        self._make_signup(self.users[1], "confirmed")
+        self._make_signup(self.users[2], "rejected")
+        self._make_signup(self.users[3], "cancelled")
+        self._make_signup(self.users[4], "waitlisted")
+        ensure_tournament_with_signups(self.event)
+        self.event.refresh_from_db()
+        added_pks = set(self.event.tournament.users.values_list("pk", flat=True))
+        self.assertEqual(added_pks, {self.users[0].pk, self.users[1].pk})
+
+    def test_idempotent_when_called_twice(self):
+        self._make_signup(self.users[0], "approved")
+        self._make_signup(self.users[1], "confirmed")
+        ensure_tournament_with_signups(self.event)
+        ensure_tournament_with_signups(self.event)
+        self.event.refresh_from_db()
+        # Same two users, no duplicates (Django M2M add is a no-op on existing)
+        self.assertEqual(self.event.tournament.users.count(), 2)
+
+    def test_works_when_tournament_already_exists(self):
+        from events.services import create_tournament_for_event
+        create_tournament_for_event(self.event)
+        self.event.refresh_from_db()
+        existing_pk = self.event.tournament.pk
+
+        self._make_signup(self.users[0], "approved")
+        ensure_tournament_with_signups(self.event)
+        self.event.refresh_from_db()
+        # Same tournament, just with the user added
+        self.assertEqual(self.event.tournament.pk, existing_pk)
+        self.assertEqual(self.event.tournament.users.count(), 1)
+
+    def test_invalidates_cacheops_after_m2m_add(self):
+        """M2M add does not auto-invalidate cacheops; ensure_tournament_with_signups must.
+
+        Mock invalidate_after_commit and assert it's called with the tournament
+        and event after the M2M add. This is more deterministic than measuring a
+        live cache state, and captures the actual invariant we care about: 'the
+        M2M path goes through invalidate_after_commit'.
+        """
+        from unittest.mock import patch
+
+        self._make_signup(self.users[0], "approved")
+        with patch("events.services.invalidate_after_commit") as mock_inv:
+            ensure_tournament_with_signups(self.event)
+
+        self.event.refresh_from_db()
+        mock_inv.assert_called_with(self.event.tournament, self.event)

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -37,6 +37,7 @@ from events.services import (
     create_tournament_for_event,
     demote_to_waitlist,
     ensure_discord_event,
+    ensure_tournament_with_signups,
     finalize_event_tournament,
     process_rsvp,
     reinstate_signup,
@@ -606,20 +607,21 @@ class EventViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"])
     def start_tournament(self, request, pk=None):
-        """Start the tournament (after roll call or directly)."""
+        """Start the tournament (after roll call or directly).
+
+        Self-heals legacy events whose tournament is missing or empty (#200).
+        """
         event = self.get_object()
         if not has_event_staff_access(request.user, event):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
-            if event.state == EventState.ROLL_CALL:
-                event.transition_state(EventState.IN_PROGRESS)
-            elif event.state == EventState.SIGNUPS_OPEN:
-                event.transition_state(EventState.IN_PROGRESS)
-            else:
+            if event.state not in (EventState.ROLL_CALL, EventState.SIGNUPS_OPEN):
                 return Response(
                     {"error": f"Cannot start tournament from '{event.state}' state."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+            ensure_tournament_with_signups(event)
+            event.transition_state(EventState.IN_PROGRESS)
             finalize_event_tournament(event)
             # Start auto-create herodrafts polling if enabled
             if event.tournament and event.tournament.auto_create_hero_drafts:


### PR DESCRIPTION
## Summary
\`start_tournament\` previously silently no-op'd when \`event.tournament\` was None (legacy events created before \`perform_create\` wired \`create_tournament_for_event\`). Adds \`ensure_tournament_with_signups()\` that:

1. Creates the tournament if missing
2. Bulk-adds APPROVED + CONFIRMED signups via M2M (idempotent)
3. Invalidates cacheops on commit (Django M2M does NOT auto-invalidate)

Closes #200

## Test plan
- [ ] \`backend/events/tests/test_start_tournament_idempotent.py\` — 5 tests: missing tournament heals, double-call no-op, M2M idempotent, cache invalidates, only APPROVED/CONFIRMED bulk-added
- [ ] Manual: trigger start_tournament on a legacy event with no tournament → tournament created with all approved signups

---
Split out of #204.