### PR TITLE
fix(telemetry): use CUMULATIVE temporality so Mimir stops 400'ing metrics

### DIFF
--- a/backend/telemetry/tracing.py
+++ b/backend/telemetry/tracing.py
@@ -79,36 +79,38 @@ def _setup_provider(resource, provider, endpoint, header_dict, sample_rate) -> N
     _tracer_provider = provider
     atexit.register(_shutdown_tracer_provider)
 
-    # Configure metrics export (delta temporality required by Grafana Cloud Mimir)
+    # Configure metrics export.
+    #
+    # Grafana Cloud Mimir's OTLP ingest uses the OpenTelemetry Collector's
+    # Prometheus remote-write translator. That translator rejects DELTA
+    # temporality for every Sum and Histogram type — see
+    # `isValidAggregationTemporality` in
+    # open-telemetry/opentelemetry-collector-contrib :
+    # pkg/translator/prometheusremotewrite/helper.go . Accepted combinations:
+    #
+    #   Gauge / Summary  : DELTA or CUMULATIVE (temporality ignored)
+    #   Sum (Counter, UpDownCounter, Observable{Up,Down}Counter)  : CUMULATIVE
+    #   Histogram, ExponentialHistogram                            : CUMULATIVE
+    #
+    # The SDK default is CUMULATIVE for every instrument type, which matches
+    # Mimir exactly. Older revisions of this file shipped a custom
+    # `preferred_temporality` map that forced DELTA on Counter / Histogram /
+    # ObservableCounter — the cause of the recurring
+    # "invalid temporality and type combination" 400s on
+    # `http.client.*`, `otel.sdk.*`, `flower.task.runtime.seconds`, etc.
+    # Don't reintroduce that map. If a specific metric needs DELTA in the
+    # future, override it with a per-instrument View, not globally.
     try:
         from opentelemetry import metrics
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
             OTLPMetricExporter,
         )
-        from opentelemetry.sdk.metrics import (
-            Counter,
-            Histogram,
-            MeterProvider,
-            ObservableCounter,
-            ObservableGauge,
-            ObservableUpDownCounter,
-            UpDownCounter,
-        )
+        from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.metrics.export import (
-            AggregationTemporality,
             PeriodicExportingMetricReader,
         )
-        from opentelemetry.sdk.metrics.view import View
+        from opentelemetry.sdk.metrics.view import DropAggregation, View
 
-        # Grafana Cloud Mimir requires delta temporality for all instrument types
-        delta_temporality = {
-            Counter: AggregationTemporality.DELTA,
-            UpDownCounter: AggregationTemporality.CUMULATIVE,
-            Histogram: AggregationTemporality.DELTA,
-            ObservableCounter: AggregationTemporality.DELTA,
-            ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
-            ObservableGauge: AggregationTemporality.DELTA,
-        }
         # Wrap the exporter so that when Grafana Cloud rejects a batch with a
         # 4xx the response body is captured to our logs. The stock SDK only
         # logs `code: 400, reason: Bad Request` which is useless — Grafana's
@@ -131,26 +133,18 @@ def _setup_provider(resource, provider, endpoint, header_dict, sample_rate) -> N
         metric_exporter = _DiagnosticMetricExporter(
             endpoint=endpoint + "/v1/metrics",
             headers=header_dict or None,
-            preferred_temporality=delta_temporality,
         )
         metric_reader = PeriodicExportingMetricReader(metric_exporter)
 
-        # Drop metrics that Grafana Cloud Mimir rejects with HTTP 400:
+        # Drop metrics we don't want shipped. These drops are about *noise*
+        # and *duplication*, not the old temporality-mismatch problem:
         #
-        # * http.client.* — requests instrumentation reports these with a
-        #   temporality combination Mimir refuses. We get the same data from
-        #   server-side http.server.duration spans.
+        # * http.client.* — requests instrumentation duplicates data we
+        #   already get from server-side http.server.duration spans.
         #
-        # * otel.sdk.* — the SDK reports its own self-monitoring metrics
-        #   (collection.duration, exported.count, etc.) which use a
-        #   type/temporality combo Mimir parses as invalid:
-        #   "otlp parse error: invalid temporality and type combination for
-        #    metric \"otel.sdk.metric_reader.collection.duration\"".
-        #   These are exporter internals — not useful telemetry — and they
-        #   poison every batch because Mimir rejects the whole payload on
-        #   any invalid series. Dropping them ends the per-minute 400s.
-        from opentelemetry.sdk.metrics.view import DropAggregation
-
+        # * otel.sdk.* — the SDK's own self-monitoring metrics
+        #   (collection.duration, exported.count, etc.). Exporter internals,
+        #   not useful telemetry.
         meter_provider = MeterProvider(
             resource=resource,
             metric_readers=[metric_reader],


### PR DESCRIPTION
## Why this keeps coming back

We've shipped three previous "fixes" for OTLP 400 errors against Grafana Cloud Mimir:

- Drop `http.client.*` histograms.
- Drop `otel.sdk.*` self-monitoring metrics.
- (Reported, never landed) Drop `flower.task.runtime.seconds`.

Each one was a per-name `DropAggregation` View added after Mimir started rejecting that specific series. The pattern is whack-a-mole: every new histogram from any instrumentation we add becomes the next offender. Prod is *still* logging the same 400 today, now on `flower.task.runtime.seconds` from `opentelemetry-instrumentation-celery`.

## Actual root cause

`_setup_provider` configured the OTLP exporter with `preferred_temporality` forcing **DELTA** on `Counter`, `Histogram`, and `ObservableCounter`. The original comment claimed *"Grafana Cloud Mimir requires delta temporality for all instrument types"* — **this is wrong**.

Grafana Cloud Mimir's OTLP ingest reuses the OpenTelemetry Collector's Prometheus remote-write translator. The validator is `isValidAggregationTemporality` in [`pkg/translator/prometheusremotewrite/helper.go`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/prometheusremotewrite/helper.go). It rejects **DELTA** for every `Sum` and `Histogram` type:

| OTLP metric type | DELTA | CUMULATIVE |
|---|---|---|
| Gauge | accepted (temporality ignored) | accepted |
| Summary | accepted (temporality ignored) | accepted |
| Sum (Counter, UpDownCounter, ObservableCounter, ObservableUpDownCounter) | **REJECTED** | accepted |
| Histogram, ExponentialHistogram | **REJECTED** | accepted |

So:

- `Counter: DELTA` → rejected
- `Histogram: DELTA` → rejected (this is `flower.task.runtime.seconds`)
- `ObservableCounter: DELTA` → rejected (and semantically wrong — observable counters are inherently cumulative per the OTel spec)

The `flower.task.runtime.seconds` Histogram is created by `CeleryInstrumentor._create_celery_metrics` (`opentelemetry-instrumentation-celery`) using the global meter provider — so our `preferred_temporality` map applies to it, marks it DELTA, and Mimir refuses it. Every future histogram from any instrumentation hits the same wall.

Confirming references:
- Mimir's translator: [`isValidAggregationTemporality`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/prometheusremotewrite/helper.go)
- Mimir bug confirming this validator gates OTLP ingest: [grafana/mimir#6696](https://github.com/grafana/mimir/issues/6696)
- Same error class against Grafana Cloud OTLP: [collector-contrib#30435](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30435), [collector-contrib#37164](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37164)

## Fix

Drop the custom `preferred_temporality` map entirely. The OpenTelemetry Python SDK default is **CUMULATIVE for every instrument type**, which matches Mimir's accepted column exactly. The kept `DropAggregation` Views (`http.client.*`, `otel.sdk.*`) are now justified by noise / server-side duplication rather than the (now-fixed) temporality mismatch — and the in-file comment block warns future-us not to reintroduce the DELTA map.

## Test plan

- [x] Backend tests still pass — change is a single config flip, no behavior changes outside the OTel exporter.
- [ ] After deploy, watch the prod celery-worker logs for the next ~10 minutes and confirm `OTLP metric export rejected: 400` stops appearing.
- [ ] Confirm `flower.task.runtime.seconds` / `http.server.duration` / etc. start landing in Grafana Cloud Metrics Explorer (they were silently being dropped before).