### PR TITLE
fix(events): surface Discord 403/400 errors on scheduled-event create

### DIFF
--- a/backend/discordbot/tests/test_lease_helpers.py
+++ b/backend/discordbot/tests/test_lease_helpers.py
@@ -3,9 +3,14 @@
 Uses Django's TestCase in-process ORM — the worker-side helpers POST over
 HTTP, but in tests we exercise the underlying Django views via an APIClient
 authenticated with the same X-Internal-Token header that workers use.
+
+InternalServiceAuth requires BOTH (a) the X-Internal-Token header to match
+settings.INTERNAL_SERVICE_TOKEN AND (b) the request IP to be in the
+allowlist. We pin a known token via @override_settings so the test container
+(where INTERNAL_SERVICE_TOKEN is unset by default) can authenticate; the
+APIClient request IP defaults to 127.0.0.1 which is in DEFAULT_ALLOWED_IPS.
 """
 
-import os
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -14,16 +19,16 @@ from discordbot.models import DiscordMessageLog
 
 
 CLAIM_PAYLOAD = dict(channel_id="ch_1", embed_data={"title": "test"})
+INTERNAL_TOKEN = "test-internal-token"
 
 
 def _internal_client():
     client = APIClient()
-    client.credentials(
-        HTTP_X_INTERNAL_TOKEN=os.environ.get("INTERNAL_SERVICE_TOKEN", "")
-    )
+    client.credentials(HTTP_X_INTERNAL_TOKEN=INTERNAL_TOKEN)
     return client
 
 
+@override_settings(INTERNAL_SERVICE_TOKEN=INTERNAL_TOKEN)
 class LeaseEndpointsTest(TestCase):
     def test_claim_returns_201_with_log_id(self):
         client = _internal_client()

--- a/backend/discordbot/utils.py
+++ b/backend/discordbot/utils.py
@@ -668,6 +668,9 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
     Returns:
         dict: API response or None on error
     """
+    from telemetry.logging import get_logger
+    structured_log = get_logger(__name__)
+
     url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
 
     payload = {}
@@ -676,15 +679,61 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
     if components is not None:
         payload["components"] = components
 
+    structured_log.info(
+        "discord_message_edit_attempt",
+        system="events",
+        subsystem="discord",
+        channel_id=str(channel_id),
+        message_id=str(message_id),
+        embed_count=len(payload.get("embeds", []) or []),
+        component_count=len(payload.get("components", []) or []),
+    )
     try:
         response = _rate_limited_request(
             "PATCH", url, json=payload, headers=_get_headers()
         )
-        response.raise_for_status()
-        log.info(f"Edited message {message_id} in channel {channel_id}")
+        if not (200 <= response.status_code < 300):
+            # Capture Discord's response body so 4xx errors (e.g. 404 Unknown
+            # Message — the channel/message pair the bot tries to edit no
+            # longer exists; this is the most likely "message got deleted"
+            # scenario) are visible in Grafana without a DB dive.
+            body = None
+            try:
+                body = response.json()
+            except Exception:
+                body = (response.text or "")[:500]
+            discord_code = body.get("code") if isinstance(body, dict) else None
+            discord_msg = body.get("message") if isinstance(body, dict) else None
+            structured_log.error(
+                "discord_message_edit_failed",
+                system="events",
+                subsystem="discord",
+                channel_id=str(channel_id),
+                message_id=str(message_id),
+                status_code=response.status_code,
+                discord_code=discord_code,
+                discord_message=discord_msg,
+            )
+            response.raise_for_status()
+        structured_log.info(
+            "discord_message_edit_success",
+            system="events",
+            subsystem="discord",
+            channel_id=str(channel_id),
+            message_id=str(message_id),
+        )
         return response.json()
     except requests.RequestException as e:
-        log.error(f"Failed to edit message {message_id}: {e}")
+        # Already logged the structured failure above when status_code was bad;
+        # this branch also catches network errors (timeouts, DNS, etc.).
+        structured_log.error(
+            "discord_message_edit_exception",
+            system="events",
+            subsystem="discord",
+            channel_id=str(channel_id),
+            message_id=str(message_id),
+            error=str(e),
+        )
         return None
 
 

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -118,10 +118,16 @@ def sync_discord_events():
     Runs every 5 minutes via celery beat. All reads via internal HTTP API.
     """
     from app.internal_client import get_sync_discord_state
+    from telemetry.logging import get_logger
+    structured_log = get_logger(__name__)
 
     state = get_sync_discord_state()
     if not state:
-        logger.error("Failed to fetch sync Discord state from internal API")
+        structured_log.error(
+            "sync_discord_state_fetch_failed",
+            system="events",
+            subsystem="discord",
+        )
         return "Failed: could not fetch sync state"
 
     existing_logs = {tuple(x) for x in state.existing_logs}
@@ -133,6 +139,16 @@ def sync_discord_events():
     notices_created = 0
     discord_events_created = 0
 
+    structured_log.info(
+        "sync_discord_events_start",
+        system="events",
+        subsystem="discord",
+        active_events=len(state.active_events),
+        events_with_signup_post=len(events_with_signup_post),
+        events_with_scheduled=len(events_with_scheduled),
+        events_with_recent_attempt=len(events_with_recent_attempt),
+    )
+
     for event in state.active_events:
         pk = event["pk"]
 
@@ -140,18 +156,37 @@ def sync_discord_events():
         has_signup = (
             pk in events_with_signup_post or ("event_announcement", pk) in existing_logs
         )
-        if (
+        signup_eligible = (
             event["state"] == "signups_open"
             and event["discord_announcement"]
             and event["discord_announcement_channel_id"]
             and not has_signup
-        ):
+        )
+        if signup_eligible:
+            structured_log.info(
+                "sync_signup_post_attempt",
+                system="events",
+                subsystem="discord",
+                event_id=pk,
+                channel_id=str(event.get("discord_announcement_channel_id") or ""),
+            )
             try:
                 send_event_announcement(pk)
                 signup_posts_created += 1
-                logger.info("Sync: created signup post for event %s", pk)
-            except Exception:
-                logger.exception("Sync: failed signup post for event %s", pk)
+                structured_log.info(
+                    "sync_signup_post_created",
+                    system="events",
+                    subsystem="discord",
+                    event_id=pk,
+                )
+            except Exception as e:
+                structured_log.exception(
+                    "sync_signup_post_failed",
+                    system="events",
+                    subsystem="discord",
+                    event_id=pk,
+                    error=str(e),
+                )
 
         # 2. Discord scheduled event
         has_scheduled = (
@@ -159,28 +194,50 @@ def sync_discord_events():
             or ("create_discord_event", pk) in existing_logs
             or pk in events_with_recent_attempt
         )
-        if (
+        sched_eligible = (
             event["discord_create_event"]
             and event["organization__discord_server_id"]
             and not has_scheduled
-        ):
+        )
+        if sched_eligible:
+            structured_log.info(
+                "sync_scheduled_event_attempt",
+                system="events",
+                subsystem="discord",
+                event_id=pk,
+                guild_id=str(event.get("organization__discord_server_id") or ""),
+            )
             try:
                 create_discord_scheduled_event(pk)
                 discord_events_created += 1
-                logger.info("Sync: created Discord scheduled event for event %s", pk)
-            except Exception:
-                logger.exception(
-                    "Sync: failed Discord scheduled event for event %s", pk
+                structured_log.info(
+                    "sync_scheduled_event_created",
+                    system="events",
+                    subsystem="discord",
+                    event_id=pk,
+                )
+            except Exception as e:
+                # create_discord_scheduled_event now raises with a Discord
+                # error string (PR #222). The structlog event captures it so
+                # operators can grep `sync_scheduled_event_failed` in Grafana
+                # to find every silent 403/400 without DB diving.
+                structured_log.exception(
+                    "sync_scheduled_event_failed",
+                    system="events",
+                    subsystem="discord",
+                    event_id=pk,
+                    error=str(e),
                 )
 
-    total = signup_posts_created + notices_created + discord_events_created
-    if total:
-        logger.info(
-            "sync_discord_events: %d signup posts, %d notices, %d scheduled events",
-            signup_posts_created,
-            notices_created,
-            discord_events_created,
-        )
+    structured_log.info(
+        "sync_discord_events_complete",
+        system="events",
+        subsystem="discord",
+        active_events=len(state.active_events),
+        signup_posts_created=signup_posts_created,
+        notices_created=notices_created,
+        scheduled_events_created=discord_events_created,
+    )
     return (
         f"Scanned {len(state.active_events)} events: "
         f"{signup_posts_created} signup posts, "
@@ -463,9 +520,24 @@ def send_signup_update(event_id):
     )
     from discordbot.utils import sync_edit_message
     from events.discord.embeds import build_announcement_v2
+    from telemetry.logging import get_logger
+    structured_log = get_logger(__name__)
+
+    structured_log.info(
+        "signup_update_start",
+        system="events",
+        subsystem="discord",
+        event_id=event_id,
+    )
 
     event = get_event_for_task(event_id)
     if not event:
+        structured_log.warning(
+            "signup_update_event_not_found",
+            system="events",
+            subsystem="discord",
+            event_id=event_id,
+        )
         return f"Failed: event {event_id} not found"
 
     # Try new model first
@@ -517,7 +589,11 @@ def send_signup_update(event_id):
 
     result = build_announcement_v2(event)
 
-    sync_edit_message(
+    # Tracks whether the edit landed — sync_edit_message returns None on
+    # failure (404 Unknown Message most often: the operator or another bot
+    # deleted the post outside our flow). Capture this so Grafana shows
+    # whether the next signup-update job was a no-op or a real recovery.
+    edit_response = sync_edit_message(
         channel_id=edit_channel_id,
         message_id=message_id,
         embed=result["embeds"],
@@ -538,9 +614,18 @@ def send_signup_update(event_id):
                 action="edit_signup_post",
                 target_type="DiscordEventMsgSignup",
                 message_id=message_id,
-                success=True,
+                success=edit_response is not None,
             )
 
+    structured_log.info(
+        "signup_update_complete",
+        system="events",
+        subsystem="discord",
+        event_id=event.pk,
+        message_id=str(message_id),
+        channel_id=str(edit_channel_id),
+        edit_succeeded=edit_response is not None,
+    )
     return f"Updated announcement for event {event.pk}"
 
 

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -624,20 +624,35 @@ def create_discord_scheduled_event(event_id):
         data = response.json()
         success = response.status_code in (200, 201)
 
+        # Extract the Discord-side error message from the response body
+        # (`{"message": "Missing Permissions", "code": 50013}` etc.) so the
+        # audit log surfaces it without anyone having to dig through
+        # response_data JSON. Default to the raw status when Discord
+        # didn't send a structured body.
+        error_message = ""
+        if not success:
+            if isinstance(data, dict) and data.get("message"):
+                error_message = (
+                    f"{data['message']} (code {data.get('code', '?')}, "
+                    f"HTTP {response.status_code})"
+                )
+            else:
+                error_message = f"HTTP {response.status_code}"
+
         # Legacy log via internal API
         create_message_log(
             channel_id=guild_id,
             embed_data=payload,
             source="create_discord_event",
             source_id=event.pk,
-            discord_message_id=data.get("id"),
+            discord_message_id=data.get("id") if isinstance(data, dict) else None,
             status_code=response.status_code,
             response_data=data,
             success=success,
         )
 
         # Store scheduled event ID via internal API
-        if success and data.get("id"):
+        if success and isinstance(data, dict) and data.get("id"):
             update_discord_event(discord_event_pk, scheduled_event_id=data["id"])
 
         # Audit log via internal API
@@ -648,9 +663,28 @@ def create_discord_scheduled_event(event_id):
             status_code=response.status_code,
             response_data=data,
             success=success,
+            error_message=error_message,
         )
 
+        if not success:
+            # Raise so the caller (sync_discord_events) logs an accurate
+            # "Sync: failed Discord scheduled event ..." line instead of
+            # "Sync: created ..." — the silent-success bug that caused 20+
+            # invisible 403 Missing-Permissions failures on prod (0.9.49).
+            logger.error(
+                "Discord scheduled-event create failed for event %s: %s",
+                event.pk, error_message,
+            )
+            raise RuntimeError(
+                f"Discord scheduled-event create failed for event {event.pk}: "
+                f"{error_message}"
+            )
+
         return f"Created Discord event for event {event.pk}"
+    except RuntimeError:
+        # Already logged + already wrote DiscordEventLog above. Re-raise so
+        # the caller's except branch fires (which emits "Sync: failed ...").
+        raise
     except Exception as e:
         create_message_log(
             channel_id=guild_id,

--- a/backend/events/tests/test_create_discord_scheduled_event.py
+++ b/backend/events/tests/test_create_discord_scheduled_event.py
@@ -1,0 +1,151 @@
+"""Tests for events.tasks.create_discord_scheduled_event.
+
+Pinning the contract that surfaced after the prod 0.9.49 incident:
+- On Discord API non-success (e.g., 403 Missing Permissions), the task MUST
+  raise so the caller (`sync_discord_events`) can record the failure and
+  emit an accurate log line. The previous behavior silently returned a
+  "Created Discord event for event X" success string while the underlying
+  API call returned 403 — `sync_discord_events` then logged
+  "Sync: created Discord scheduled event for event X" 20+ times despite
+  every attempt failing.
+- DiscordEventLog.error_message MUST be populated with the Discord error
+  string on non-success responses so operators don't have to inspect
+  response_data JSON to find out what went wrong.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+
+class CreateDiscordScheduledEventTest(TestCase):
+    """The task must NOT silently swallow Discord API non-success responses."""
+
+    def _mock_event(self):
+        from datetime import datetime, timezone
+
+        event = MagicMock()
+        event.pk = 12
+        event.discord_create_event = True
+        event.organization.discord_server_id = "734185035623825559"
+        event.discord_event_title = "Sunday Turbo Tournament"
+        event.description = "Test"
+        event.discord_event_description = ""
+        event.name = "Sunday Turbo Tournament"
+        event.scheduled_at = datetime(2026, 5, 17, 23, 0, tzinfo=timezone.utc)
+        return event
+
+    @patch("events.tasks.req.post" if False else "requests.post")
+    @patch("app.internal_client.create_event_log")
+    @patch("app.internal_client.create_message_log")
+    @patch("app.internal_client.update_discord_event")
+    @patch("app.internal_client.get_or_create_discord_event")
+    @patch("app.internal_client.get_event_for_task")
+    def test_raises_on_discord_403_missing_permissions(
+        self,
+        mock_get_event,
+        mock_get_de,
+        mock_update,
+        mock_message_log,
+        mock_event_log,
+        mock_post,
+    ):
+        """The exact prod scenario: bot lacks MANAGE_EVENTS in the guild.
+        Discord returns 403 with code 50013. The task MUST raise so the
+        caller knows to emit a 'failed' log, not 'created'."""
+        from events.tasks import create_discord_scheduled_event
+
+        mock_get_event.return_value = self._mock_event()
+        mock_get_de.return_value = MagicMock(
+            ok=True, json=lambda: {"id": 17}
+        )
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.json.return_value = {
+            "message": "Missing Permissions",
+            "code": 50013,
+        }
+        mock_post.return_value = resp
+
+        with self.assertRaises(Exception) as ctx:
+            create_discord_scheduled_event(12)
+
+        # The raised exception must surface the Discord error text so the
+        # caller's logger.exception() emits something operators can read.
+        self.assertIn("Missing Permissions", str(ctx.exception))
+        # scheduled_event_id must NOT be persisted on failure.
+        mock_update.assert_not_called()
+
+    @patch("requests.post")
+    @patch("app.internal_client.create_event_log")
+    @patch("app.internal_client.create_message_log")
+    @patch("app.internal_client.update_discord_event")
+    @patch("app.internal_client.get_or_create_discord_event")
+    @patch("app.internal_client.get_event_for_task")
+    def test_writes_error_message_to_event_log_on_failure(
+        self,
+        mock_get_event,
+        mock_get_de,
+        mock_update,
+        mock_message_log,
+        mock_event_log,
+        mock_post,
+    ):
+        """The DiscordEventLog row for the failed attempt must carry the
+        Discord error message in `error_message`, not just response_data."""
+        from events.tasks import create_discord_scheduled_event
+
+        mock_get_event.return_value = self._mock_event()
+        mock_get_de.return_value = MagicMock(
+            ok=True, json=lambda: {"id": 17}
+        )
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.json.return_value = {
+            "message": "Missing Permissions",
+            "code": 50013,
+        }
+        mock_post.return_value = resp
+
+        with self.assertRaises(Exception):
+            create_discord_scheduled_event(12)
+
+        # Audit log must include the human-readable error.
+        mock_event_log.assert_called_once()
+        kwargs = mock_event_log.call_args.kwargs
+        self.assertFalse(kwargs["success"])
+        self.assertIn("Missing Permissions", kwargs.get("error_message", ""))
+
+    @patch("requests.post")
+    @patch("app.internal_client.create_event_log")
+    @patch("app.internal_client.create_message_log")
+    @patch("app.internal_client.update_discord_event")
+    @patch("app.internal_client.get_or_create_discord_event")
+    @patch("app.internal_client.get_event_for_task")
+    def test_success_path_persists_scheduled_event_id(
+        self,
+        mock_get_event,
+        mock_get_de,
+        mock_update,
+        mock_message_log,
+        mock_event_log,
+        mock_post,
+    ):
+        """On 201 Created, the task should persist the new scheduled_event_id
+        and NOT raise — this is the happy path."""
+        from events.tasks import create_discord_scheduled_event
+
+        mock_get_event.return_value = self._mock_event()
+        mock_get_de.return_value = MagicMock(
+            ok=True, json=lambda: {"id": 17}
+        )
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.json.return_value = {"id": "1505242926014402792"}
+        mock_post.return_value = resp
+
+        result = create_discord_scheduled_event(12)
+        self.assertIn("Created", result)
+        mock_update.assert_called_once_with(
+            17, scheduled_event_id="1505242926014402792"
+        )

--- a/backend/events/tests/test_signup_writethrough.py
+++ b/backend/events/tests/test_signup_writethrough.py
@@ -63,27 +63,40 @@ class SignupWritethroughTest(TestCase):
         self.user.refresh_from_db()
         return signup
 
-    def test_positions_writethrough_last_write_wins(self):
-        """Submitted positions overwrite User.positions on each signup save.
+    def test_positions_writethrough_no_longer_runs_here(self):
+        """`apply_signup_writethrough` MUST NOT touch User.positions.
 
-        PositionsModel uses carry/mid/offlane/soft_support/hard_support (IntegerField,
-        0 = no play, 1 = plays it). PlayerDotaProfile uses boolean pos_1..5 booleans.
-        Writethrough maps pos_1→carry, pos_2→mid, pos_3→offlane, pos_4→soft_support,
-        pos_5→hard_support.
+        Position writethrough used to live here (mapping PlayerDotaProfile.pos_N
+        booleans to PositionsModel priorities flattened at 1). That was removed in
+        PR #217 because it overwrote the real per-role priorities (0..5) that
+        users now pick in the web signup modal — those land on user.positions
+        directly via `apply_signup_input` BEFORE `_create_signup` runs. Discord
+        users with `positions=list[int]` get slot-order-derived priorities
+        through the same `apply_signup_input` path. Re-introducing a flatten-
+        to-1 here would silently clobber both.
         """
-        # First signup — declares carry (pos_1) + mid (pos_2)
-        self._signup_with_positions(pos_1=True, pos_2=True)
-        self.assertEqual(self.user.positions.carry, 1)
-        self.assertEqual(self.user.positions.mid, 1)
-        self.assertEqual(self.user.positions.offlane, 0)
+        # Seed user.positions with real priorities (simulating what
+        # apply_signup_input wrote during the signup modal flow).
+        self.user.positions.carry = 1
+        self.user.positions.mid = 2
+        self.user.positions.offlane = 3
+        self.user.positions.soft_support = 0
+        self.user.positions.hard_support = 0
+        self.user.positions.save()
 
-        # Second signup — declares hard support (pos_5) only; carry+mid should be gone
-        EventSignup.objects.filter(event=self.event, user=self.user).delete()
-        self._signup_with_positions(pos_5=True)
+        # Signup with PlayerDotaProfile.pos_N flags set. The writethrough
+        # would, in the old behavior, have flattened all of these to 1.
+        self._signup_with_positions(
+            pos_1=True, pos_2=True, pos_3=True, pos_4=True, pos_5=True,
+        )
         self.user.positions.refresh_from_db()
-        self.assertEqual(self.user.positions.carry, 0)
-        self.assertEqual(self.user.positions.mid, 0)
-        self.assertEqual(self.user.positions.hard_support, 1)
+
+        # Priorities preserved — writethrough did not touch positions.
+        self.assertEqual(self.user.positions.carry, 1)
+        self.assertEqual(self.user.positions.mid, 2)
+        self.assertEqual(self.user.positions.offlane, 3)
+        self.assertEqual(self.user.positions.soft_support, 0)
+        self.assertEqual(self.user.positions.hard_support, 0)
 
 
 class SignupSteamIdWritethroughTest(SignupWritethroughTest):
@@ -126,31 +139,46 @@ class SignupWritethroughInvariantsTest(SignupWritethroughTest):
         self.assertEqual(self.org_user.mmr, 4500)
 
     def test_user_update_failure_rolls_back(self):
-        """If saving the User's positions fails, the writethrough is fully rolled back."""
+        """If an unprotected write inside `apply_signup_writethrough` fails, a
+        caller wrapping `signup.create + writethrough` in `transaction.atomic`
+        gets full rollback.
+
+        Post-#217 the writethrough is mostly defensive — the steam_id branch has
+        its own `try/except (ValueError, Exception)` to keep a steam-id sync
+        failure from blocking signup creation. The one unprotected call near
+        the end is `invalidate_after_commit`; patching it to raise tests the
+        rollback path realistically. Wrap in atomic to mirror the production
+        call pattern (`_create_signup` → `EventSignup.create` → writethrough,
+        all inside a transaction).
+        """
         from unittest.mock import patch
 
-        # Force PositionsModel.save to raise; verify nothing leaked through.
-        with patch("app.models.PositionsModel.save", side_effect=RuntimeError("boom")):
+        with patch(
+            "events.services.invalidate_after_commit",
+            side_effect=RuntimeError("boom"),
+        ):
             with self.assertRaises(RuntimeError):
-                self._signup_with_positions(pos_1=True)
+                with transaction.atomic():
+                    self._signup_with_positions(pos_1=True)
 
-        self.user.refresh_from_db()
-        # No partial state survived — carry should still be 0
-        self.assertEqual(self.user.positions.carry, 0)
+        # No partial state survived — the signup row was rolled back.
+        self.assertEqual(
+            EventSignup.objects.filter(event=self.event, user=self.user).count(),
+            0,
+        )
 
     def test_signup_create_rolls_back_when_writethrough_fails(self):
         """Spec invariant: signup save + writethrough share one transaction.atomic.
 
-        When a caller wraps EventSignup.objects.create + apply_signup_writethrough in
-        the same atomic block, a writethrough failure must roll back the signup too.
-
-        A PlayerDotaProfile must exist for the writethrough to reach PositionsModel.save
-        — without one it returns early and nothing raises.
+        When a caller wraps EventSignup.objects.create + apply_signup_writethrough
+        in the same atomic block, a writethrough failure must roll back the signup
+        too. Force the failure at `invalidate_after_commit` (the only unprotected
+        write in the writethrough's post-#217 body).
         """
         from unittest.mock import patch
         from events.services import apply_signup_writethrough
 
-        # Pre-create the dota profile so writethrough proceeds to PositionsModel.save
+        # Pre-create profile so the writethrough proceeds past its early returns.
         PlayerDotaProfile.objects.get_or_create(org_user=self.org_user)
 
         initial_signup_count = EventSignup.objects.filter(event=self.event).count()
@@ -159,12 +187,12 @@ class SignupWritethroughInvariantsTest(SignupWritethroughTest):
             with transaction.atomic():
                 signup = EventSignup.objects.create(event=self.event, user=self.user)
                 with patch(
-                    "app.models.PositionsModel.save",
+                    "events.services.invalidate_after_commit",
                     side_effect=RuntimeError("boom"),
                 ):
                     apply_signup_writethrough(signup)
 
-        # Signup AND writethrough rolled back as a unit
+        # Signup AND writethrough rolled back as a unit.
         self.assertEqual(
             EventSignup.objects.filter(event=self.event).count(),
             initial_signup_count,


### PR DESCRIPTION
## Summary
Surfaces silent Discord API failures in `create_discord_scheduled_event` (root cause of the 0.9.49 prod incident where a tournament's scheduled event never appeared despite logs saying \"Sync: created…\" 20+ times). Also fixes 7 pre-existing test failures across events + discordbot suites.

## The prod incident (Event 12 / Tournament 80, 0.9.49)
- Signup post + announcement notice posted fine.
- Bot lacked **MANAGE_EVENTS** in the guild → 20+ consecutive 403 \"Missing Permissions\" responses (code 50013) from Discord on `create_scheduled_event`.
- Failure was invisible:
  1. `create_discord_scheduled_event` recorded `success=False` to `DiscordEventLog` but returned a \"Created Discord event for event X\" string.
  2. `sync_discord_events` caught only Python exceptions, treated the API-side rejection as success, and logged `\"Sync: created Discord scheduled event for event X\"` every minute.
  3. `DiscordEventLog.error_message` was empty — the only place the Discord error string lived was `response_data` JSON.

## Fix in `backend/events/tasks.py:create_discord_scheduled_event`
- Build a human-readable error string on non-success (e.g. `\"Missing Permissions (code 50013, HTTP 403)\"`).
- Pass it to `create_event_log` as `error_message` so operators see it without inspecting `response_data`.
- `logger.error(...)` the same string.
- `raise RuntimeError(...)` so the caller's try/except emits the accurate `\"Sync: failed…\"` log line.

**The broader sync is unaffected.** `sync_discord_events` wraps each event in its own try/except, so one event's permissions failure does NOT block the loop or stop signup/announcement message updates for other events.

Three new tests pin the contract:
- 403 Missing-Permissions raises with the Discord error in the exception message.
- `DiscordEventLog.error_message` carries the readable error.
- Happy path (201) persists `scheduled_event_id` and does not raise.

## Pre-existing test failures fixed (7 total)

### `backend/events/tests/test_signup_writethrough.py` (3 cases)
PR #217 removed the position writethrough from `apply_signup_writethrough` (priorities now come from `apply_signup_input` upstream of `_create_signup`). The tests asserted the old contract:
- `test_positions_writethrough_last_write_wins` → repurposed as `test_positions_writethrough_no_longer_runs_here`. Asserts existing user.positions priorities **survive** the writethrough untouched.
- `test_user_update_failure_rolls_back`: was patching `PositionsModel.save` (now never called for that step). Switched to patching `invalidate_after_commit` (the only unprotected write left) and wrapped in `transaction.atomic` to mirror the realistic call site (`_create_signup`).
- `test_signup_create_rolls_back_when_writethrough_fails`: same injection-point swap.

### `backend/discordbot/tests/test_lease_helpers.py` (4 cases)
`InternalServiceAuth` requires both `X-Internal-Token` header AND IP allowlist. Tests were reading `INTERNAL_SERVICE_TOKEN` from env (unset in the test container), sending an empty header, getting 403. Fixed via `@override_settings(INTERNAL_SERVICE_TOKEN=\"test-internal-token\")` on the test class and pinning the same value as the header. The APIClient default 127.0.0.1 client IP passes the default allowlist.

## Test plan
- [x] `python manage.py test events.tests discordbot.tests org.tests` — 411/411 pass (7 skipped — live-Discord integration tests gated on `DISCORD_BOT_TOKEN`).
- [ ] CI `@cicd` smoke set.
- [ ] Manual on prod: grant the bot `MANAGE_EVENTS` in guild 734185035623825559 → next `sync_discord_events` should populate `DiscordEvent.scheduled_event_id` and the failed-attempt counter should stop incrementing.

## Out of scope
The user reported `\"later checked deleted the message\"` after granting permission. That's a separate investigation — this PR only fixes the visibility of Discord API failures. Will follow up once we have repro details.