### PR TITLE
fix(discord): stop deleting signup posts on every button click

### DIFF
--- a/backend/discordbot/signup_responses.py
+++ b/backend/discordbot/signup_responses.py
@@ -5,11 +5,22 @@ generating) rather than ephemerals that auto-dismiss after 60 seconds. When a
 user has DMs disabled (Discord 50007), fall back to ephemeral and prefix with
 <@user_id> so they get a notification badge.
 
-Discord interactions must be acknowledged within 3 seconds — defer first to
-extend the window to 15 minutes, then attempt the DM. On DM success, delete
-the deferred placeholder so the originating button doesn't appear hung.
-delete_original_response is best-effort: NotFound/HTTPException are swallowed
-since the DM already landed.
+CRITICAL — `thinking=True` on defer for component interactions:
+
+    For a *component* (button) interaction, discord.py's `defer(ephemeral=...)`
+    without `thinking=True` issues a `DEFERRED_MESSAGE_UPDATE` (type 6). That
+    type does NOT create a new response message — it silently defers an
+    *update to the source message* (the message the button lives on), and
+    the `ephemeral` flag is ignored. After that, `@original` IS the source
+    message, so `delete_original_response()` deletes the public signup post.
+
+    Passing `thinking=True` switches discord.py to
+    `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` (type 5), creating a fresh
+    ephemeral placeholder. Then `@original` is that placeholder and
+    `delete_original_response()` cleans up only the placeholder.
+
+    Removing `thinking=True` here will start deleting users' signup posts
+    on every button click again. Do not change without re-reading this.
 """
 
 from enum import Enum
@@ -26,6 +37,11 @@ class ResponseChannel(Enum):
     EPHEMERAL = "ephemeral"
 
 
+def _message_id(interaction: discord.Interaction) -> str | None:
+    msg = getattr(interaction, "message", None)
+    return str(msg.id) if msg is not None and getattr(msg, "id", None) else None
+
+
 async def respond_to_signup_user(
     interaction: discord.Interaction,
     *,
@@ -37,17 +53,36 @@ async def respond_to_signup_user(
     """Try DM → fall back to ephemeral with <@user_id> prefix on Forbidden(50007)."""
     user_id = interaction.user.id
     event_id = getattr(event, "pk", None)
+    source_message_id = _message_id(interaction)
+    channel_id = (
+        str(interaction.channel_id) if getattr(interaction, "channel_id", None) else None
+    )
 
     if not interaction.response.is_done():
-        await interaction.response.defer(ephemeral=True)
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        log.info(
+            "signup_interaction_deferred",
+            system="events",
+            subsystem="discord",
+            user_id=user_id,
+            event_id=event_id,
+            channel_id=channel_id,
+            source_message_id=source_message_id,
+        )
 
     try:
         dm_channel = await interaction.user.create_dm()
         await dm_channel.send(content=content, embed=embed, view=view)
         try:
             await interaction.delete_original_response()
-        except (discord.NotFound, discord.HTTPException):
-            # Cleanup is best-effort; the DM already landed.
+            log.info(
+                "signup_interaction_placeholder_deleted",
+                system="events",
+                subsystem="discord",
+                user_id=user_id,
+                event_id=event_id,
+            )
+        except discord.NotFound:
             pass
         channel = ResponseChannel.DM
     except discord.Forbidden as e:
@@ -65,6 +100,8 @@ async def respond_to_signup_user(
                 subsystem="discord",
                 user_id=user_id,
                 event_id=event_id,
+                channel_id=channel_id,
+                source_message_id=source_message_id,
                 error=str(e),
             )
             raise
@@ -77,5 +114,7 @@ async def respond_to_signup_user(
         fallback_to_ephemeral=(channel == ResponseChannel.EPHEMERAL),
         user_id=user_id,
         event_id=event_id,
+        channel_id=channel_id,
+        source_message_id=source_message_id,
     )
     return channel

--- a/backend/discordbot/tests/test_signup_responses.py
+++ b/backend/discordbot/tests/test_signup_responses.py
@@ -34,7 +34,18 @@ def _make_forbidden(code):
 
 
 class RespondToSignupUserDMSuccessTest(SimpleTestCase):
-    async def test_dm_path_defers_then_sends_then_deletes_original(self):
+    async def test_dm_path_defers_with_thinking_then_sends_then_deletes_placeholder(self):
+        """Regression guard for the signup-post-deletion bug.
+
+        For component (button) interactions, `defer(ephemeral=True)` WITHOUT
+        `thinking=True` issues DEFERRED_MESSAGE_UPDATE (type 6), making
+        `@original` resolve to the SOURCE message (the public signup post).
+        `delete_original_response()` then deletes the signup post.
+
+        `thinking=True` switches to DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+        (type 5), creating an ephemeral placeholder. `@original` is the
+        placeholder, and the subsequent delete only clears that.
+        """
         interaction = _make_interaction()
         dm_channel = AsyncMock()
         dm_channel.send = AsyncMock()
@@ -42,7 +53,9 @@ class RespondToSignupUserDMSuccessTest(SimpleTestCase):
 
         result = await respond_to_signup_user(interaction, content="hi")
 
-        interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+        interaction.response.defer.assert_awaited_once_with(
+            ephemeral=True, thinking=True
+        )
         interaction.user.create_dm.assert_awaited_once()
         dm_channel.send.assert_awaited_once_with(content="hi", embed=None, view=None)
         interaction.delete_original_response.assert_awaited_once()
@@ -57,17 +70,30 @@ class RespondToSignupUserDMSuccessTest(SimpleTestCase):
         await respond_to_signup_user(interaction, content="hi")
         interaction.response.defer.assert_not_called()
 
-    async def test_delete_original_failure_does_not_break_dm_success(self):
-        """delete_original_response can raise NotFound/HTTPException; cleanup is best-effort."""
+    async def test_delete_original_not_found_does_not_break_dm_success(self):
+        """delete_original_response can raise NotFound if the placeholder is
+        already gone; cleanup is best-effort and the DM has already landed."""
         interaction = _make_interaction()
         dm_channel = AsyncMock()
         interaction.user.create_dm.return_value = dm_channel
         interaction.delete_original_response.side_effect = discord.NotFound(
             MagicMock(status=404), "not found"
         )
-        # Should not raise — DM already succeeded.
         result = await respond_to_signup_user(interaction, content="hi")
         self.assertEqual(result, ResponseChannel.DM)
+
+    async def test_other_http_errors_on_delete_propagate(self):
+        """We narrowed the except to NotFound only — a 403/5xx on delete should
+        surface, not be silently swallowed (it would have masked the signup-
+        post-deletion bug otherwise)."""
+        interaction = _make_interaction()
+        dm_channel = AsyncMock()
+        interaction.user.create_dm.return_value = dm_channel
+        interaction.delete_original_response.side_effect = discord.HTTPException(
+            MagicMock(status=500), "server error"
+        )
+        with self.assertRaises(discord.HTTPException):
+            await respond_to_signup_user(interaction, content="hi")
 
 
 class RespondToSignupUserDMDisabledTest(SimpleTestCase):
@@ -109,8 +135,16 @@ class RespondToSignupUserLoggingTest(SimpleTestCase):
         with patch("discordbot.signup_responses.log") as mock_log:
             await respond_to_signup_user(interaction, content="hi")
 
-        mock_log.info.assert_called_once()
-        kwargs = mock_log.info.call_args.kwargs
+        events = [call.args[0] for call in mock_log.info.call_args_list]
+        self.assertIn("signup_interaction_deferred", events)
+        self.assertIn("signup_interaction_placeholder_deleted", events)
+        self.assertIn("signup_response_sent", events)
+
+        sent_call = next(
+            c for c in mock_log.info.call_args_list
+            if c.args[0] == "signup_response_sent"
+        )
+        kwargs = sent_call.kwargs
         self.assertEqual(kwargs["system"], "events")
         self.assertEqual(kwargs["subsystem"], "discord")
         self.assertEqual(kwargs["channel"], "dm")


### PR DESCRIPTION
## Summary

- Every signup button click was deleting the public signup post (and, for forum threads, the whole thread). Root cause: `interaction.response.defer(ephemeral=True)` for a component interaction issues `DEFERRED_MESSAGE_UPDATE` (type 6) — the `ephemeral` flag is silently ignored and `@original` resolves to the **source message** (the signup post). `delete_original_response()` then nukes it.
- Fix: pass `thinking=True` so discord.py issues `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` (type 5), creating an ephemeral placeholder; `@original` is the placeholder and the subsequent delete only clears that.
- Narrowed the swallow on `delete_original_response` from `HTTPException` to `NotFound` only. The broader `except` had been masking exactly this kind of self-inflicted damage.
- Added structured log events (`signup_interaction_deferred`, `signup_interaction_placeholder_deleted`) with `channel_id` and `source_message_id`, so future regressions can be traced from logs.
- Added a regression test asserting the defer call uses `thinking=True`, plus a test that non-NotFound errors on delete propagate.

## Symptom timeline observed in prod (`backend/discordbot/signup_responses.py`)

Every `signup_response_sent` event (in prod logs) was followed by a 404 / "Unknown Message" on the next `sync_edit_message` attempt for that event's signup post, because the delete had taken the post (and forum-thread) with it. The recently-shipped orphaned-message auto-recovery would then recreate the post on the next `sync_discord_events` tick — masking the bug at the cost of churning the post on every click.

## Test plan

- [x] `discordbot.tests.test_signup_responses` — 8/8 pass, including new regression test `test_dm_path_defers_with_thinking_then_sends_then_deletes_placeholder`
- [x] Full `discordbot.tests` suite — 113/113 pass
- [ ] Manual: in prod, click Sign Up / Tentative / Decline on a signup post and verify the post is NOT deleted; verify a DM lands; verify the next edit succeeds

## Notes

- This is a hotfix — recommend merging and bumping `0.9.52`.
- A separate diagnostic finding (out of scope for this PR): the celery-worker stopped emitting stdout for ~8h on prod despite running `--pool=solo` and consuming tasks. Worth investigating later but does not block this fix.