### PR TITLE
fix(events): signup-positions testid + dialog overflow clipping

### DIFF
--- a/backend/tests/data/users.py
+++ b/backend/tests/data/users.py
@@ -675,7 +675,19 @@ EVENT_PLAYER_NO_PROFILE: TestUser = TestUser(
     discord_id="880000000000099999",
     steam_id_64=76561198900199999,
     mmr=None,
-    positions=TestPositions(),
+    # All-zero priorities so the EventSignupModal's prefill chip doesn't
+    # auto-collapse the position section for this user. Default
+    # TestPositions() seeds every role at 3 ("If the team needs"), which
+    # the modal interprets as "user has picked positions" and triggers
+    # the prefilled-summary chip — masking the picker in the @cicd
+    # "incomplete profile opens modal with all sections" spec.
+    positions=TestPositions(
+        carry=0,
+        mid=0,
+        offlane=0,
+        soft_support=0,
+        hard_support=0,
+    ),
 )
 
 EVENTS_USERS: list[TestUser] = [

--- a/frontend/app/components/events/EventSignupModal.tsx
+++ b/frontend/app/components/events/EventSignupModal.tsx
@@ -244,11 +244,20 @@ export function EventSignupModal({
     : null;
 
   const scrollableBody = (
-    // shadcn ScrollArea wraps a Radix Viewport (which IS the scroll container)
-    // with a custom-styled scrollbar that matches the brand. The Viewport gets
-    // size-full from the primitive; we make the outer Root flex-1/min-h-0 so
-    // it claims the remaining vertical space inside the form column.
+    // shadcn ScrollArea wraps a Radix Viewport (which IS the scroll
+    // container) with a brand-styled scrollbar. Playwright tests that target
+    // fields below the fold MUST focus() the target before click() — the
+    // Radix Viewport's overflow contract doesn't always respond to
+    // Playwright's auto-scrollIntoView. focus() triggers the browser's
+    // native scrollIntoView({block:'nearest'}) which DOES scroll the
+    // Viewport correctly. See 12-event-signup-form.spec.ts for the
+    // focus-before-click pattern.
     <ScrollArea
+      // flex-1 min-h-0 takes remaining space inside the form column;
+      // combined with overflow-hidden on the DialogContent (see below),
+      // this gives the Radix Viewport a definite parent height so its
+      // size-full resolves correctly, content actually clips inside the
+      // Viewport, and the brand-styled scrollbar appears as expected.
       className="flex-1 min-h-0 -mx-6 px-6"
       data-testid="event-signup-modal-body"
     >
@@ -399,7 +408,13 @@ export function EventSignupModal({
   if (isDesktop) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="flex max-h-[90vh] flex-col sm:max-w-2xl">
+        {/* overflow-hidden: shadcn's default DialogContent doesn't clip its
+            content, so without it long forms render past the dialog edge
+            even when max-h-[90vh] is set. Clipping here lets the inner
+            ScrollArea (Radix Viewport) get a definite height so size-full
+            resolves, content overflow is contained, and the brand scrollbar
+            appears. */}
+        <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
           </DialogHeader>

--- a/frontend/app/pages/profile/forms/position.tsx
+++ b/frontend/app/pages/profile/forms/position.tsx
@@ -29,6 +29,11 @@ type PositionFieldsProps = {
   /** Tailwind grid classes for the field grid. Override when embedding in a
    *  smaller container (e.g. the EventSignupModal uses 2 fixed columns). */
   gridClassName?: string;
+  /** Override the default data-testid. Defaults to `position-choices` so any
+   *  consumer (EditProfileModal, EventSignupModal, future callers) can find
+   *  this picker by a stable name. Each Select inside also carries
+   *  `data-testid="position-choice-<role>"` for direct selection. */
+  testId?: string;
 };
 
 const DEFAULT_GRID_CLASS =
@@ -39,9 +44,10 @@ const DEFAULT_GRID_CLASS =
 export const PositionFormFields = ({
   form,
   gridClassName,
+  testId = 'position-choices',
 }: PositionFieldsProps) => {
   return (
-    <div className={gridClassName ?? DEFAULT_GRID_CLASS}>
+    <div className={gridClassName ?? DEFAULT_GRID_CLASS} data-testid={testId}>
       <FormField
         control={form.control}
         name="positions.carry"
@@ -56,7 +62,7 @@ export const PositionFormFields = ({
                 defaultValue={field.value?.toString()}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger data-testid="position-choice-carry">
                     <SelectValue placeholder={PositionChoiceEnum[field.value]} />
                   </SelectTrigger>
                 </FormControl>
@@ -81,7 +87,7 @@ export const PositionFormFields = ({
                 defaultValue={field.value?.toString()}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger data-testid="position-choice-mid">
                     <SelectValue placeholder={PositionChoiceEnum[field.value]} />
                   </SelectTrigger>
                 </FormControl>
@@ -106,7 +112,7 @@ export const PositionFormFields = ({
                 defaultValue={field.value?.toString()}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger data-testid="position-choice-offlane">
                     <SelectValue placeholder={PositionChoiceEnum[field.value]} />
                   </SelectTrigger>
                 </FormControl>
@@ -131,7 +137,7 @@ export const PositionFormFields = ({
                 defaultValue={field.value?.toString()}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger data-testid="position-choice-soft_support">
                     <SelectValue placeholder={PositionChoiceEnum[field.value]} />
                   </SelectTrigger>
                 </FormControl>
@@ -156,7 +162,7 @@ export const PositionFormFields = ({
                 defaultValue={field.value?.toString()}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger data-testid="position-choice-hard_support">
                     <SelectValue placeholder={PositionChoiceEnum[field.value]} />
                   </SelectTrigger>
                 </FormControl>

--- a/frontend/tests/playwright/e2e/16-events/12-event-signup-form.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/12-event-signup-form.spec.ts
@@ -84,7 +84,7 @@ test.describe('Event Signup Form (@cicd)', () => {
     await expect(modal).toBeVisible();
     await expect(modal.getByTestId('signup-friend-id')).toBeVisible();
     await expect(modal.getByTestId('signup-rank-status')).toBeVisible();
-    await expect(modal.getByTestId('signup-positions')).toBeVisible();
+    await expect(modal.getByTestId('position-choices')).toBeVisible();
   });
 
   test('rank_status="never" reveals Battle Cup Tier (not Medal/Star)', async ({
@@ -144,7 +144,7 @@ test.describe('Event Signup Form (@cicd)', () => {
     await expect(modal.getByTestId('signup-friend-id')).toBeVisible();
     // Non-Dota game: rank-status / positions sections must not render.
     await expect(modal.getByTestId('signup-rank-status')).toHaveCount(0);
-    await expect(modal.getByTestId('signup-positions')).toHaveCount(0);
+    await expect(modal.getByTestId('position-choices')).toHaveCount(0);
   });
 
   test('upgrade tentative to rsvp re-runs gap evaluation', async ({ page, context }) => {


### PR DESCRIPTION
## Summary
Fixes the `12-event-signup-form.spec.ts:78` (\"incomplete profile opens modal with all sections\") test that started failing on main after PR #217.

- **PositionFormFields** now carries `data-testid=\"position-choices\"` (overridable via `testId` prop). Each per-role SelectTrigger also gets `data-testid=\"position-choice-<role>\"` for direct targeting. PR #217 deleted PositionPickerGrid (which had the testid) without porting the hook over.
- **`DialogContent` now has `overflow-hidden`** so the inner ScrollArea Viewport gets a definite height to clip against. Without it the form grew past the dialog edge, Playwright reported \"Element is outside of the viewport\" on click attempts to medal/star below the fold, and the screenshot showed Position rows rendering OUTSIDE the dialog box. Verified the root cause against the Radix scroll-area source — Viewport uses `size-full` which needs a parent with definite height.
- **Test data**: `EVENT_PLAYER_NO_PROFILE` was seeded with default `TestPositions()` which sets every role to priority=3, triggering the prefilled-summary chip and collapsing the position section. Overridden to all-zero priorities so the \"incomplete profile\" test actually sees the section.
- Test now uses `position-choices` instead of `signup-positions`.

## Test plan
- [x] `just test::pw::spec 12-event-signup-form` — 8/8 pass locally (22.6s)
- [ ] CI `@cicd` smoke set

No code-side hacks needed in the test — the overflow-hidden fix on DialogContent let Playwright's native auto-scrollIntoView do its job.