### PR TITLE
chore(discord): swap MMR screenshot prompt from imgur to catbox.moe

### DIFF
--- a/backend/discordbot/components.py
+++ b/backend/discordbot/components.py
@@ -973,8 +973,8 @@ class ScreenshotUploadModal(ui.Modal):
         else:
             self.file_upload = None
             self.url_input = ui.TextInput(
-                label="Imgur Link",
-                placeholder="Paste your imgur.com link here",
+                label="Catbox Link",
+                placeholder="https://files.catbox.moe/abc123.png",
                 custom_id=f"screenshot_url:{event_id}:{screenshot_type}",
                 required=True,
                 style=discord.TextStyle.short,

--- a/backend/discordbot/screenshot_tips.py
+++ b/backend/discordbot/screenshot_tips.py
@@ -5,7 +5,7 @@ SCREENSHOT_TIPS = (
     "• **Windows:** Press `Win + Shift + S` to capture a region\n"
     "• **Mac:** Press `Cmd + Shift + 4` to capture a region\n"
     "• Crop to show only the relevant info\n\n"
-    "📤 **Upload your screenshot to [imgur.com/upload](https://imgur.com/upload)** "
-    "and paste the link below\n"
+    "📤 **Upload your screenshot to [catbox.moe](https://catbox.moe/)** "
+    "and paste the direct file link (e.g. `https://files.catbox.moe/abc123.png`) below\n"
     "• Accepted formats: `.png`, `.jpg`, `.jpeg`, `.webp`"
 )


### PR DESCRIPTION
## Summary

- Update the MMR / Battle Cup screenshot upload prompt in Discord modals to point users at [catbox.moe](https://catbox.moe/) instead of imgur.com.
- Two strings changed, no logic / validation / storage changes.

## Why

Discord CDN attachment URLs expire (~24h), and Imgur links can be flaky / require account flows. Catbox direct file URLs (`https://files.catbox.moe/<id>.<ext>`) are permanent and anonymous — better for screenshots that may be reviewed days after a signup is submitted.

## Changed

- `backend/discordbot/screenshot_tips.py` — `SCREENSHOT_TIPS` prompt text in the modal's `TextDisplay`.
- `backend/discordbot/components.py` — `ScreenshotUploadModal` `TextInput` `label` and `placeholder` (the fallback shown when `discord.py`'s `ui.FileUpload` isn't available).

## Out of scope

- No backend re-hosting. `SCREENSHOT_URL_RE` already accepts any direct `.png/.jpg/.jpeg/.webp` URL, so `files.catbox.moe/*.png` validates without changes.
- Test fixtures still use `i.imgur.com/...` URLs — those are just regex-matched test data and don't affect users.

## Test plan

- [ ] Open the MMR upload modal in Discord, verify the prompt text mentions catbox.moe and the input label/placeholder reference catbox.
- [ ] Paste a `https://files.catbox.moe/<id>.png` link and confirm it's accepted by `SCREENSHOT_URL_RE` and stored on the signup.