### PR TITLE
fix(steam): periodic sync iterates DB-configured leagues

### DIFF
--- a/backend/app/internal_client.py
+++ b/backend/app/internal_client.py
@@ -385,6 +385,18 @@ def get_steam_sync_state(league_id):
     return None
 
 
+def get_tracked_steam_league_ids():
+    """Return list of League.steam_league_id values currently configured.
+
+    Returns None on transport error so the caller can distinguish that
+    from a legitimate empty list (no League has steam_league_id set).
+    """
+    resp = _get("/steam/tracked-leagues/")
+    if resp and resp.ok:
+        return resp.json().get("steam_league_ids", [])
+    return None
+
+
 def update_steam_sync_state(league_id, **fields):
     """Update sync state fields. Returns True on success."""
     resp = _patch(f"/steam/sync-state/{league_id}/", fields)

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -472,12 +472,14 @@ from steam.views_internal import (
     recalculate_mmr,
     steam_sync_state,
     store_match,
+    tracked_leagues,
     update_league_stats,
 )
 
 urlpatterns += [
     path("api/internal/steam/sync-state/<int:league_id>/", steam_sync_state),
     path("api/internal/steam/store-match/", store_match),
+    path("api/internal/steam/tracked-leagues/", tracked_leagues),
     path(
         "api/internal/steam/update-league-stats/<int:league_id>/", update_league_stats
     ),

--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -34,7 +34,7 @@ def init_worker_telemetry(**kwargs):
 # Beat schedule for periodic tasks
 _beat_schedule = {
     "sync-league-matches-every-minute": {
-        "task": "steam.tasks.sync_league_matches_task",
+        "task": "steam.tasks.sync_all_steam_leagues_task",
         "schedule": 60.0,
     },
     "check-discord-scheduled-events": {

--- a/backend/config/celery_light.py
+++ b/backend/config/celery_light.py
@@ -29,7 +29,7 @@ app.autodiscover_tasks(["events"], related_name="tournament_tasks")
 # Beat schedule — copied from config/celery.py
 _beat_schedule = {
     "sync-league-matches-every-minute": {
-        "task": "steam.tasks.sync_league_matches_task",
+        "task": "steam.tasks.sync_all_steam_leagues_task",
         "schedule": 60.0,
     },
     "check-discord-scheduled-events": {

--- a/backend/steam/tasks.py
+++ b/backend/steam/tasks.py
@@ -10,12 +10,12 @@ from celery import shared_task
 
 from app.internal_client import (
     get_steam_sync_state,
+    get_tracked_steam_league_ids,
     recalculate_user_mmr,
     store_steam_match,
     update_league_stats,
     update_steam_sync_state,
 )
-from steam.constants import LEAGUE_ID
 from steam.utils.retry import retry_with_backoff
 from steam.utils.steam_api_caller import SteamAPI
 from telemetry.logging import get_logger
@@ -24,14 +24,56 @@ log = get_logger(__name__)
 
 
 @shared_task(bind=True, max_retries=3)
-def sync_league_matches_task(self, league_id: int = None):
-    """
-    Fetch new matches from Steam API, store via internal API.
-    Scheduled to run every minute.
-    """
-    if league_id is None:
-        league_id = LEAGUE_ID
+def sync_all_steam_leagues_task(self):
+    """Periodic coordinator — fan out one `sync_league_matches_task` per
+    League row that has `steam_league_id` set.
 
+    Replaces the prior beat entry that called `sync_league_matches_task`
+    directly with no argument and silently fell back to a hardcoded
+    constant, pinning the periodic sync to a single league regardless
+    of DB configuration.
+
+    Dispatch is via `.delay()` so each league becomes its own job. Steam
+    API pressure is bounded by `sync_league_matches_task`'s own
+    `rate_limit` — workers process one league at a time at most one per
+    second, no matter how many leagues are tracked.
+    """
+    league_ids = get_tracked_steam_league_ids()
+    if league_ids is None:
+        log.error(
+            "steam_sync_fanout_state_fetch_failed",
+            system="steam",
+            subsystem="sync",
+            reason="internal_api_returned_none",
+        )
+        raise self.retry(countdown=60)
+
+    log.info(
+        "steam_sync_fanout_dispatch",
+        system="steam",
+        subsystem="sync",
+        league_count=len(league_ids),
+        league_ids=league_ids,
+    )
+
+    for league_id in league_ids:
+        sync_league_matches_task.delay(league_id)
+
+    return {"dispatched": len(league_ids), "league_ids": league_ids}
+
+
+@shared_task(bind=True, max_retries=3, rate_limit="60/m")
+def sync_league_matches_task(self, league_id: int):
+    """Fetch new matches from Steam API for a single league, store via internal API.
+
+    Dispatched per-league by `sync_all_steam_leagues_task`; never scheduled
+    directly anymore. The `rate_limit="60/m"` is a backstop against
+    Steam API abuse if many leagues are tracked — celery will serialize
+    task starts to at most one per second per worker. Each task itself
+    may issue multiple Steam calls (1 history + N detail per new match);
+    the cursor-based incremental sync keeps steady-state at one history
+    call per tick.
+    """
     started_at = time.monotonic()
 
     # 1. Check sync state
@@ -266,11 +308,8 @@ def _fetch_and_store_match(api, match_id, match_seq_num, league_id):
 
 
 @shared_task(bind=True)
-def update_league_stats_task(self, league_id: int = None):
+def update_league_stats_task(self, league_id: int):
     """Update LeaguePlayerStats for all users in a league via internal API."""
-    if league_id is None:
-        league_id = LEAGUE_ID
-
     log.info(
         "steam_league_stats_start",
         system="steam",

--- a/backend/steam/tests/test_internal_views.py
+++ b/backend/steam/tests/test_internal_views.py
@@ -293,3 +293,38 @@ class RecalculateMmrEndpointTest(TestCase):
             **HEADERS,
         )
         self.assertEqual(resp.status_code, 404)
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class TrackedLeaguesEndpointTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = "/api/internal/steam/tracked-leagues/"
+
+    def test_returns_empty_when_no_leagues_configured(self):
+        resp = self.client.get(self.url, **HEADERS)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"steam_league_ids": []})
+
+    def test_returns_steam_ids_sorted(self):
+        from app.models import League
+
+        League.objects.create(name="DTX", steam_league_id=19571)
+        League.objects.create(name="Other", steam_league_id=12345)
+        League.objects.create(name="NoSteamId", steam_league_id=None)
+
+        resp = self.client.get(self.url, **HEADERS)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"steam_league_ids": [12345, 19571]})
+
+    def test_excludes_leagues_without_steam_league_id(self):
+        from app.models import League
+
+        League.objects.create(name="Unconfigured", steam_league_id=None)
+
+        resp = self.client.get(self.url, **HEADERS)
+        self.assertEqual(resp.json(), {"steam_league_ids": []})
+
+    def test_requires_internal_auth(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 403)

--- a/backend/steam/tests/test_tasks_http.py
+++ b/backend/steam/tests/test_tasks_http.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from steam.tasks import (
     recalculate_user_league_mmr_task,
+    sync_all_steam_leagues_task,
     sync_league_matches_task,
     update_league_stats_task,
 )
@@ -108,3 +109,53 @@ class RecalculateMmrTaskTest(TestCase):
 
         result = recalculate_user_league_mmr_task(99999)
         self.assertIsNone(result)
+
+
+class SyncAllSteamLeaguesTaskTest(TestCase):
+    @patch("steam.tasks.sync_league_matches_task")
+    @patch("app.internal_client.requests.get")
+    def test_dispatches_one_subtask_per_tracked_league(self, mock_get, mock_subtask):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"steam_league_ids": [19571, 12345]}
+        mock_get.return_value = mock_resp
+
+        result = sync_all_steam_leagues_task()
+
+        self.assertEqual(result, {
+            "dispatched": 2,
+            "league_ids": [19571, 12345],
+        })
+        self.assertEqual(mock_subtask.delay.call_count, 2)
+        mock_subtask.delay.assert_any_call(19571)
+        mock_subtask.delay.assert_any_call(12345)
+
+    @patch("steam.tasks.sync_league_matches_task")
+    @patch("app.internal_client.requests.get")
+    def test_no_dispatch_when_no_leagues_configured(self, mock_get, mock_subtask):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"steam_league_ids": []}
+        mock_get.return_value = mock_resp
+
+        result = sync_all_steam_leagues_task()
+
+        self.assertEqual(result, {"dispatched": 0, "league_ids": []})
+        mock_subtask.delay.assert_not_called()
+
+    @patch("steam.tasks.sync_league_matches_task")
+    @patch("app.internal_client.requests.get")
+    def test_retries_on_internal_api_failure(self, mock_get, mock_subtask):
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 500
+        mock_resp.text = "boom"
+        mock_get.return_value = mock_resp
+
+        # Celery's self.retry raises Retry; we just assert it bubbles up
+        # and no sub-tasks were dispatched.
+        from celery.exceptions import Retry
+
+        with self.assertRaises(Retry):
+            sync_all_steam_leagues_task()
+        mock_subtask.delay.assert_not_called()

--- a/backend/steam/views_internal.py
+++ b/backend/steam/views_internal.py
@@ -162,6 +162,26 @@ def store_match(request):
     )
 
 
+@api_view(["GET"])
+@authentication_classes(_auth)
+@permission_classes(_perm)
+def tracked_leagues(request):
+    """Return League.steam_league_id values currently set on any League row.
+
+    The periodic sync coordinator calls this to discover which leagues
+    to poll — replaces the hardcoded LEAGUE_ID constant that previously
+    pinned sync to a single league.
+    """
+    from app.models import League
+
+    ids = list(
+        League.objects.filter(steam_league_id__isnull=False)
+        .values_list("steam_league_id", flat=True)
+        .order_by("steam_league_id")
+    )
+    return Response({"steam_league_ids": ids})
+
+
 @api_view(["POST"])
 @authentication_classes(_auth)
 @permission_classes(_perm)


### PR DESCRIPTION
## Root cause (traced via #226's diagnostic logging)

The first run of `steam_sync_complete` after #226 told us everything:

```
prior_last_match_id   = 8720162892
batch_first_match_id  = 8720162892   ← Steam's newest matches the cursor exactly
batch_skipped         = 100
batch_new             = 0
advanced_cursor       = False
```

The sync was healthy for league `17929` — but `17929` is irrelevant. DTX League's `steam_league_id` was changed in the DB to `19571`, and no `League` row has `steam_league_id=17929` anymore. The Celery beat schedule fired `sync_league_matches_task` with no argument every minute, the task fell back to a hardcoded constant (`steam.constants.LEAGUE_ID = 17929`), and the DB change never affected what got polled.

## What changed

### Coordinator + fan-out

* New `GET /api/internal/steam/tracked-leagues/` returns `{"steam_league_ids": [int, ...]}` — every `League.steam_league_id` currently set, sorted ascending.
* New `sync_all_steam_leagues_task` coordinator queries that endpoint and dispatches `sync_league_matches_task.delay(league_id)` per row. The beat schedule in both `config/celery.py` and `config/celery_light.py` now points at the coordinator instead of the per-league task.
* `get_tracked_steam_league_ids()` added to `app/internal_client.py` — returns `None` on transport error so the coordinator can distinguish that from a legitimate empty list and retry via celery.

### Rate limit (Steam API protection)

`sync_league_matches_task` gets `rate_limit="60/m"` — celery serializes task starts to **at most one per second per worker**. The cursor-based incremental sync already keeps steady-state at one Steam history call per league per tick; this backstop ensures that even if many leagues become tracked (or some have bursty new-match counts), workers don't slam Steam in parallel.

### No more hidden defaults

`sync_league_matches_task` and `update_league_stats_task` no longer accept `league_id=None`. The parameter is required. The hardcoded constant `LEAGUE_ID = 17929` remains in `steam/constants.py` because `steam/views.py`, `steam/services.py`, and test fixtures import it for display/filtering — those are separate from the periodic sync and cleaning them up is out of scope.

## Observability

* `steam_sync_fanout_dispatch` (info) at the start of each periodic tick, carrying `league_count` and `league_ids`.
* `steam_sync_fanout_state_fetch_failed` (error) on internal API failure, followed by a celery retry.
* Existing per-league `steam_sync_start` / `steam_sync_batch` / `steam_sync_complete` events from #226 continue to fire, now once per tracked league per tick.

## Test plan

- [x] `python manage.py test steam.tests.test_internal_views steam.tests.test_tasks_http -v 2` — 26/26 pass, including:
  - `TrackedLeaguesEndpointTest` (4 tests: empty list, sorted ids, excludes `NULL`, auth required)
  - `SyncAllSteamLeaguesTaskTest` (3 tests: dispatches per league, no-op when none configured, retries on internal API failure)
- [x] `python manage.py test steam.tests.test_api steam.tests.test_serializers -v 1` — 53/53 pass (regression check on the unrelated `LEAGUE_ID` importers)
- [x] `python manage.py check` — no issues
- [ ] After merge & deploy, watch for `steam_sync_fanout_dispatch league_ids=[19571]` in the next tick, followed by `steam_sync_start league_id=19571`. The old `17929` polling should disappear entirely.