### PR TITLE
fix(discord): rename discord_token env var to DISCORD_BOT_TOKEN

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,5 @@
 discord_secret=
 client_id=
-discord_token=
 STEAM_API_KEY=
 
 # Discord Bot

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -34,7 +34,7 @@ load_dotenv()
 DISCORD_API_BASE_URL = "https://discord.com/api"
 SOCIAL_AUTH_DISCORD_KEY = os.environ.get("client_id")
 SOCIAL_AUTH_DISCORD_SECRET = os.environ.get("discord_secret")
-DISCORD_BOT_TOKEN = os.environ.get("discord_token")
+DISCORD_BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN")
 DISCORD_GUILD_ID = 734185035623825559
 DISCORD_ADMIN_CHANNEL_ID = os.environ.get("DISCORD_ADMIN_CHANNEL_ID")
 DISCORD_PUBLIC_KEY = os.environ.get("DISCORD_PUBLIC_KEY")

--- a/backend/config/settings_celery.py
+++ b/backend/config/settings_celery.py
@@ -60,7 +60,7 @@ INTERNAL_SERVICE_TOKEN = os.environ.get("INTERNAL_SERVICE_TOKEN", "")
 # In TEST mode we still need this for the matching TEST_DISCORD_USER_ID path,
 # and in production for real DMs from Celery tasks. Read the same env var
 # the Daphne backend uses.
-DISCORD_BOT_TOKEN = os.environ.get("discord_token", "")
+DISCORD_BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
 
 # Public site URL used by Discord embed builders to construct links
 # (e.g. /herodraft/<id>, /tournament/<id>/teams/draft). Without this,

--- a/backend/events/tests/test_discord_integration.py
+++ b/backend/events/tests/test_discord_integration.py
@@ -42,7 +42,7 @@ def setUpModule():
     if not HAS_TOKEN:
         warnings.warn(
             "\n⚠️  DISCORD_BOT_TOKEN not set — all Discord integration tests will be skipped.\n"
-            "   Set discord_token in backend/.env to enable.",
+            "   Set DISCORD_BOT_TOKEN in backend/.env to enable.",
             stacklevel=1,
         )
     elif not HAS_MULTI_USER:


### PR DESCRIPTION
## Summary
Settings code already named the Django setting \`DISCORD_BOT_TOKEN\`, but read it from a lowercase \`discord_token\` env var — confusing for token rotation and inconsistent with other Discord env vars (\`DISCORD_ADMIN_CHANNEL_ID\`, \`DISCORD_PUBLIC_KEY\`, \`DISCORD_TEST_BOT_*_TOKEN\`).

Reads from \`DISCORD_BOT_TOKEN\` to match.

- \`backend/backend/settings.py\`
- \`backend/config/settings_celery.py\` (celery worker entrypoint)
- \`backend/.env.example\` — drop duplicate \`discord_token=\` line; the \`DISCORD_BOT_TOKEN=\` line was already present
- \`backend/events/tests/test_discord_integration.py\` — update help message

## Migration note for existing deployments
Rename the line in your local \`backend/.env\`:
\`\`\`
discord_token=<value>     →    DISCORD_BOT_TOKEN=<value>
\`\`\`
Then \`just dev::restart\` (or \`docker restart df-discord-bot-1\`).

## Test plan
- [ ] \`docker exec backend printenv DISCORD_BOT_TOKEN\` returns the token after rename + restart
- [ ] Discord bot logs in successfully (no \`LoginFailure: Improper token has been passed.\`)

---
Surfaced when investigating a discord-bot login failure during the #204 work; not associated with a tracked issue.