### PR TITLE
docs(brand): new theming reference — ScrollArea inside Dialog clipping

### DIFF
--- a/.claude/skills/brand/SKILL.md
+++ b/.claude/skills/brand/SKILL.md
@@ -59,6 +59,7 @@ All of the below live in `docs/theming-guide/ai/references/` (hidden from the Mk
 - [review-checklist.md](../../../docs/theming-guide/ai/references/review-checklist.md) — single ordered checklist; the spine of a review pass.
 - [grep-recipes.md](../../../docs/theming-guide/ai/references/grep-recipes.md) — copy-paste `rg` recipes for each anti-pattern.
 - [severity-rubric.md](../../../docs/theming-guide/ai/references/severity-rubric.md) — `block` / `warn` / `nit` definitions and output format.
+- [scrollbars-dialogs.md](../../../docs/theming-guide/ai/references/scrollbars-dialogs.md) — `<ScrollArea>` inside `<DialogContent>` contract: `overflow-hidden` clipping rule, why Radix Viewport's `size-full` needs a definite parent height, and the `-mx-6 px-6` padding-cancel trick.
 
 ## Updating This Skill
 

--- a/docs/THEMING-GUIDE.md
+++ b/docs/THEMING-GUIDE.md
@@ -224,6 +224,8 @@ The shadcn `DialogContent` default is `sm:max-w-lg` (32rem). That's right for **
 
 The `-mx-6 px-6` cancels the dialog's `p-6` for the viewport so the scrollbar sits flush against the edge without chopping content.
 
+See [`theming-guide/ai/references/scrollbars-dialogs.md`](theming-guide/ai/references/scrollbars-dialogs.md) for the full ScrollArea-inside-Dialog contract (the `overflow-hidden` rule, why Radix Viewport's `size-full` needs a definite parent height, and how to verify the dialog actually clips).
+
 ### 3D Depth Effects
 
 Buttons support a `depth` prop for 3D press effects:
@@ -518,6 +520,10 @@ The companion `brand` skill (`.claude/skills/brand/SKILL.md`) loads these same f
 ### Severity Rubric
 
 --8<-- "theming-guide/ai/references/severity-rubric.md"
+
+### ScrollArea inside Dialog
+
+--8<-- "theming-guide/ai/references/scrollbars-dialogs.md"
 
 ---
 

--- a/docs/theming-guide/ai/index.md
+++ b/docs/theming-guide/ai/index.md
@@ -23,6 +23,7 @@ The skill itself is short — it points back to the pages here. Update content *
 | [`review-checklist.md`](references/review-checklist.md) | Single ordered checklist to walk a diff. Each item links to the relevant section of `THEMING-GUIDE.md` for the *why*. |
 | [`grep-recipes.md`](references/grep-recipes.md) | Copy-paste `rg` recipes for finding each anti-pattern across `frontend/app/`. |
 | [`severity-rubric.md`](references/severity-rubric.md) | `block` / `warn` / `nit` definitions and review-output format. |
+| [`scrollbars-dialogs.md`](references/scrollbars-dialogs.md) | `<ScrollArea>` inside `<DialogContent>` contract — the `overflow-hidden` clipping rule, why Radix Viewport's `size-full` needs a definite parent height, and the `-mx-6 px-6` padding-cancel trick. |
 
 ## Hidden From MkDocs Nav
 

--- a/docs/theming-guide/ai/references/grep-recipes.md
+++ b/docs/theming-guide/ai/references/grep-recipes.md
@@ -126,6 +126,14 @@ rg -nB0 -A2 '<DialogContent' "$SCOPE" | rg -L 'max-w-'
 # the brand-styled scrollbar. The OS-default scrollbar inside a themed
 # dialog reads as visual drift. See THEMING-GUIDE.md §"Dialog Widths".
 rg -nB0 -A8 '<DialogContent' "$SCOPE" | rg -B1 -A2 'overflow-y-auto'
+
+# DialogContent with a <ScrollArea> child but no overflow-hidden — the
+# dialog won't clip, ScrollArea Root has no definite height, Radix Viewport
+# never enables its scrollbar. See scrollbars-dialogs.md for the full chain.
+# Block-severity finding (PR #220 broke a Playwright spec because of this).
+rg -nB0 -A12 '<DialogContent' "$SCOPE" \
+  | rg -B12 'ScrollArea' \
+  | rg -L 'overflow-hidden'
 ```
 
 ## Keyboard hints

--- a/docs/theming-guide/ai/references/scrollbars-dialogs.md
+++ b/docs/theming-guide/ai/references/scrollbars-dialogs.md
@@ -1,0 +1,61 @@
+# ScrollArea inside Dialog — clipping contract
+
+Long forms inside `<DialogContent>` MUST scroll via shadcn `<ScrollArea>`, not raw `overflow-y-auto`. The Radix Viewport gives a brand-styled thin scrollbar; the OS-default scrollbar inside an otherwise-themed dialog reads as visual drift.
+
+See [`THEMING-GUIDE.md` §"Dialog Widths"](../../THEMING-GUIDE.md#dialog-widths) for width conventions; this reference covers the **clipping contract** that makes the ScrollArea inside a Dialog actually work.
+
+## The rule
+
+When `<DialogContent>` contains a `<ScrollArea>` (or any flex child that's expected to scroll), `<DialogContent>` MUST carry `overflow-hidden`.
+
+```tsx
+// ✓ correct
+<DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-2xl">
+  <DialogHeader>…</DialogHeader>
+  <ScrollArea className="flex-1 min-h-0 -mx-6 px-6">
+    <div className="flex flex-col gap-4 pb-4">{/* form body */}</div>
+  </ScrollArea>
+  <DialogFooter>…</DialogFooter>
+</DialogContent>
+
+// ✗ wrong — form grows past the dialog edge, ScrollArea never scrolls
+<DialogContent className="flex max-h-[90vh] flex-col sm:max-w-2xl">
+  <ScrollArea className="flex-1 min-h-0 -mx-6 px-6">…</ScrollArea>
+</DialogContent>
+```
+
+Decision dialogs (`ConfirmDialog`, plain `AlertDialog` with two buttons) do NOT need this — their content fits and never overflows. The rule applies only to form-heavy modals with a `<ScrollArea>` child.
+
+## Why
+
+shadcn's default `DialogContent` has no `overflow-hidden`. Without it, the chain unravels:
+
+1. The form (`flex-1`) inside the dialog grows past `max-h-[90vh]` because nothing is clipping it.
+2. The `<ScrollArea>` Root with `flex-1 min-h-0` inherits the unconstrained height — it has no definite parent height to bound against.
+3. The Radix `<Viewport>` inside uses `height: 100%` (`size-full`). With no definite parent height, that resolves to `auto` (= content height).
+4. Radix sees `viewport.scrollHeight === viewport.clientHeight` (no internal overflow), keeps the Viewport's `overflow` at `hidden`, and never enables the scrollbar.
+5. Content renders past the dialog's visual edge. Users see broken layout; Playwright reports *"Element is outside of the viewport"* on clicks below the fold.
+
+The Radix Viewport IS the scrolling element (per [radix-ui/primitives scroll-area source](https://github.com/radix-ui/primitives/blob/main/packages/react/scroll-area/src/scroll-area.tsx)) — it sets `overflow: scroll` itself, conditional on detected overflow. Once `<DialogContent>` clips, all the height calculations resolve and Radix enables the scrollbar.
+
+## The `-mx-6 px-6` cancel trick
+
+`<DialogContent>` carries `p-6` (24px padding). A naive `<ScrollArea>` inside that padding renders its scrollbar 24px in from the dialog edge — visible whitespace on the right of the scrollbar that looks unfinished. Cancel the padding on the ScrollArea and re-add it on the inner content wrapper:
+
+```tsx
+<ScrollArea className="flex-1 min-h-0 -mx-6 px-6">  {/* cancel-then-readd */}
+  <div className="flex flex-col gap-4 pb-4">{/* content lives here */}</div>
+</ScrollArea>
+```
+
+This sits the scrollbar flush against the dialog's inner edge without chopping content horizontally.
+
+## Severity & review
+
+Form-heavy `<DialogContent>` with a `<ScrollArea>` (or any flex-scroll child) but no `overflow-hidden` is a `block` finding. Symptoms reviewers will see:
+
+- Visual: content rendering past the dialog's visual edge (often only visible at certain viewport sizes).
+- Playwright: `Element is outside of the viewport` errors when clicking fields below the fold.
+- Bug history: PR #220 fixed exactly this on the `EventSignupModal`.
+
+See [grep-recipes.md §Dialogs](grep-recipes.md#dialogs) for the `rg` recipe that flags this.


### PR DESCRIPTION
## Summary
Adds a new brand-review reference, `docs/theming-guide/ai/references/scrollbars-dialogs.md`, capturing the contract for using shadcn `<ScrollArea>` inside `<DialogContent>`. Documents:

- The `overflow-hidden` rule on form-heavy `<DialogContent>` whenever a `<ScrollArea>` (or any flex-scroll) child is present.
- **Why** the chain fails without it: shadcn's default `<DialogContent>` doesn't clip, so the form grows past the dialog edge; the `<ScrollArea>` Root inherits unconstrained height; the Radix `<Viewport>`'s `size-full` (height:100%) resolves to `auto`; Radix detects no overflow and keeps the Viewport at `overflow: hidden`; content renders past the dialog's visual edge; Playwright fails clicks below the fold with *"Element is outside of the viewport"*.
- The `-mx-6 px-6` padding-cancel trick so the brand-styled thin scrollbar sits flush against the dialog inner edge.
- Severity: `block`. PR #220 was caused by exactly this miss.

## Why a new reference (not edited inline)
The original Dialog Widths section in `THEMING-GUIDE.md` only covered widths + the bare "use ScrollArea, not overflow-y-auto" preference. The clipping contract is mechanically specific (Radix Viewport's `size-full` semantics, the `flex-1 min-h-0` chain, the `-mx-6 px-6` cancel trick) and worth its own grep-targetable reference. Splitting it out keeps `THEMING-GUIDE.md` skimmable for humans and gives `/review` runs a clean, focused file to load on demand.

## /brand-update lockstep
Followed the canonical workflow:

- New file: `docs/theming-guide/ai/references/scrollbars-dialogs.md` (61 lines).
- `docs/theming-guide/ai/index.md` — new row in the reference map.
- `docs/THEMING-GUIDE.md` — `--8<--` snippet block at the end of `## References`, plus a pointer from the existing §"Dialog Widths" section into the new reference.
- `.claude/skills/brand/SKILL.md` — bullet added to "References (loaded on demand)".
- `docs/theming-guide/ai/references/grep-recipes.md` — recipe that flags `<DialogContent>` with `<ScrollArea>` descendant but no `overflow-hidden` (block severity).

## Verification (workflow steps)
- [x] Snippet integrity: `ls references/*.md` matches the `--8<--` blocks in `THEMING-GUIDE.md`.
- [x] Line counts: `SKILL.md` 73, `scrollbars-dialogs.md` 61 — both under the 150-line cap. `grep-recipes.md` 172 and `inline-styles.md` 188 are pre-existing overflows, unchanged here.
- [x] `brand` skill `description` still 181 chars (≤200 cap).
- [x] `mkdocs.yml` `nav:` has zero `theming-guide/` entries — AI refs stay hidden from the rendered sidebar.
- [x] `mkdocs build` passes. The one new warning (`scrollbars-dialogs.md` → `../../THEMING-GUIDE.md#dialog-widths`) matches the pre-existing relative-link pattern shared by all other AI refs.