### PR TITLE
docs(events): per-game coverage + web vs Discord signup parity

### DIFF
--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -22,6 +22,27 @@ Organizations create one-off or recurring events that automatically generate tou
 
 ---
 
+## Supported Games
+
+Events are typed by `event.game_type` (set at event creation, immutable thereafter):
+
+| Game | `game_type` | Profile model | Web signup | Discord signup |
+|---|---|---|---|---|
+| Dota 2 | `1` | `PlayerDotaProfile` | ✓ (full modal) | ✓ |
+| Deadlock | `2` | `PlayerDeadlockProfile` | partial — Friend ID only today | ✓ (full modal) |
+
+The signup-modal field set is selected by `game_type`. Most rank/skill fields are **Dota-only**:
+
+- **Profile fields** (Dota-only): `positions` (carry/mid/offlane/soft_support/hard_support priorities 0–5), `rank_status` (active / previous / never), `rank_medal` (e.g. "Legend 4"), `battle_cup_tier` (1–8), `rank_screenshot`, `battlecup_screenshot`.
+- **Profile fields** (Deadlock-only): `rank` (free-text), `rank_date`.
+- **Profile fields** (shared): `unverified_friend_id` (mirrored to `CustomUser.steam_account_id` first-write-wins on approve).
+- **Event-config flags** (Dota-only): `allow_active_mmr`, `allow_previous_rank`, `allow_battlecup_rating`, `min_mmr`, `require_mmr_verified`, `discord_require_rank_screenshot`, `discord_require_battlecup_screenshot`.
+
+!!! note "Deadlock web parity"
+    The web signup modal currently only renders the optional Friend ID section for Deadlock events. The full Deadlock rank/date capture lives on the Discord side today (`PlayerDeadlockProfile` direct write). Web parity is tracked as a follow-up.
+
+---
+
 ## Features
 
 ### Event Creation
@@ -51,14 +72,43 @@ Admins configure default settings per organization. When creating new events, th
 | Profile reminder | DM users to complete their profile (Steam ID, MMR) |
 | Confirm attendance | Require Discord reply to confirm attendance on event day |
 
+**Discord signup pipeline** (Dota events): clicking *Sign Up* either signs the user up directly (profile complete) or opens a modal with rank-status select → position select view → optional medal+star follow-up → optional screenshot upload. Each step routes through `events.services.apply_signup_input` — the **same service the web `/signup/` endpoint uses** — so the two paths converge on identical writes. Deadlock signups take a separate Discord-only branch that writes `PlayerDeadlockProfile.rank` directly.
+
 ### RSVP & Signups
 
-Players RSVP from the event page. The signup flow respects event configuration:
+Players RSVP from the event page (web) or via the Discord signup post. The signup flow respects event configuration:
 
 - **Auto-approve** — signups go directly to Approved status
 - **Manual approval** — admin reviews and approves each signup
 - **Waitlist** — when max players is reached, new signups are waitlisted with position tracking
 - **Re-RSVP** — cancelled signups can re-register
+
+#### Web vs Discord parity
+
+Both signup paths funnel through `apply_signup_input` and write the same per-org `PlayerDotaProfile` row, so the two surfaces are interchangeable for Dota events. The table below shows where each field is captured and which model it lands on.
+
+| Field | Web (`/signup/`) | Discord modal | Storage |
+|---|---|---|---|
+| `unverified_friend_id` | ✓ when `require_steam_id` | ✓ modal text input | `PlayerDotaProfile.unverified_friend_id` (Dota) or `PlayerDeadlockProfile.unverified_friend_id`. First-write-wins mirror to `CustomUser.steam_account_id`. |
+| `positions` (Dota) | ✓ priority dict 0–5 per role (PositionForm) | ✓ slot-ordered list (1st / 2nd / 3rd choice selects) | `PlayerDotaProfile.pos_1..5` booleans (derived) **and** `CustomUser.positions` PositionsModel (priorities 1–5). Web sends a literal dict; Discord's `list[int]` is mapped to priorities by slot index (1st pick → priority 1, 2nd → 2, capped at 5; earliest slot wins on duplicate role). |
+| `rank_status` (Dota) | ✓ RankStatusRadioGroup | ✓ rank select | `PlayerDotaProfile.rank_status` |
+| `rank_medal` (Dota) | ✓ medal+star → joined ("Legend 4") | ✓ MedalSelect + StarSelect follow-up | `PlayerDotaProfile.rank_medal` |
+| `battle_cup_tier` (Dota) | ✓ when `rank_status="never"` | ✓ BattleCupTierSelect | `PlayerDotaProfile.battle_cup_tier` |
+| `rank_screenshot` (Dota) | ✓ URL field, validated for `.png/.jpg/.jpeg/.webp` | ✓ Discord attachment URL | `PlayerDotaProfile.rank_screenshot`. Required only when `rank_status="active"` and the event sets `discord_require_rank_screenshot`. "I had an MMR" (previous) records the rank via medal+star without a screenshot. |
+| `battlecup_screenshot` (Dota) | ✓ | ✓ | `PlayerDotaProfile.battlecup_screenshot` |
+| `deadlock_rank` | **not yet** | ✓ modal text | `PlayerDeadlockProfile.rank` |
+| `mmr` numeric (admin-only) | ✓ on approve (`mmr_override`) | ✓ on approve | `OrgUser.mmr`, `has_active_dota_mmr`, `dota_mmr_last_verified` — also emits an `OrgLog` `set_mmr` entry |
+
+The endpoint is a single canonical action accepting `{intent, profile}`; the older `/rsvp/` and `/tentative/` actions have been removed.
+
+#### Approve flow
+
+Admin approve uses `POST /api/event-signups/{id}/approve/` with optional `{ "mmr": <int> }`. On approve:
+
+- `EventSignup.status` → `approved`.
+- If `mmr` is supplied, `OrgUser.mmr` is written and the OrgLog records `set_mmr`. An `OrgUser` row is created if missing.
+- Friend ID is mirrored to `CustomUser.steam_account_id` if not yet set (first-write-wins).
+- **Approve does NOT mutate positions.** The legacy behavior that flattened `pos_N` booleans into `priority=1` on `CustomUser.positions` at approve time has been removed — priorities now come exclusively from the signup write via `apply_signup_input`, which is authoritative. The per-org `PlayerDotaProfile.pos_N` booleans are the derived binary view for that event.
 
 ### Repeater Subscriptions
 
@@ -74,16 +124,37 @@ See [Roll Call](events/roll-call.md) for the dedicated roll call feature documen
 
 ## API Endpoints
 
+### Events
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/events/` | List events (filterable by org, state) |
 | POST | `/api/events/` | Create event (org staff only) |
 | GET | `/api/events/{id}/` | Event detail |
-| POST | `/api/events/{id}/rsvp/` | RSVP for event |
+| POST | `/api/events/{id}/signup/` | Canonical signup. Body: `{"intent": "rsvp" \| "tentative", "profile": {...SignupInputPatch}}`. Replaces the deleted `/rsvp/` and `/tentative/` actions. |
+| POST | `/api/events/{id}/admin-signup/` | Staff signs another user up (e.g. via Discord interaction or manual add) |
 | POST | `/api/events/{id}/open_signups/` | Transition to signups_open |
 | POST | `/api/events/{id}/start_roll_call/` | Transition to roll_call |
-| POST | `/api/events/{id}/start_tournament/` | Start tournament |
+| POST | `/api/events/{id}/start_tournament/` | Start tournament with the confirmed roster |
 | POST | `/api/events/{id}/cancel/` | Cancel event |
+| GET | `/api/events/{id}/discord-logs/` | Discord notification audit log for the event's tournament |
+
+### Signup actions (admin)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/event-signups/{id}/approve/` | Approve a signup. Optional body `{"mmr": <int>}` writes `OrgUser.mmr` and logs `set_mmr`. Does NOT mutate positions. |
+| POST | `/api/event-signups/{id}/reject/` | Reject a signup |
+| POST | `/api/event-signups/{id}/confirm/` | Confirm attendance (roll-call) |
+| POST | `/api/event-signups/{id}/unconfirm/` | Reverse a confirm |
+| POST | `/api/event-signups/{id}/demote/` | Demote approved/confirmed back to pending |
+| POST | `/api/event-signups/{id}/cancel_signup/` | Cancel a signup (user or admin) |
+| POST | `/api/event-signups/{id}/reinstate/` | Re-enable a cancelled signup |
+
+### Repeaters & defaults
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
 | GET | `/api/events/repeaters/` | List repeaters |
 | POST | `/api/events/repeaters/{id}/subscribe/` | Subscribe to repeater |
 | POST | `/api/events/repeaters/{id}/unsubscribe/` | Unsubscribe |

--- a/docs/features/events/roll-call.md
+++ b/docs/features/events/roll-call.md
@@ -91,15 +91,21 @@ When an event reaches `max_players`, new RSVPs go to the waitlist:
 
 ## Configuration
 
-These event config fields control signup behavior:
+These event config fields control signup behavior. **Game** column flags fields that only apply to one game type (Dota 2 vs Deadlock).
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `auto_approve` | false | Auto-approve signups (skip pending state) |
-| `auto_confirm` | false | Auto-confirm approved signups |
-| `max_players` | null | Maximum signups before waitlisting |
-| `min_players` | null | Minimum confirmed players to start tournament |
-| `roll_call_enabled` | false | Require roll call before tournament start |
-| `require_steam_id` | false | Require Steam ID for approval |
-| `require_mmr_verified` | false | Require verified MMR for approval |
-| `require_profile_complete` | false | Require complete profile for approval |
+| Field | Default | Game | Description |
+|-------|---------|------|-------------|
+| `auto_approve` | false | any | Auto-approve signups (skip pending state) |
+| `auto_confirm` | false | any | Auto-confirm approved signups |
+| `max_players` | null | any | Maximum signups before waitlisting |
+| `min_players` | null | any | Minimum confirmed players to start tournament |
+| `roll_call_enabled` | false | any | Require roll call before tournament start |
+| `require_steam_id` | false | any | Require Steam ID (Dota Friend ID / Deadlock Friend ID) for approval |
+| `require_profile_complete` | false | any | Require complete profile for approval (per-game definition: Dota needs rank + positions; Deadlock needs `rank` text) |
+| `require_mmr_verified` | false | Dota | Require admin-verified MMR for approval |
+| `allow_active_mmr` | true | Dota | Allow signups that claim a current MMR rank |
+| `allow_previous_rank` | true | Dota | Allow signups that record a previously-held rank (no current screenshot required) |
+| `allow_battlecup_rating` | true | Dota | Allow Battle-Cup-only signups (`rank_status="never"` + tier) |
+| `min_mmr` | null | Dota | Minimum MMR threshold for auto-approval |
+| `discord_require_rank_screenshot` | false | Dota | Discord/web modal require a `.png/.jpg/.jpeg/.webp` rank screenshot for `rank_status="active"` only — "previous" rank captures the medal+star without a screenshot |
+| `discord_require_battlecup_screenshot` | false | Dota | Require a Battle Cup screenshot for `rank_status="never"` |


### PR DESCRIPTION
## Summary
- Adds a **Supported Games** section to `docs/features/events.md` distinguishing Dota 2 (`game_type=1`) from Deadlock (`game_type=2`), and listing which fields/event-config flags are Dota-only.
- Adds a **Web vs Discord parity** table under RSVP & Signups showing each field × signup surface × storage model. Documents the positions write-shape difference (web sends a 0–5 priority dict; Discord sends slot-ordered `list[int]` mapped to priorities 1–5 in `apply_signup_input`, earliest-slot-wins on duplicates).
- Adds an **Approve flow** subsection making explicit that admin approve writes `OrgUser.mmr` (with `OrgLog` `set_mmr`) and **no longer mutates positions** — the legacy \"flatten to priority=1\" behavior was removed in PR #217.
- Documents the **Discord signup pipeline** (modal → rank → positions → medal/star → screenshot) and that it shares `apply_signup_input` with the web `/signup/` endpoint.
- Fixes the **API Endpoints** table — `/rsvp/` and `/tentative/` are removed; the canonical endpoint is `POST /api/events/{id}/signup/` with body `{intent, profile}`. Admin signup-action endpoints (`approve / reject / confirm / unconfirm / demote / cancel_signup / reinstate`) added, plus `admin-signup` and `discord-logs`.
- `roll-call.md` configuration table gains a **Game** column. Flags `allow_active_mmr`, `allow_previous_rank`, `allow_battlecup_rating`, `min_mmr`, `require_mmr_verified`, `discord_require_rank_screenshot`, `discord_require_battlecup_screenshot` as Dota-only. Reworded `require_steam_id` and `require_profile_complete` to note per-game semantics.

## Why
The events docs predated PR #217 (web signup form). A reader had no way to tell:
- the signup-modal field set is gated by `event.game_type`
- most rank/skill event-config flags are Dota-only
- `/rsvp/` and `/tentative/` had been replaced by `/signup/`
- the web and Discord signup paths now converge on `apply_signup_input` (Dota), and Deadlock signup is Discord-only today

## Test plan
- [x] `mkdocs build` runs clean. The 19 strict-mode warnings that surface are all pre-existing link issues in `THEMING-GUIDE.md`, `theming-guide/*`, and `testing/playwright.md` — none reference `events.md` or `roll-call.md`.
- [ ] Visual sanity check via `just docs::serve` and skim the rendered pages.