### PR TITLE
fix(bracket): purge stale HeroDraft when a Game's teams change (#235)

### DIFF
--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -263,6 +263,7 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
     # written yet (we're in pre_save), so the new IDs live on `instance`,
     # not in the DB. Match prior assignments to new slots by the prior
     # tournament_team_id.
+    updated_draft_teams = []
     for dt in DraftTeam.objects.filter(draft=draft):
         if dt.tournament_team_id == prior.radiant_team_id:
             new_team_id = instance.radiant_team_id
@@ -277,8 +278,12 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
         dt.is_connected = False
         dt.reserve_time_remaining = 90000
         dt.save()
+        updated_draft_teams.append(dt)
 
-    # Wipe picks/bans — they belong to the wrong captain.
+    # Wipe picks/bans — they belong to the wrong captain. `app.herodraftround`
+    # is NOT in CACHEOPS so the bulk delete doesn't need cache invalidation
+    # of its own; the parent HeroDraft invalidation below covers any
+    # consumer that re-prefetches rounds.
     HeroDraftRound.objects.filter(draft=draft).delete()
 
     # Reset HeroDraft scheduling fields and state. Keep HeroDraftEvent rows
@@ -289,6 +294,17 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
     draft.resuming_until = None
     draft.is_manual_pause = False
     draft.save()
+
+    # Re-invalidate AFTER commit. The .save() calls above already invalidate
+    # via Model.save() → invalidate_obj, but those fire immediately while
+    # save_bracket's @transaction.atomic is still open — between the
+    # immediate invalidate and the commit, a concurrent reader could pull
+    # the pre-update rows from the DB and re-cache them with the old
+    # captains, defeating the whole reset. `invalidate_after_commit` schedules
+    # a second invalidation on transaction.on_commit to close that race.
+    from app.cache_utils import invalidate_after_commit
+
+    invalidate_after_commit(draft, *updated_draft_teams)
 
     _broadcast_draft_event(draft.pk, "draft_reset", instance.pk)
 

--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -174,7 +174,7 @@ def handle_tournament_user_addition(sender, instance, action, pk_set, **kwargs):
 
 
 @receiver(pre_save, sender="app.Game")
-def purge_stale_herodraft_on_team_change(sender, instance, **kwargs):
+def reset_herodraft_on_team_change(sender, instance, **kwargs):
     """Issue #235: bracket reset leaves stale HeroDraft with old captains.
 
     A HeroDraft holds its captains via DraftTeam.tournament_team, captured
@@ -187,14 +187,29 @@ def purge_stale_herodraft_on_team_change(sender, instance, **kwargs):
 
     Catch every team-mutation path in one place: just before Game.save()
     commits, compare the new (radiant_team_id, dire_team_id) against what
-    is still in the DB. If either changed, delete the dependent HeroDraft
-    (and its DraftTeam / HeroDraftRound / HeroDraftEvent rows via FK
-    cascade). The next request to start a draft on that Game rebuilds a
-    clean one from the current teams.
+    is still in the DB. If either changed and the game has a HeroDraft,
+    reset the draft **in place**:
 
-    Why this can't be preserved across the team change: any picks/bans
-    made before the change were made by the *wrong* captain, so carrying
-    them over is worse than starting fresh.
+      - Repoint each DraftTeam.tournament_team at the Game's new team so
+        captains resolve correctly.
+      - Wipe HeroDraftRound rows (the picks/bans were made by the *wrong*
+        captain — carrying them over is worse than starting fresh).
+      - Reset DraftTeam state (is_ready / is_connected / reserve_time) and
+        HeroDraft scheduling fields (roll_winner / paused_at / resuming_until /
+        is_manual_pause) back to defaults, transition to
+        WAITING_FOR_CAPTAINS.
+      - Keep HeroDraftEvent rows — they're the audit trail of the wrong
+        setup; clearing them would hide that it ever happened.
+
+    The HeroDraft PK is preserved, so any external reference (the Discord-
+    posted /herodraft/{pk}/ link from notify_herodraft_created, etc.)
+    keeps working after the reset.
+
+    Edge case — Game slot cleared to NULL: DraftTeam.tournament_team is
+    non-nullable, so the in-place reset can't repoint to None. Fall back
+    to deleting the HeroDraft. When the bracket is re-saved with real
+    teams create_herodraft rebuilds; the Discord link 404s in this narrow
+    window.
     """
     if not instance.pk:
         return
@@ -212,14 +227,20 @@ def purge_stale_herodraft_on_team_change(sender, instance, **kwargs):
     ):
         return
 
-    from app.models import HeroDraft
+    from app.models import DraftTeam, HeroDraft, HeroDraftRound, HeroDraftState
 
     draft = HeroDraft.objects.filter(game_id=instance.pk).first()
     if not draft:
         return
 
+    teams_cleared = (
+        instance.radiant_team_id is None or instance.dire_team_id is None
+    )
+
     log.info(
-        "herodraft_purged_on_team_change",
+        "herodraft_deleted_on_team_cleared"
+        if teams_cleared
+        else "herodraft_reset_on_team_change",
         extra={
             "system": "bracket",
             "subsystem": "herodraft",
@@ -231,4 +252,76 @@ def purge_stale_herodraft_on_team_change(sender, instance, **kwargs):
             "new_dire_team_id": instance.dire_team_id,
         },
     )
-    draft.delete()
+
+    if teams_cleared:
+        draft_pk = draft.pk
+        draft.delete()
+        _broadcast_draft_event(draft_pk, "draft_invalidated", instance.pk)
+        return
+
+    # Repoint DraftTeams at the Game's new teams. The Game row hasn't been
+    # written yet (we're in pre_save), so the new IDs live on `instance`,
+    # not in the DB. Match prior assignments to new slots by the prior
+    # tournament_team_id.
+    for dt in DraftTeam.objects.filter(draft=draft):
+        if dt.tournament_team_id == prior.radiant_team_id:
+            new_team_id = instance.radiant_team_id
+        elif dt.tournament_team_id == prior.dire_team_id:
+            new_team_id = instance.dire_team_id
+        else:
+            # Shouldn't happen — DraftTeam.tournament_team should always
+            # match one of the Game's two teams. Skip rather than crash.
+            continue
+        dt.tournament_team_id = new_team_id
+        dt.is_ready = False
+        dt.is_connected = False
+        dt.reserve_time_remaining = 90000
+        dt.save()
+
+    # Wipe picks/bans — they belong to the wrong captain.
+    HeroDraftRound.objects.filter(draft=draft).delete()
+
+    # Reset HeroDraft scheduling fields and state. Keep HeroDraftEvent rows
+    # as the audit trail.
+    draft.state = HeroDraftState.WAITING_FOR_CAPTAINS
+    draft.roll_winner = None
+    draft.paused_at = None
+    draft.resuming_until = None
+    draft.is_manual_pause = False
+    draft.save()
+
+    _broadcast_draft_event(draft.pk, "draft_reset", instance.pk)
+
+
+def _broadcast_draft_event(draft_pk, event_type, game_id):
+    """Send a HeroDraftConsumer event to the draft's channel group.
+
+    Best-effort: a missing channel layer (tests, fallback to in-memory)
+    or send failure must NOT raise — the data-integrity guarantees are
+    the row updates that already committed, not the broadcast.
+    """
+    try:
+        from asgiref.sync import async_to_sync
+        from channels.layers import get_channel_layer
+
+        channel_layer = get_channel_layer()
+        if channel_layer is None:
+            return
+        async_to_sync(channel_layer.group_send)(
+            f"herodraft_{draft_pk}",
+            {
+                "type": "herodraft.event",
+                "event_type": event_type,
+                "event_id": None,
+                "draft_team": None,
+                "metadata": {
+                    "reason": "teams_changed",
+                    "game_id": game_id,
+                },
+                "timestamp": None,
+            },
+        )
+    except Exception as exc:
+        log.warning(
+            f"Failed to broadcast {event_type} for HeroDraft {draft_pk}: {exc}"
+        )

--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -11,6 +11,7 @@ Handles:
 
 import logging
 
+from django.db import transaction
 from django.db.models.signals import m2m_changed, pre_save
 from django.dispatch import receiver
 
@@ -256,7 +257,9 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
     if teams_cleared:
         draft_pk = draft.pk
         draft.delete()
-        _broadcast_draft_event(draft_pk, "draft_invalidated", instance.pk)
+        transaction.on_commit(
+            lambda: _broadcast_draft_event(draft_pk, "draft_invalidated", instance.pk)
+        )
         return
 
     # Repoint DraftTeams at the Game's new teams. The Game row hasn't been
@@ -276,6 +279,12 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
         dt.tournament_team_id = new_team_id
         dt.is_ready = False
         dt.is_connected = False
+        # Clear roll-aftermath choices — leaving these set would make
+        # do_submit_choice reject the new captains with "already chosen"
+        # even though the draft is back at WAITING_FOR_CAPTAINS. Matches
+        # what reset_draft does in herodraft_views.py.
+        dt.is_first_pick = None
+        dt.is_radiant = None
         dt.reserve_time_remaining = 90000
         dt.save()
         updated_draft_teams.append(dt)
@@ -306,7 +315,14 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
 
     invalidate_after_commit(draft, *updated_draft_teams)
 
-    _broadcast_draft_event(draft.pk, "draft_reset", instance.pk)
+    # Defer the broadcast to commit too. If we fired now, clients would
+    # receive draft_reset, immediately refetch from the API, and read the
+    # pre-commit rows (or repopulate cacheops with them) — defeating the
+    # whole reset for any reader that's faster than the COMMIT.
+    draft_pk = draft.pk
+    transaction.on_commit(
+        lambda: _broadcast_draft_event(draft_pk, "draft_reset", instance.pk)
+    )
 
 
 def _broadcast_draft_event(draft_pk, event_type, game_id):

--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -6,11 +6,12 @@ Handles:
 - Team deletion when last member is removed
 - Cascade removal from tournament.users to team.members
 - Auto-add tournament users to organization and league
+- Purge stale HeroDraft when a Game's teams change (issue #235)
 """
 
 import logging
 
-from django.db.models.signals import m2m_changed
+from django.db.models.signals import m2m_changed, pre_save
 from django.dispatch import receiver
 
 log = logging.getLogger(__name__)
@@ -170,3 +171,64 @@ def handle_tournament_user_addition(sender, instance, action, pk_set, **kwargs):
                 f"Created LeagueUser for {user.username} in league {league.name} "
                 f"(via tournament {tournament.name})"
             )
+
+
+@receiver(pre_save, sender="app.Game")
+def purge_stale_herodraft_on_team_change(sender, instance, **kwargs):
+    """Issue #235: bracket reset leaves stale HeroDraft with old captains.
+
+    A HeroDraft holds its captains via DraftTeam.tournament_team, captured
+    at draft-creation time. When the underlying Game's radiant_team or
+    dire_team is rewritten — by ``save_bracket`` (full bracket re-save) or
+    ``advance_winner`` (re-advancing a different winner into a downstream
+    match) — the Game's teams change but the DraftTeam rows still point at
+    the *previous* teams. The draft UI then renders the wrong captains and
+    no client reload recovers it.
+
+    Catch every team-mutation path in one place: just before Game.save()
+    commits, compare the new (radiant_team_id, dire_team_id) against what
+    is still in the DB. If either changed, delete the dependent HeroDraft
+    (and its DraftTeam / HeroDraftRound / HeroDraftEvent rows via FK
+    cascade). The next request to start a draft on that Game rebuilds a
+    clean one from the current teams.
+
+    Why this can't be preserved across the team change: any picks/bans
+    made before the change were made by the *wrong* captain, so carrying
+    them over is worse than starting fresh.
+    """
+    if not instance.pk:
+        return
+
+    try:
+        prior = sender.objects.only("radiant_team_id", "dire_team_id").get(
+            pk=instance.pk
+        )
+    except sender.DoesNotExist:
+        return
+
+    if (
+        prior.radiant_team_id == instance.radiant_team_id
+        and prior.dire_team_id == instance.dire_team_id
+    ):
+        return
+
+    from app.models import HeroDraft
+
+    draft = HeroDraft.objects.filter(game_id=instance.pk).first()
+    if not draft:
+        return
+
+    log.info(
+        "herodraft_purged_on_team_change",
+        extra={
+            "system": "bracket",
+            "subsystem": "herodraft",
+            "game_id": instance.pk,
+            "herodraft_id": draft.pk,
+            "prior_radiant_team_id": prior.radiant_team_id,
+            "new_radiant_team_id": instance.radiant_team_id,
+            "prior_dire_team_id": prior.dire_team_id,
+            "new_dire_team_id": instance.dire_team_id,
+        },
+    )
+    draft.delete()

--- a/backend/app/tests/test_herodraft_stale_purge.py
+++ b/backend/app/tests/test_herodraft_stale_purge.py
@@ -252,17 +252,46 @@ class HeroDraftResetOnGameTeamChangeTest(TestCase):
         other_game.dire_team = self.team_dire_corrected
         other_game.save()  # must not raise
 
+    def test_reset_clears_pick_order_and_side_choices(self):
+        """``do_submit_choice`` rejects when ``is_first_pick`` or
+        ``is_radiant`` is non-null ("Pick order already chosen" / "Side
+        already chosen"). After a team-swap reset the new captains must
+        be able to roll + choose again — so both fields go back to None,
+        matching what the user-facing ``reset_draft`` view does."""
+        self.dt_radiant.is_first_pick = True
+        self.dt_radiant.is_radiant = True
+        self.dt_radiant.save()
+        self.dt_dire.is_first_pick = False
+        self.dt_dire.is_radiant = False
+        self.dt_dire.save()
+
+        self.game.dire_team = self.team_dire_corrected
+        self.game.save()
+
+        self.dt_radiant.refresh_from_db()
+        self.dt_dire.refresh_from_db()
+        self.assertIsNone(self.dt_radiant.is_first_pick)
+        self.assertIsNone(self.dt_radiant.is_radiant)
+        self.assertIsNone(self.dt_dire.is_first_pick)
+        self.assertIsNone(self.dt_dire.is_radiant)
+
     def test_reset_broadcasts_draft_reset_event_with_same_pk(self):
         """Connected HeroDraftConsumer clients learn the draft was reset
         via the existing channel group (``herodraft_{pk}``). They can
-        refetch and stay on the same draft URL since the pk is preserved."""
+        refetch and stay on the same draft URL since the pk is preserved.
+
+        The broadcast is deferred to ``transaction.on_commit`` so clients
+        never see pre-commit data; ``captureOnCommitCallbacks(execute=True)``
+        runs the deferred callbacks at block exit (Django ``TestCase``
+        rolls the surrounding transaction back, so on_commit otherwise
+        never fires)."""
         draft_pk = self.draft.pk
 
         mock_layer = MagicMock()
         mock_layer.group_send = AsyncMock()
         with patch(
             "channels.layers.get_channel_layer", return_value=mock_layer
-        ):
+        ), self.captureOnCommitCallbacks(execute=True):
             self.game.dire_team = self.team_dire_corrected
             self.game.save()
 
@@ -277,6 +306,33 @@ class HeroDraftResetOnGameTeamChangeTest(TestCase):
         self.assertEqual(payload["metadata"]["reason"], "teams_changed")
         self.assertEqual(payload["metadata"]["game_id"], self.game.pk)
 
+    def test_broadcast_is_deferred_until_transaction_commit(self):
+        """Regression for the in-transaction race: if the WS broadcast
+        fires while ``save_bracket``'s outer ``@transaction.atomic`` is
+        still open, clients refetch and read pre-reset rows (or repopulate
+        cacheops with them), defeating the whole reset. The broadcast must
+        be scheduled on commit, not run synchronously inside the signal."""
+        mock_layer = MagicMock()
+        mock_layer.group_send = AsyncMock()
+        with patch(
+            "channels.layers.get_channel_layer", return_value=mock_layer
+        ), self.captureOnCommitCallbacks(execute=False) as callbacks:
+            self.game.dire_team = self.team_dire_corrected
+            self.game.save()
+            # Inside the block: the signal has run and the rows are
+            # updated, but the broadcast must NOT have fired yet. (The
+            # ``callbacks`` list is only populated at block exit, so
+            # length is asserted after the ``with``.)
+            mock_layer.group_send.assert_not_called()
+
+        # ``execute=False`` leaves the captured callbacks unrun, so the
+        # broadcast still has not fired even after the block. The list
+        # has more than one entry because ``invalidate_after_commit`` also
+        # registers an on_commit hook — we only care that *the broadcast*
+        # was deferred, not the precise count.
+        self.assertGreaterEqual(len(callbacks), 1)
+        mock_layer.group_send.assert_not_called()
+
     def test_clearing_team_to_none_broadcasts_draft_invalidated(self):
         """The delete-fallback path uses event_type=draft_invalidated so the
         frontend can show a different message from the in-place reset
@@ -287,7 +343,7 @@ class HeroDraftResetOnGameTeamChangeTest(TestCase):
         mock_layer.group_send = AsyncMock()
         with patch(
             "channels.layers.get_channel_layer", return_value=mock_layer
-        ):
+        ), self.captureOnCommitCallbacks(execute=True):
             self.game.dire_team = None
             self.game.save()
 
@@ -307,7 +363,7 @@ class HeroDraftResetOnGameTeamChangeTest(TestCase):
         failing_layer.group_send.side_effect = RuntimeError("channel down")
         with patch(
             "channels.layers.get_channel_layer", return_value=failing_layer
-        ):
+        ), self.captureOnCommitCallbacks(execute=True):
             self.game.dire_team = self.team_dire_corrected
             self.game.save()  # must not raise
 

--- a/backend/app/tests/test_herodraft_stale_purge.py
+++ b/backend/app/tests/test_herodraft_stale_purge.py
@@ -1,0 +1,159 @@
+"""Tests for the pre_save signal that purges stale HeroDraft on Game team
+change (issue #235).
+
+Scenario the signal exists to prevent: an admin sets a bracket match's
+teams incorrectly, a HeroDraft is created for that match, then the bracket
+is reset/re-saved with the correct teams. Without the signal, the
+DraftTeam rows still FK the previous teams and the draft UI keeps showing
+the wrong captains — no client reload recovers it.
+"""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from app.models import (
+    CustomUser,
+    DraftTeam,
+    Game,
+    HeroDraft,
+    PositionsModel,
+    Team,
+    Tournament,
+)
+
+
+def _make_user(username):
+    positions = PositionsModel.objects.create()
+    return CustomUser.objects.create(
+        username=username,
+        discordId=f"discord_{username}",
+        positions=positions,
+    )
+
+
+def _make_team(tournament, name, captain):
+    team = Team.objects.create(tournament=tournament, name=name)
+    team.members.set([captain])
+    team.captain = captain
+    team.save()
+    return team
+
+
+class HeroDraftPurgedOnGameTeamChangeTest(TestCase):
+    def setUp(self):
+        self.tournament = Tournament.objects.create(
+            name="Bug 235 Tournament",
+            tournament_type="double_elimination",
+            date_played=timezone.now(),
+        )
+
+        # Captains.
+        self.cap_radiant_original = _make_user("light")
+        self.cap_dire_original = _make_user("heff")
+        self.cap_dire_corrected = _make_user("noks")
+
+        # Tournament teams (HeroDraft FKs these via DraftTeam.tournament_team).
+        self.team_radiant = _make_team(
+            self.tournament, "Radiant", self.cap_radiant_original
+        )
+        self.team_dire_original = _make_team(
+            self.tournament, "Dire (wrong)", self.cap_dire_original
+        )
+        self.team_dire_corrected = _make_team(
+            self.tournament, "Dire (corrected)", self.cap_dire_corrected
+        )
+
+        self.tournament.users.add(
+            self.cap_radiant_original,
+            self.cap_dire_original,
+            self.cap_dire_corrected,
+        )
+
+        # Bracket match with the wrong dire team, then a HeroDraft on it.
+        self.game = Game.objects.create(
+            tournament=self.tournament,
+            radiant_team=self.team_radiant,
+            dire_team=self.team_dire_original,
+        )
+        self.draft = HeroDraft.objects.create(game=self.game)
+        DraftTeam.objects.create(
+            draft=self.draft, tournament_team=self.team_radiant
+        )
+        DraftTeam.objects.create(
+            draft=self.draft, tournament_team=self.team_dire_original
+        )
+
+    def test_changing_dire_team_purges_herodraft(self):
+        """The exact reproduction from issue #235: bracket is re-saved with a
+        different dire team; the existing HeroDraft (stuck on the old team)
+        must be deleted so the next start-draft call rebuilds a clean one."""
+        draft_pk = self.draft.pk
+        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
+
+        # Simulate save_bracket overwriting the dire team on the existing Game.
+        self.game.dire_team = self.team_dire_corrected
+        self.game.save()
+
+        self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
+        self.assertFalse(
+            DraftTeam.objects.filter(draft_id=draft_pk).exists(),
+            "DraftTeam rows should cascade-delete with HeroDraft",
+        )
+
+    def test_changing_radiant_team_purges_herodraft(self):
+        """Same purge fires when the radiant slot is the one rewritten
+        (e.g. advance_winner from an upstream game flips which team feeds
+        the radiant slot of this downstream match)."""
+        draft_pk = self.draft.pk
+        other_radiant = _make_team(
+            self.tournament, "Other Radiant", _make_user("other_cap")
+        )
+
+        self.game.radiant_team = other_radiant
+        self.game.save()
+
+        self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
+
+    def test_clearing_a_team_to_none_purges_herodraft(self):
+        """The ``advance_winner`` unset path can leave a Game's slot empty;
+        the captured DraftTeam.tournament_team is then orphaned. Treat the
+        clear as a change and purge."""
+        draft_pk = self.draft.pk
+
+        self.game.dire_team = None
+        self.game.save()
+
+        self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
+
+    def test_saving_game_with_unchanged_teams_preserves_herodraft(self):
+        """Status / next_game / scheduling changes must NOT nuke the draft —
+        only actual team-slot changes do."""
+        draft_pk = self.draft.pk
+
+        self.game.status = "live"
+        self.game.swiss_record_wins = 1
+        self.game.save()
+
+        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
+
+    def test_creating_a_game_does_not_error(self):
+        """The pre_save guard must short-circuit cleanly for new (unsaved)
+        Game instances — there's no prior row to compare against and no
+        HeroDraft yet."""
+        Game.objects.create(
+            tournament=self.tournament,
+            radiant_team=self.team_radiant,
+            dire_team=self.team_dire_corrected,
+        )
+
+    def test_game_with_no_herodraft_team_change_is_noop(self):
+        """Games without a HeroDraft must change teams freely with no error
+        — most bracket matches go through advance_winner before anyone
+        starts a draft on them."""
+        other_game = Game.objects.create(
+            tournament=self.tournament,
+            radiant_team=self.team_radiant,
+            dire_team=self.team_dire_original,
+        )
+        other_game.dire_team = self.team_dire_corrected
+        other_game.save()  # must not raise

--- a/backend/app/tests/test_herodraft_stale_purge.py
+++ b/backend/app/tests/test_herodraft_stale_purge.py
@@ -1,12 +1,23 @@
-"""Tests for the pre_save signal that purges stale HeroDraft on Game team
-change (issue #235).
+"""Tests for the pre_save signal that resets a stale HeroDraft when the
+underlying Game's teams change (issue #235).
 
-Scenario the signal exists to prevent: an admin sets a bracket match's
-teams incorrectly, a HeroDraft is created for that match, then the bracket
-is reset/re-saved with the correct teams. Without the signal, the
-DraftTeam rows still FK the previous teams and the draft UI keeps showing
-the wrong captains — no client reload recovers it.
+Scenario the signal exists to handle: an admin sets a bracket match's
+teams incorrectly, a HeroDraft is created for that match, then the
+bracket is reset/re-saved with the correct teams. Without the signal,
+the DraftTeam rows still FK the previous teams and the draft UI keeps
+showing the wrong captains; no client reload recovers it.
+
+The signal resets the draft **in place** — same HeroDraft pk, repointed
+DraftTeam.tournament_team FKs, cleared rounds/state, kept event-log
+history — so any external reference to the draft (Discord-posted
+``/herodraft/{pk}/`` link, etc.) keeps working.
+
+Edge case: when a Game slot is cleared to NULL (the in-place reset can't
+repoint to None because DraftTeam.tournament_team is non-nullable) the
+signal falls back to deleting the HeroDraft.
 """
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import TestCase
 from django.utils import timezone
@@ -16,6 +27,9 @@ from app.models import (
     DraftTeam,
     Game,
     HeroDraft,
+    HeroDraftEvent,
+    HeroDraftRound,
+    HeroDraftState,
     PositionsModel,
     Team,
     Tournament,
@@ -39,7 +53,7 @@ def _make_team(tournament, name, captain):
     return team
 
 
-class HeroDraftPurgedOnGameTeamChangeTest(TestCase):
+class HeroDraftResetOnGameTeamChangeTest(TestCase):
     def setUp(self):
         self.tournament = Tournament.objects.create(
             name="Bug 235 Tournament",
@@ -75,35 +89,84 @@ class HeroDraftPurgedOnGameTeamChangeTest(TestCase):
             radiant_team=self.team_radiant,
             dire_team=self.team_dire_original,
         )
-        self.draft = HeroDraft.objects.create(game=self.game)
-        DraftTeam.objects.create(
-            draft=self.draft, tournament_team=self.team_radiant
+        self.draft = HeroDraft.objects.create(
+            game=self.game,
+            state=HeroDraftState.DRAFTING,
         )
-        DraftTeam.objects.create(
-            draft=self.draft, tournament_team=self.team_dire_original
+        self.dt_radiant = DraftTeam.objects.create(
+            draft=self.draft,
+            tournament_team=self.team_radiant,
+            is_ready=True,
+            is_connected=True,
+            reserve_time_remaining=42000,
+        )
+        self.dt_dire = DraftTeam.objects.create(
+            draft=self.draft,
+            tournament_team=self.team_dire_original,
+            is_ready=True,
+            is_connected=True,
+            reserve_time_remaining=37000,
         )
 
-    def test_changing_dire_team_purges_herodraft(self):
-        """The exact reproduction from issue #235: bracket is re-saved with a
-        different dire team; the existing HeroDraft (stuck on the old team)
-        must be deleted so the next start-draft call rebuilds a clean one."""
+        # A pick from the wrong captain, and an audit-log event.
+        HeroDraftRound.objects.create(
+            draft=self.draft,
+            draft_team=self.dt_dire,
+            action_type="pick",
+            state="completed",
+            round_number=1,
+            hero_id=1,
+        )
+        HeroDraftEvent.objects.create(
+            draft=self.draft,
+            event_type="captain_connected",
+            metadata={"who": "wrong_captain"},
+        )
+
+    def test_changing_dire_team_resets_draft_in_place(self):
+        """The exact reproduction from issue #235. After the bracket is
+        re-saved with the correct dire team:
+        - The HeroDraft pk is preserved (Discord links still work).
+        - The dire DraftTeam now points at the corrected team, so its
+          captain resolves to the right user.
+        - Picks/bans from the wrong captain are wiped.
+        - DraftTeam ready/connected flags reset (captains must re-join).
+        - Draft state returns to WAITING_FOR_CAPTAINS."""
         draft_pk = self.draft.pk
-        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
 
-        # Simulate save_bracket overwriting the dire team on the existing Game.
         self.game.dire_team = self.team_dire_corrected
         self.game.save()
 
-        self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
-        self.assertFalse(
-            DraftTeam.objects.filter(draft_id=draft_pk).exists(),
-            "DraftTeam rows should cascade-delete with HeroDraft",
-        )
+        # Same row — pk preserved.
+        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
+        draft = HeroDraft.objects.get(pk=draft_pk)
+        self.assertEqual(draft.state, HeroDraftState.WAITING_FOR_CAPTAINS)
+        self.assertIsNone(draft.roll_winner)
+        self.assertIsNone(draft.paused_at)
+        self.assertIsNone(draft.resuming_until)
+        self.assertFalse(draft.is_manual_pause)
 
-    def test_changing_radiant_team_purges_herodraft(self):
-        """Same purge fires when the radiant slot is the one rewritten
-        (e.g. advance_winner from an upstream game flips which team feeds
-        the radiant slot of this downstream match)."""
+        # DraftTeams repointed to current Game teams.
+        self.dt_radiant.refresh_from_db()
+        self.dt_dire.refresh_from_db()
+        self.assertEqual(self.dt_radiant.tournament_team, self.team_radiant)
+        self.assertEqual(self.dt_dire.tournament_team, self.team_dire_corrected)
+
+        # Ready / connected flags reset (captains must re-join).
+        self.assertFalse(self.dt_radiant.is_ready)
+        self.assertFalse(self.dt_radiant.is_connected)
+        self.assertEqual(self.dt_radiant.reserve_time_remaining, 90000)
+        self.assertFalse(self.dt_dire.is_ready)
+        self.assertFalse(self.dt_dire.is_connected)
+        self.assertEqual(self.dt_dire.reserve_time_remaining, 90000)
+
+        # Picks/bans from the wrong captain are gone.
+        self.assertFalse(HeroDraftRound.objects.filter(draft_id=draft_pk).exists())
+
+    def test_changing_radiant_team_resets_draft_in_place(self):
+        """Same reset fires when the radiant slot is the one rewritten
+        (e.g. advance_winner flips which team feeds the radiant slot of
+        this downstream match)."""
         draft_pk = self.draft.pk
         other_radiant = _make_team(
             self.tournament, "Other Radiant", _make_user("other_cap")
@@ -112,29 +175,60 @@ class HeroDraftPurgedOnGameTeamChangeTest(TestCase):
         self.game.radiant_team = other_radiant
         self.game.save()
 
-        self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
+        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
+        self.dt_radiant.refresh_from_db()
+        self.assertEqual(self.dt_radiant.tournament_team, other_radiant)
 
-    def test_clearing_a_team_to_none_purges_herodraft(self):
-        """The ``advance_winner`` unset path can leave a Game's slot empty;
-        the captured DraftTeam.tournament_team is then orphaned. Treat the
-        clear as a change and purge."""
+    def test_clearing_team_to_none_falls_back_to_delete(self):
+        """DraftTeam.tournament_team is non-nullable, so the in-place reset
+        can't repoint a slot to None. When a Game slot is cleared
+        (e.g. mid-bracket-reset, before winners are re-entered), fall back
+        to deleting the HeroDraft. Once the bracket is re-saved with real
+        teams, create_herodraft rebuilds. The Discord link 404s in this
+        narrow window — better than leaving stale FK state."""
         draft_pk = self.draft.pk
 
         self.game.dire_team = None
         self.game.save()
 
         self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
+        self.assertFalse(
+            DraftTeam.objects.filter(draft_id=draft_pk).exists(),
+            "DraftTeam rows should cascade-delete with HeroDraft",
+        )
 
-    def test_saving_game_with_unchanged_teams_preserves_herodraft(self):
-        """Status / next_game / scheduling changes must NOT nuke the draft —
-        only actual team-slot changes do."""
+    def test_reset_keeps_herodraft_event_history(self):
+        """HeroDraftEvent rows survive the reset — they're the audit trail
+        of the wrong setup ever happening. Clearing them would hide that."""
+        draft_pk = self.draft.pk
+        events_before = list(
+            HeroDraftEvent.objects.filter(draft_id=draft_pk).values_list("pk", flat=True)
+        )
+        self.assertTrue(events_before)
+
+        self.game.dire_team = self.team_dire_corrected
+        self.game.save()
+
+        events_after = list(
+            HeroDraftEvent.objects.filter(draft_id=draft_pk).values_list("pk", flat=True)
+        )
+        self.assertEqual(set(events_before), set(events_after))
+
+    def test_saving_game_with_unchanged_teams_preserves_draft_state(self):
+        """Status / next_game / scheduling changes must NOT reset the draft
+        — only actual team-slot changes do."""
         draft_pk = self.draft.pk
 
         self.game.status = "live"
         self.game.swiss_record_wins = 1
         self.game.save()
 
-        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
+        draft = HeroDraft.objects.get(pk=draft_pk)
+        self.assertEqual(draft.state, HeroDraftState.DRAFTING)
+        self.dt_dire.refresh_from_db()
+        self.assertTrue(self.dt_dire.is_ready)
+        self.assertEqual(self.dt_dire.tournament_team, self.team_dire_original)
+        self.assertTrue(HeroDraftRound.objects.filter(draft_id=draft_pk).exists())
 
     def test_creating_a_game_does_not_error(self):
         """The pre_save guard must short-circuit cleanly for new (unsaved)
@@ -157,3 +251,68 @@ class HeroDraftPurgedOnGameTeamChangeTest(TestCase):
         )
         other_game.dire_team = self.team_dire_corrected
         other_game.save()  # must not raise
+
+    def test_reset_broadcasts_draft_reset_event_with_same_pk(self):
+        """Connected HeroDraftConsumer clients learn the draft was reset
+        via the existing channel group (``herodraft_{pk}``). They can
+        refetch and stay on the same draft URL since the pk is preserved."""
+        draft_pk = self.draft.pk
+
+        mock_layer = MagicMock()
+        mock_layer.group_send = AsyncMock()
+        with patch(
+            "channels.layers.get_channel_layer", return_value=mock_layer
+        ):
+            self.game.dire_team = self.team_dire_corrected
+            self.game.save()
+
+        # Draft row still exists.
+        self.assertTrue(HeroDraft.objects.filter(pk=draft_pk).exists())
+        # And the broadcast fired.
+        mock_layer.group_send.assert_called_once()
+        group_name, payload = mock_layer.group_send.call_args.args
+        self.assertEqual(group_name, f"herodraft_{draft_pk}")
+        self.assertEqual(payload["type"], "herodraft.event")
+        self.assertEqual(payload["event_type"], "draft_reset")
+        self.assertEqual(payload["metadata"]["reason"], "teams_changed")
+        self.assertEqual(payload["metadata"]["game_id"], self.game.pk)
+
+    def test_clearing_team_to_none_broadcasts_draft_invalidated(self):
+        """The delete-fallback path uses event_type=draft_invalidated so the
+        frontend can show a different message from the in-place reset
+        (where the same draft URL keeps working)."""
+        draft_pk = self.draft.pk
+
+        mock_layer = MagicMock()
+        mock_layer.group_send = AsyncMock()
+        with patch(
+            "channels.layers.get_channel_layer", return_value=mock_layer
+        ):
+            self.game.dire_team = None
+            self.game.save()
+
+        self.assertFalse(HeroDraft.objects.filter(pk=draft_pk).exists())
+        mock_layer.group_send.assert_called_once()
+        group_name, payload = mock_layer.group_send.call_args.args
+        self.assertEqual(group_name, f"herodraft_{draft_pk}")
+        self.assertEqual(payload["event_type"], "draft_invalidated")
+
+    def test_reset_still_succeeds_when_channel_layer_send_fails(self):
+        """The in-place reset is the integrity guarantee; the WS broadcast
+        is best-effort. A channel layer failure must NOT block the reset
+        or raise."""
+        draft_pk = self.draft.pk
+
+        failing_layer = MagicMock()
+        failing_layer.group_send.side_effect = RuntimeError("channel down")
+        with patch(
+            "channels.layers.get_channel_layer", return_value=failing_layer
+        ):
+            self.game.dire_team = self.team_dire_corrected
+            self.game.save()  # must not raise
+
+        # Reset still applied to the row.
+        draft = HeroDraft.objects.get(pk=draft_pk)
+        self.assertEqual(draft.state, HeroDraftState.WAITING_FOR_CAPTAINS)
+        self.dt_dire.refresh_from_db()
+        self.assertEqual(self.dt_dire.tournament_team, self.team_dire_corrected)

--- a/backend/app/views/bracket.py
+++ b/backend/app/views/bracket.py
@@ -205,6 +205,20 @@ def save_bracket(request, tournament_id):
             dire_team["pk"] if dire_team and dire_team.get("pk") else None
         )
 
+        # Persist the winning team from the FE's `winner` field
+        # ('radiant' | 'dire' | None). Without this, clicking "Set Winner"
+        # in the match modal and then Save would store status='completed'
+        # but leave winning_team=NULL — mapApiMatchToMatch can't derive
+        # match.winner on reload, the bracket card loses its green check,
+        # and the row goes "stuck" (covered by issue #235).
+        winner_slot = match.get("winner")
+        if winner_slot == "radiant":
+            game.winning_team_id = game.radiant_team_id
+        elif winner_slot == "dire":
+            game.winning_team_id = game.dire_team_id
+        else:
+            game.winning_team_id = None
+
         # Clear next_game/loser_next_game before pass 2 rewires them
         game.next_game = None
         game.loser_next_game = None

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -34,6 +34,12 @@ from tests.data.users import (
     USER_CLAIMER,
 )
 
+# Populate functions for non-standard tournament resets. Top-level imports —
+# the previous lambda+__import__ form was a holdover; these are leaf modules
+# with no circular-import risk.
+from tests.populate.bracket import populate_bracket_unset_winner_tournament
+from tests.populate.shuffle_tie import populate_shuffle_tie_data
+
 log = logging.getLogger(__name__)
 
 
@@ -742,20 +748,16 @@ def reset_tournament_by_key(request, key: str):
     from app.serializers import TournamentSerializer
     from tests.helpers.tournament_config import TEST_TOURNAMENTS
 
-    # Special reset functions for non-standard tournament configs
+    # Special reset functions for non-standard tournament configs.
+    # Each entry is the populate function itself, called with force=True below.
     RESET_FUNCTIONS = {
-        "shuffle_tie_resolution": lambda: __import__(
-            "tests.populate.shuffle_tie", fromlist=["populate_shuffle_tie_data"]
-        ).populate_shuffle_tie_data(force=True),
-        "bracket_unset_winner": lambda: __import__(
-            "tests.populate.bracket",
-            fromlist=["populate_bracket_unset_winner_tournament"],
-        ).populate_bracket_unset_winner_tournament(force=True),
+        "shuffle_tie_resolution": populate_shuffle_tie_data,
+        "bracket_unset_winner": populate_bracket_unset_winner_tournament,
     }
 
     reset_fn = RESET_FUNCTIONS.get(key)
     if reset_fn:
-        tournament = reset_fn()
+        tournament = reset_fn(force=True)
         tournament = Tournament.objects.get(pk=tournament.pk)
         return Response(TournamentSerializer(tournament).data)
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -747,6 +747,10 @@ def reset_tournament_by_key(request, key: str):
         "shuffle_tie_resolution": lambda: __import__(
             "tests.populate.shuffle_tie", fromlist=["populate_shuffle_tie_data"]
         ).populate_shuffle_tie_data(force=True),
+        "bracket_unset_winner": lambda: __import__(
+            "tests.populate.bracket",
+            fromlist=["populate_bracket_unset_winner_tournament"],
+        ).populate_bracket_unset_winner_tournament(force=True),
     }
 
     reset_fn = RESET_FUNCTIONS.get(key)

--- a/backend/tests/test_bracket.py
+++ b/backend/tests/test_bracket.py
@@ -1,0 +1,103 @@
+"""Test-only endpoints for bracket scenarios that are awkward to create
+through the regular API but easy to verify with Playwright.
+
+Exposed at ``/api/tests/bracket/...`` and gated on ``isTestEnvironment``;
+returns 404 in any non-test environment.
+"""
+
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from app.models import Game, Team
+from common.utils import isTestEnvironment
+
+
+@csrf_exempt
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([AllowAny])
+def force_mismatched_winning_team(request):
+    """Force a Game into the "stuck" state from issue #235:
+
+      Game.status         = 'completed'
+      Game.winning_team   = <a team that is NEITHER radiant_team NOR dire_team>
+
+    Reproduces the production bug where a winner was set, then the Game's
+    teams were rewritten (by ``save_bracket`` or ``advance_winner``)
+    leaving ``winning_team_id`` pointing at the prior team. The frontend
+    can no longer derive ``match.winner`` so both Set Winner (gated on
+    status != 'completed') and the *original* Unset Winner (gated on
+    match.winner being truthy) are hidden — admins stuck.
+
+    Body::
+
+        {"game_id": <int>}
+
+    Picks any team in the game's tournament that's NOT already in either
+    slot, assigns it as ``winning_team``, sets ``status='completed'``,
+    saves. Returns the chosen winning_team_id so the caller can assert
+    against it.
+    """
+    if not isTestEnvironment(request):
+        return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+    game_id = request.data.get("game_id")
+    if not game_id:
+        return Response(
+            {"error": "game_id is required"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        game = Game.objects.get(pk=game_id)
+    except Game.DoesNotExist:
+        return Response(
+            {"error": f"Game {game_id} not found"},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    if not game.tournament_id:
+        return Response(
+            {"error": f"Game {game_id} has no tournament — cannot pick another team"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    excluded_pks = {pk for pk in (game.radiant_team_id, game.dire_team_id) if pk}
+    other_team = (
+        Team.objects.filter(tournament_id=game.tournament_id)
+        .exclude(pk__in=excluded_pks)
+        .first()
+    )
+    if not other_team:
+        return Response(
+            {
+                "error": "No other team available in the tournament to use as a "
+                "mismatched winning_team. Add at least one extra team."
+            },
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Only changes winning_team_id + status, so the pre_save Game signal
+    # short-circuits (its early-return checks radiant_team_id / dire_team_id
+    # only) and we don't accidentally reset an attached HeroDraft.
+    game.winning_team = other_team
+    game.status = "completed"
+    game.save()
+
+    return Response(
+        {
+            "game_id": game.pk,
+            "winning_team_id": other_team.pk,
+            "winning_team_name": other_team.name,
+            "radiant_team_id": game.radiant_team_id,
+            "dire_team_id": game.dire_team_id,
+            "status": game.status,
+        }
+    )

--- a/backend/tests/urls.py
+++ b/backend/tests/urls.py
@@ -27,6 +27,7 @@ from .test_auth import (
     reset_tournament_by_key,
     sync_discord_events_test,
 )
+from .test_bracket import force_mismatched_winning_team
 from .test_csv import reset_csv_import
 from .test_demo import generate_demo_bracket, get_demo_tournament, reset_demo_tournament
 from .test_health import healthz
@@ -243,4 +244,10 @@ urlpatterns = [
         name="test-demo-get",
     ),
     path("healthz/", healthz, name="test-healthz"),
+    # Bracket scenario helpers (gated on TEST=true)
+    path(
+        "bracket/force-mismatched-winning-team/",
+        force_mismatched_winning_team,
+        name="test-bracket-force-mismatched-winning-team",
+    ),
 ]

--- a/frontend/app/components/bracket/modals/MatchStatsModal.tsx
+++ b/frontend/app/components/bracket/modals/MatchStatsModal.tsx
@@ -221,8 +221,15 @@ export function MatchStatsModal({ match: matchProp, isOpen, onClose, initialDraf
             </div>
           )}
 
-          {/* Unset Winner - only show if match has winner */}
-          {isLeagueStaff && match.status === 'completed' && match.winner && (
+          {/* Unset Winner — show whenever the row is "set", even if the
+              derived winner is missing. A match can land in status=completed
+              with winner=undefined when the backend's winning_team FK
+              doesn't match either current radiant_team / dire_team (e.g. a
+              prior team change broke the derivation in bracketStore.ts), and
+              admins need a recovery path. The unset is a pending local
+              change (isDirty=true) and only persists on Save, so showing
+              the button even mid-edit is safe. */}
+          {isLeagueStaff && (match.status === 'completed' || match.winner) && (
             <div className="border-t pt-4">
               <SecondaryButton
                 size="sm"

--- a/frontend/app/components/bracket/nodes/MatchNode.tsx
+++ b/frontend/app/components/bracket/nodes/MatchNode.tsx
@@ -68,6 +68,7 @@ export const MatchNode = memo(({ data, selected }: NodeProps & { data: MatchNode
       data-bracket-type={data.bracketType}
       data-round={data.round}
       data-position={data.position}
+      data-game-pk={data.gameId ?? ''}
       className={cn(
         'w-52 cursor-pointer transition-all relative',
         bracketStyle.bg,
@@ -103,6 +104,7 @@ export const MatchNode = memo(({ data, selected }: NodeProps & { data: MatchNode
           score={data.radiantScore}
           isWinner={data.winner === 'radiant'}
           isCompleted={data.status === 'completed'}
+          slot="radiant"
         />
         <div className="border-t my-1" />
         <TeamSlot
@@ -110,6 +112,7 @@ export const MatchNode = memo(({ data, selected }: NodeProps & { data: MatchNode
           score={data.direScore}
           isWinner={data.winner === 'dire'}
           isCompleted={data.status === 'completed'}
+          slot="dire"
         />
       </BaseNodeContent>
 
@@ -131,12 +134,17 @@ interface TeamSlotProps {
   score?: number;
   isWinner: boolean;
   isCompleted: boolean;
+  slot: 'radiant' | 'dire';
 }
 
-function TeamSlot({ team, score, isWinner, isCompleted }: TeamSlotProps) {
+function TeamSlot({ team, score, isWinner, isCompleted, slot }: TeamSlotProps) {
   if (!team) {
     return (
-      <div className="flex items-center gap-2 p-1.5 rounded bg-muted/50">
+      <div
+        className="flex items-center gap-2 p-1.5 rounded bg-muted/50"
+        data-testid={`bracket-team-slot-${slot}`}
+        data-team-status="empty"
+      >
         <div className="h-6 w-6 rounded-full bg-muted" />
         <span className="text-xs text-muted-foreground italic">TBD</span>
       </div>
@@ -155,6 +163,9 @@ function TeamSlot({ team, score, isWinner, isCompleted }: TeamSlotProps) {
         isWinner && isCompleted && 'bg-green-500/10',
         !isWinner && isCompleted && 'opacity-50'
       )}
+      data-testid={`bracket-team-slot-${slot}`}
+      data-team-status={isCompleted ? (isWinner ? 'winner' : 'loser') : 'pending'}
+      data-team-pk={team.pk}
     >
       {/* Captain avatar */}
       <Avatar className="h-6 w-6">
@@ -188,7 +199,14 @@ function TeamSlot({ team, score, isWinner, isCompleted }: TeamSlotProps) {
       )}
 
       {/* Winner indicator */}
-      {isWinner && isCompleted && <span className="text-green-500">&#x2713;</span>}
+      {isWinner && isCompleted && (
+        <span
+          className="text-green-500"
+          data-testid={`bracket-winner-check-${slot}`}
+        >
+          &#x2713;
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/app/components/herodraft/DraftToasts.tsx
+++ b/frontend/app/components/herodraft/DraftToasts.tsx
@@ -4,7 +4,7 @@ import { UserAvatar } from "~/components/user/UserAvatar";
 
 interface CaptainInfo {
   pk: number;
-  username: string;
+  username: string | null;
   nickname: string | null;
   avatar: string | null;
   avatarUrl?: string | null;

--- a/frontend/app/components/herodraft/DraftTopBar.tsx
+++ b/frontend/app/components/herodraft/DraftTopBar.tsx
@@ -26,7 +26,7 @@ function formatTime(ms: number): string {
  */
 function captainToUser(captain: {
   pk: number;
-  username: string;
+  username: string | null;
   nickname: string | null;
   avatar: string | null;
   avatarUrl?: string | null;
@@ -115,7 +115,7 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
 
   // Helper to render a player avatar with name underneath
   const renderPlayer = (
-    player: { pk: number; username: string; nickname: string | null; avatar: string | null; avatarUrl?: string | null; discordId?: string | null },
+    player: { pk: number; username: string | null; nickname: string | null; avatar: string | null; avatarUrl?: string | null; discordId?: string | null },
     isCaptain: boolean,
     testIdPrefix: string
   ) => (

--- a/frontend/app/components/herodraft/__tests__/schemas.test.ts
+++ b/frontend/app/components/herodraft/__tests__/schemas.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DraftTeamCaptainSchema,
+  DraftTeamSchema,
+  HeroDraftSchema,
+  HeroDraftWebSocketMessageSchema,
+} from '~/components/herodraft/schemas';
+
+// CustomUser.username is declared null=True at the model level so that
+// Steam-only signups (no Discord OAuth, no chosen handle) can still exist
+// as DB rows. When such a user is added to a tournament team, the team
+// gets included verbatim in the HeroDraft initial_state WS payload via
+// DraftTeamSerializerFull. Before this PR, the frontend Zod schemas had
+// ``username: z.string()`` — a single Steam-only player on any team in
+// any draft was enough to fail safeParse on the entire ``initial_state``
+// message, causing heroDraftStore to early-return without setting
+// ``draft``. The page then rendered blank.
+//
+// These tests lock the schema contract to match the model.
+
+const captainStub = {
+  pk: 1,
+  username: 'kettleofketchup',
+  nickname: null,
+  avatar: null,
+};
+
+const captainStubNullUsername = {
+  ...captainStub,
+  username: null,
+};
+
+describe('DraftTeamCaptainSchema', () => {
+  it('accepts a Steam-only user (username: null)', () => {
+    expect(() =>
+      DraftTeamCaptainSchema.parse(captainStubNullUsername),
+    ).not.toThrow();
+  });
+
+  it('still accepts a normal user (username: string)', () => {
+    expect(() => DraftTeamCaptainSchema.parse(captainStub)).not.toThrow();
+  });
+});
+
+describe('DraftTeamSchema members[]', () => {
+  it('accepts a roster that includes a Steam-only member', () => {
+    const team = {
+      id: 1,
+      tournament_team: 35,
+      captain: captainStub,
+      team_name: 'Team 1',
+      members: [
+        captainStub,
+        captainStubNullUsername, // the regression case
+      ],
+      is_first_pick: null,
+      is_radiant: null,
+      reserve_time_remaining: 90000,
+      is_ready: false,
+      is_connected: false,
+    };
+    expect(() => DraftTeamSchema.parse(team)).not.toThrow();
+  });
+});
+
+describe('HeroDraftWebSocketMessageSchema initial_state', () => {
+  it('parses a real shape with a Steam-only member nested under draft_teams', () => {
+    // Mirrors the payload tournament 8 / herodraft 2 sends — the
+    // exact case that triggered the blank-screen bug.
+    const initial = {
+      type: 'initial_state' as const,
+      draft_state: {
+        id: 2,
+        game: 99,
+        tournament_id: 8,
+        state: 'waiting_for_captains' as const,
+        roll_winner: null,
+        draft_teams: [
+          {
+            id: 1,
+            tournament_team: 35,
+            captain: captainStub,
+            team_name: 'Team 1',
+            members: [captainStub],
+            is_first_pick: null,
+            is_radiant: null,
+            reserve_time_remaining: 90000,
+            is_ready: false,
+            is_connected: false,
+          },
+          {
+            id: 2,
+            tournament_team: 36,
+            captain: captainStub,
+            team_name: 'Team 2',
+            members: [
+              captainStub,
+              captainStubNullUsername, // the actual production payload shape
+            ],
+            is_first_pick: null,
+            is_radiant: null,
+            reserve_time_remaining: 90000,
+            is_ready: false,
+            is_connected: false,
+          },
+        ],
+        rounds: [],
+        current_round: null,
+        created_at: '2026-05-19T00:00:00Z',
+        updated_at: '2026-05-19T00:00:00Z',
+      },
+    };
+    const parsed = HeroDraftWebSocketMessageSchema.safeParse(initial);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('HeroDraftSchema', () => {
+  it('rejects a username of the wrong type (number) — sanity check', () => {
+    const team = {
+      ...captainStub,
+      username: 123 as unknown as string,
+    };
+    expect(() => DraftTeamCaptainSchema.parse(team)).toThrow();
+  });
+});

--- a/frontend/app/components/herodraft/__tests__/schemas.test.ts
+++ b/frontend/app/components/herodraft/__tests__/schemas.test.ts
@@ -6,18 +6,6 @@ import {
   HeroDraftWebSocketMessageSchema,
 } from '~/components/herodraft/schemas';
 
-// CustomUser.username is declared null=True at the model level so that
-// Steam-only signups (no Discord OAuth, no chosen handle) can still exist
-// as DB rows. When such a user is added to a tournament team, the team
-// gets included verbatim in the HeroDraft initial_state WS payload via
-// DraftTeamSerializerFull. Before this PR, the frontend Zod schemas had
-// ``username: z.string()`` — a single Steam-only player on any team in
-// any draft was enough to fail safeParse on the entire ``initial_state``
-// message, causing heroDraftStore to early-return without setting
-// ``draft``. The page then rendered blank.
-//
-// These tests lock the schema contract to match the model.
-
 const captainStub = {
   pk: 1,
   username: 'kettleofketchup',

--- a/frontend/app/components/herodraft/schemas.ts
+++ b/frontend/app/components/herodraft/schemas.ts
@@ -2,7 +2,10 @@ import { z } from 'zod';
 
 export const DraftTeamCaptainSchema = z.object({
   pk: z.number(),  // Backend uses 'pk' not 'id'
-  username: z.string(),
+  // ``CustomUser.username`` is nullable (Steam-only signups don't pick one),
+  // so the schema has to accept null too. Render sites fall back to
+  // nickname / '?' via DisplayName.
+  username: z.string().nullable(),
   nickname: z.string().nullable(),
   avatar: z.string().nullable(),
   avatarUrl: z.string().nullable().optional(),

--- a/frontend/app/components/user/UserAvatar.tsx
+++ b/frontend/app/components/user/UserAvatar.tsx
@@ -9,7 +9,10 @@ import type { UserType, UserClassType, GuildMember } from './types';
  */
 type UserLike = UserType | GuildMember | {
   pk?: number;
-  username?: string;
+  // Username can be null for Steam-only signups (CustomUser.username is
+  // null=True at the model level). DisplayName already falls back to
+  // nickname / '?'.
+  username?: string | null;
   nickname?: string | null;
   avatar?: string | null;
   avatarUrl?: string | null;

--- a/frontend/app/components/user/avatar.tsx
+++ b/frontend/app/components/user/avatar.tsx
@@ -6,7 +6,8 @@ import type { GuildMember, UserClassType, UserType } from '~/index';
  * Username can be optional to handle partial data from various sources.
  */
 type DisplayNameable = {
-  username?: string;
+  // Username may be null for Steam-only signups (model field is null=True).
+  username?: string | null;
   nickname?: string | null;
 };
 

--- a/frontend/app/components/user/schemas.ts
+++ b/frontend/app/components/user/schemas.ts
@@ -32,7 +32,10 @@ export type ActiveDraftType = z.infer<typeof ActiveDraftSchema>;
 
 export const UserSchema = z.object({
   positions: PositionSchema.optional(),
-  username: z.string().min(2).max(100),
+  // Nullable because ``CustomUser.username`` is ``null=True`` at the model
+  // level (Steam-only signups). Form schemas (EditUserSchema) still enforce
+  // non-null + length when a user is editing their own profile.
+  username: z.string().min(2).max(100).nullable(),
   avatarUrl: z.string().url().optional(),
   is_staff: z.boolean().optional(),
   is_superuser: z.boolean().optional(),

--- a/frontend/app/hooks/usePermissions.ts
+++ b/frontend/app/hooks/usePermissions.ts
@@ -18,11 +18,20 @@ import type { OrganizationType } from '~/components/organization/schemas';
 import { useUserStore } from '~/store/userStore';
 
 /**
- * Check if the current user is a superuser/staff (Django global admin).
+ * Check if the current user is a site-level admin.
+ *
+ * Django models two flags here:
+ *  - ``is_staff``: can log into the Django admin
+ *  - ``is_superuser``: bypasses all permission checks
+ *
+ * Either grants site-level admin access in this app's permission
+ * hierarchy (site admin > org admin/staff > league admin/staff), so we
+ * accept either. Older callers that only checked ``is_staff`` are
+ * picked up by this same function now.
  */
 export function useIsSuperuser(): boolean {
   const currentUser = useUserStore((state) => state.currentUser);
-  return !!currentUser?.is_staff;
+  return !!(currentUser?.is_staff || currentUser?.is_superuser);
 }
 
 /**
@@ -63,10 +72,14 @@ export function useIsOrganizationAdmin(
   const isOwner = useIsOrganizationOwner(organization);
 
   return useMemo(() => {
-    if (!currentUser?.pk || !organization) return false;
+    if (!currentUser?.pk) return false;
 
-    // Superuser has access to everything
-    if (currentUser.is_staff) return true;
+    // Site admin (is_staff OR is_superuser) outranks every tier and
+    // applies even when no organization is in scope (e.g. a tournament
+    // with no league/org loaded yet).
+    if (currentUser.is_staff || currentUser.is_superuser) return true;
+
+    if (!organization) return false;
 
     // Owner is admin
     if (isOwner) return true;
@@ -80,7 +93,13 @@ export function useIsOrganizationAdmin(
     }
 
     return false;
-  }, [currentUser?.pk, currentUser?.is_staff, organization, isOwner]);
+  }, [
+    currentUser?.pk,
+    currentUser?.is_staff,
+    currentUser?.is_superuser,
+    organization,
+    isOwner,
+  ]);
 }
 
 /**
@@ -97,10 +116,18 @@ export function useIsOrganizationStaff(
   const isOrgAdmin = useIsOrganizationAdmin(organization);
 
   return useMemo(() => {
-    if (!currentUser?.pk || !organization) return false;
+    if (!currentUser?.pk) return false;
 
-    // Org admins have staff access
+    // Site admin (is_staff OR is_superuser) bypasses every tier — must
+    // short-circuit before the !organization early return so a site
+    // admin can still act on tournaments/games whose org isn't loaded.
+    if (currentUser.is_staff || currentUser.is_superuser) return true;
+
+    // Org admins have staff access (cascade through useIsOrganizationAdmin
+    // also picks up site admins, but the explicit check above runs first).
     if (isOrgAdmin) return true;
+
+    if (!organization) return false;
 
     // Check staff_ids array
     if (organization.staff_ids?.includes(currentUser.pk)) return true;
@@ -111,7 +138,13 @@ export function useIsOrganizationStaff(
     }
 
     return false;
-  }, [currentUser?.pk, organization, isOrgAdmin]);
+  }, [
+    currentUser?.pk,
+    currentUser?.is_staff,
+    currentUser?.is_superuser,
+    organization,
+    isOrgAdmin,
+  ]);
 }
 
 /**
@@ -129,25 +162,29 @@ export function useIsLeagueAdmin(
   const currentUser = useUserStore((state) => state.currentUser);
 
   return useMemo(() => {
-    if (!currentUser?.pk || !league) return false;
+    if (!currentUser?.pk) return false;
 
-    // Superuser has access to everything
-    if (currentUser.is_staff) return true;
+    // Site admin (is_staff OR is_superuser) outranks every tier — must
+    // run before the !league guard so a server admin can still edit a
+    // tournament whose league is null.
+    if (currentUser.is_staff || currentUser.is_superuser) return true;
 
-    // Check league-specific admin_ids array
-    if (league.admin_ids?.includes(currentUser.pk)) return true;
-
-    // Check league-specific admins array
-    if (league.admins?.some((admin) => admin.pk === currentUser.pk)) {
-      return true;
+    // League-specific lookups only meaningful when a league is present.
+    if (league) {
+      if (league.admin_ids?.includes(currentUser.pk)) return true;
+      if (league.admins?.some((admin) => admin.pk === currentUser.pk)) {
+        return true;
+      }
     }
 
-    // Check if user is admin of any linked organization
+    // Org-admin cascade: hierarchy puts org > league, so an org admin
+    // of the linked org grants league-admin access. Works even with no
+    // league, as long as ``organizations`` was passed in.
     const orgs = Array.isArray(organizations)
       ? organizations
       : organizations
         ? [organizations]
-        : league.organization
+        : league?.organization
           ? [league.organization]
           : [];
 
@@ -170,7 +207,13 @@ export function useIsLeagueAdmin(
     }
 
     return false;
-  }, [currentUser?.pk, currentUser?.is_staff, league, organizations]);
+  }, [
+    currentUser?.pk,
+    currentUser?.is_staff,
+    currentUser?.is_superuser,
+    league,
+    organizations,
+  ]);
 }
 
 /**
@@ -189,25 +232,33 @@ export function useIsLeagueStaff(
   const isLeagueAdmin = useIsLeagueAdmin(league, organizations);
 
   return useMemo(() => {
-    if (!currentUser?.pk || !league) return false;
+    if (!currentUser?.pk) return false;
 
-    // League admins have staff access
+    // Site admin (is_staff OR is_superuser) outranks every tier — must
+    // run before the !league guard. Without this, a server admin gets
+    // gated out of tournaments with no league.
+    if (currentUser.is_staff || currentUser.is_superuser) return true;
+
+    // League admin cascade (also covers site admins via useIsLeagueAdmin,
+    // but the direct check above already short-circuits faster).
     if (isLeagueAdmin) return true;
 
-    // Check league-specific staff_ids array
-    if (league.staff_ids?.includes(currentUser.pk)) return true;
-
-    // Check league-specific staff array
-    if (league.staff?.some((staff) => staff.pk === currentUser.pk)) {
-      return true;
+    // League-specific staff lookups only meaningful when a league is present.
+    if (league) {
+      if (league.staff_ids?.includes(currentUser.pk)) return true;
+      if (league.staff?.some((staff) => staff.pk === currentUser.pk)) {
+        return true;
+      }
     }
 
-    // Check if user is staff of any linked organization
+    // Org-staff cascade: hierarchy puts org > league, so an org staffer
+    // of the linked org grants league-staff access. Works even with no
+    // league, as long as ``organizations`` was passed in.
     const orgs = Array.isArray(organizations)
       ? organizations
       : organizations
         ? [organizations]
-        : league.organization
+        : league?.organization
           ? [league.organization]
           : [];
 
@@ -224,7 +275,14 @@ export function useIsLeagueStaff(
     }
 
     return false;
-  }, [currentUser?.pk, league, isLeagueAdmin, organizations]);
+  }, [
+    currentUser?.pk,
+    currentUser?.is_staff,
+    currentUser?.is_superuser,
+    league,
+    isLeagueAdmin,
+    organizations,
+  ]);
 }
 
 /**

--- a/frontend/app/store/bracketStore.test.ts
+++ b/frontend/app/store/bracketStore.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useBracketStore } from './bracketStore';
+import type { BracketMatch } from '~/components/bracket/types';
+import type { TeamType } from '~/components/tournament/types';
+
+const teamA = { pk: 1, name: 'Team A' } as unknown as TeamType;
+const teamB = { pk: 2, name: 'Team B' } as unknown as TeamType;
+
+function baseMatch(overrides: Partial<BracketMatch> = {}): BracketMatch {
+  return {
+    id: 'gf-1-0',
+    gameId: 10,
+    round: 1,
+    position: 0,
+    bracketType: 'grand_finals',
+    eliminationType: 'double',
+    radiantTeam: teamA,
+    direTeam: teamB,
+    status: 'pending',
+    swissRecordWins: 0,
+    swissRecordLosses: 0,
+    ...overrides,
+  };
+}
+
+describe('useBracketStore.unsetMatchWinner', () => {
+  beforeEach(() => {
+    useBracketStore.setState({
+      matches: [],
+      nodes: [],
+      edges: [],
+      isDirty: false,
+      isVirtual: true,
+    });
+  });
+
+  it('clears winner and downstream slot when winner is set', () => {
+    const downstream = baseMatch({
+      id: 'gf-1-1',
+      gameId: 11,
+      bracketType: 'grand_finals',
+      radiantTeam: teamA,
+      direTeam: undefined,
+      status: 'pending',
+    });
+    const match = baseMatch({
+      winner: 'radiant',
+      status: 'completed',
+      nextMatchId: 'gf-1-1',
+      nextMatchSlot: 'radiant',
+    });
+    useBracketStore.setState({ matches: [match, downstream], isDirty: false });
+
+    useBracketStore.getState().unsetMatchWinner(match.id);
+
+    const next = useBracketStore.getState();
+    const updated = next.matches.find((m) => m.id === match.id)!;
+    expect(updated.winner).toBeUndefined();
+    expect(updated.status).toBe('pending');
+    // Winning team is removed from the downstream slot it had been advanced into.
+    const downstreamAfter = next.matches.find((m) => m.id === 'gf-1-1')!;
+    expect(downstreamAfter.radiantTeam).toBeUndefined();
+    expect(next.isDirty).toBe(true);
+  });
+
+  it('recovers a stuck row (status=completed, winner=undefined) by clearing only the status', () => {
+    // Models the production bug: backend's winning_team FK no longer matches
+    // either radiant_team or dire_team, so mapApiMatchToMatch can't derive
+    // a winner. Without recovery, the Set Winner buttons are hidden
+    // (status === 'completed') AND the Unset Winner button was gated on
+    // winner being truthy — admin gets stuck. The recovery path resets
+    // status alone so the Set Winner buttons reappear.
+    const stuck = baseMatch({
+      winner: undefined,
+      status: 'completed',
+      nextMatchId: undefined,
+      nextMatchSlot: undefined,
+    });
+    useBracketStore.setState({ matches: [stuck], isDirty: false });
+
+    useBracketStore.getState().unsetMatchWinner(stuck.id);
+
+    const updated = useBracketStore.getState().matches.find((m) => m.id === stuck.id)!;
+    expect(updated.status).toBe('pending');
+    expect(updated.winner).toBeUndefined();
+    expect(useBracketStore.getState().isDirty).toBe(true);
+  });
+
+  it('is a no-op when the row is already pending and has no winner', () => {
+    const idle = baseMatch({ winner: undefined, status: 'pending' });
+    useBracketStore.setState({ matches: [idle], isDirty: false });
+
+    useBracketStore.getState().unsetMatchWinner(idle.id);
+
+    // Nothing changed: no winner to clear and no completed status to recover.
+    expect(useBracketStore.getState().isDirty).toBe(false);
+  });
+
+  it('is a no-op when the match id does not exist in the store', () => {
+    useBracketStore.setState({ matches: [], isDirty: false });
+    useBracketStore.getState().unsetMatchWinner('does-not-exist');
+    expect(useBracketStore.getState().isDirty).toBe(false);
+  });
+});

--- a/frontend/app/store/bracketStore.ts
+++ b/frontend/app/store/bracketStore.ts
@@ -246,7 +246,24 @@ export const useBracketStore = create<BracketStore>()((set, get) => ({
 
   unsetMatchWinner: (matchId) => {
     const match = get().matches.find((m) => m.id === matchId);
-    if (!match?.winner) return;
+    if (!match) return;
+
+    // Recovery case: the row is in status=completed but no winner can be
+    // derived (the backend's winning_team FK no longer matches either
+    // current team — e.g. teams changed after the winner was set).
+    // We don't know which downstream slots to clear, so just reset this
+    // row's status; admin can re-enter the winner from a clean state.
+    if (!match.winner) {
+      if (match.status !== 'completed') return;
+      log.debug('Unsetting match status (no derivable winner)', { matchId });
+      set((state) => ({
+        matches: state.matches.map((m) =>
+          m.id === matchId ? { ...m, status: 'pending' as const } : m
+        ),
+        isDirty: true,
+      }));
+      return;
+    }
 
     const winningTeam = match.winner === 'radiant' ? match.radiantTeam : match.direTeam;
     const losingTeam = match.winner === 'radiant' ? match.direTeam : match.radiantTeam;

--- a/frontend/tests/playwright/e2e/09-bracket/04-bracket-unset-winner.spec.ts
+++ b/frontend/tests/playwright/e2e/09-bracket/04-bracket-unset-winner.spec.ts
@@ -1,184 +1,264 @@
 /**
  * Bracket Unset Winner Tests
  *
- * Tests the ability to unset a bracket match winner, clearing the result
- * and removing the team from downstream matches.
+ * Covers the full lifecycle that was missed by the original suite:
  *
- * Uses dedicated 'bracket_unset_winner' tournament with:
- * - 4 teams in double elimination bracket
- * - All games pending (no completed games)
- * - Teams assigned to first round games
+ *  1. Sanity (no save): set → Unset Winner button appears.
+ *  2. Persistence: set → Save → reload → bracket card shows the winner
+ *     check AND modal still offers Unset Winner.
+ *  3. Unset across save boundary: set → Save → reload → click Unset → Save
+ *     → reload → bracket card has no winner check, modal shows Set Winner
+ *     buttons again.
+ *  4. Stuck-state recovery (issue #235): force the prod scenario where
+ *     ``status=completed`` but ``winning_team`` no longer matches either
+ *     team in the slots. Unset Winner must still be visible and clicking
+ *     it must unstick the row.
+ *
+ * Uses deterministic match selection via the
+ * ``[data-bracket-type][data-round][data-position]`` attributes on each
+ * ``bracket-match-node`` rather than iterating + reopening (the close-and-
+ * re-click pattern was flaky against React Flow's pan/zoom).
+ *
+ * The bracket UI exposes ``data-testid="bracket-team-slot-{slot}"`` with
+ * ``data-team-status`` of ``winner | loser | pending | empty`` and (when
+ * isWinner+isCompleted) a nested ``bracket-winner-check-{slot}`` element —
+ * the assertions hit those so a stuck row can't slip past.
+ *
+ * Uses the dedicated 'bracket_unset_winner' tournament: 4 teams in a
+ * double-elimination bracket, all games pending. Winners R1 position 0
+ * has Alpha vs Beta which we drive in every test.
  */
 
 import {
   test,
   expect,
   visitAndWaitForHydration,
-  getTournamentByKey,
 } from '../../fixtures';
+import type { Page, Locator } from '@playwright/test';
 
-let tournamentPk: number;
+// Tournament pk is captured per-test from the reset response. The reset
+// endpoint DELETES + recreates the tournament so the pk changes; capturing
+// once in beforeAll would 404 on every test after the first.
+let tournamentPk = 0;
+
+/** Winners R1 position 0 — Alpha vs Beta. Always pending after a reset. */
+const TARGET_MATCH_SELECTOR =
+  '[data-testid="bracket-match-node"][data-bracket-type="winners"][data-round="1"][data-position="0"]';
 
 test.describe('Bracket Unset Winner (e2e)', () => {
-  test.beforeAll(async ({ browser }) => {
-    const context = await browser.newContext({ ignoreHTTPSErrors: true });
-    const tournament = await getTournamentByKey(context, 'bracket_unset_winner');
-
-    if (!tournament) {
-      throw new Error('Could not find bracket_unset_winner tournament');
-    }
-
-    tournamentPk = tournament.pk;
-    await context.close();
-  });
-
-  test.beforeEach(async ({ loginStaff }) => {
+  test.beforeEach(async ({ loginStaff, page }) => {
     await loginStaff();
-  });
-
-  test('@cicd sanity: staff can set and unset bracket winner', async ({ page }) => {
-    await visitAndWaitForHydration(page, `/tournament/${tournamentPk}/games`);
-
-    const bracketContainer = page.locator('[data-testid="bracketContainer"]');
-    await expect(bracketContainer).toBeVisible({ timeout: 15000 });
-
-    // Wait for bracket to fully render
-    await page.waitForLoadState('networkidle');
-
-    // Find a match with teams and Set Winner buttons
-    const matchNodes = page.locator('[data-testid="bracket-match-node"]');
-    const nodeCount = await matchNodes.count();
-    const dialog = page.locator('[data-testid="matchStatsModal"]');
-
-    let foundMatch = false;
-    for (let i = 0; i < Math.min(nodeCount, 6); i++) {
-      await matchNodes.nth(i).click({ force: true });
-
-      const isVisible = await dialog.isVisible().catch(() => false);
-      if (!isVisible) continue;
-
-      // Check for Set Winner buttons (only visible when match has teams)
-      const setWinnerButton = dialog.locator('[data-testid="radiantWinsButton"]');
-      const btnVisible = await setWinnerButton.isVisible({ timeout: 1000 }).catch(() => false);
-
-      if (btnVisible) {
-        foundMatch = true;
-
-        // Set a winner (radiant)
-        await setWinnerButton.click();
-
-        // Unset Winner button should now appear
-        const unsetButton = dialog.locator('[data-testid="unsetWinnerButton"]');
-        await expect(unsetButton).toBeVisible({ timeout: 5000 });
-
-        // Click Unset Winner to clear the result
-        await unsetButton.click();
-
-        // Set Winner buttons should reappear after unsetting
-        await expect(setWinnerButton).toBeVisible({ timeout: 5000 });
-        break;
-      }
-
-      // Close modal and try next node
-      await page.keyboard.press('Escape');
-      await dialog.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
-    }
-
-    expect(foundMatch, 'Could not find a match with teams and Set Winner buttons').toBe(true);
-  });
-
-  test('staff can unset a bracket game winner', async ({ page }) => {
-    await visitAndWaitForHydration(page, `/tournament/${tournamentPk}/games`);
-
-    const bracketContainer = page.locator('[data-testid="bracketContainer"]');
-    await expect(bracketContainer).toBeVisible({ timeout: 15000 });
-
-    // Wait for nodes to render
-    await page.waitForLoadState('networkidle');
-
-    // Find a match with teams and set winner buttons (status !== 'completed')
-    const matchNodes = page.locator('[data-testid="bracket-match-node"]');
-    const nodeCount = await matchNodes.count();
-
-    let foundMatch = false;
-    let matchIndex = -1;
-    for (let i = 0; i < Math.min(nodeCount, 5); i++) {
-      await matchNodes.nth(i).click({ force: true });
-
-      const dialog = page.locator('[data-testid="matchStatsModal"]');
-      const isVisible = await dialog.isVisible().catch(() => false);
-
-      if (isVisible) {
-        // Check for Set Winner buttons (only visible when match is NOT completed)
-        const winButtons = dialog.locator(
-          '[data-testid="radiantWinsButton"], [data-testid="direWinsButton"]'
-        );
-        const winButtonCount = await winButtons.count();
-
-        if (winButtonCount >= 2) {
-          foundMatch = true;
-          matchIndex = i;
-
-          // Set a winner first - clicking sets status to 'completed' and advances winner
-          await winButtons.first().click();
-
-          // Wait for state to settle
-          await page.waitForTimeout(500);
-
-          break;
-        }
-
-        // Close modal and try next node
-        await page.keyboard.press('Escape');
-        await dialog.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
-      }
-    }
-
-    expect(foundMatch, 'Could not find a pending match with Set Winner buttons in the bracket').toBe(true);
-
-    // Close the current modal
-    const dialog = page.locator('[data-testid="matchStatsModal"]');
-    if (await dialog.isVisible().catch(() => false)) {
-      await page.keyboard.press('Escape');
-      await dialog.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
-    }
-
-    // Reopen the same match to see updated state
-    await matchNodes.nth(matchIndex).click({ force: true });
-    await expect(dialog).toBeVisible({ timeout: 5000 });
-
-    // Debug: Check if the match shows as completed (has "Final" badge or winner indicator)
-    // The modal should now show the match as completed with a winner
-    const dialogContent = await dialog.textContent();
-    console.log('Dialog content after setting winner:', dialogContent?.substring(0, 500));
-
-    // Now the Unset Winner button should be visible
-    const unsetButton = dialog.locator('[data-testid="unsetWinnerButton"]');
-    await expect(unsetButton).toBeVisible({ timeout: 5000 });
-
-    // Click Unset Winner to clear the result
-    await unsetButton.click();
-
-    // Wait for state to settle
-    await page.waitForTimeout(500);
-
-    // Close and reopen to see updated state
-    await page.keyboard.press('Escape');
-    await dialog.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
-
-    await matchNodes.nth(matchIndex).click({ force: true });
-    await expect(dialog).toBeVisible({ timeout: 5000 });
-
-    // After unsetting, the Set Winner buttons should reappear
-    const winButtons = dialog.locator(
-      '[data-testid="radiantWinsButton"], [data-testid="direWinsButton"]'
+    // Reset the dedicated tournament between tests so each one starts from
+    // the populated baseline (all games pending). The endpoint returns the
+    // freshly-created tournament — we re-bind tournamentPk from its body
+    // because the delete-and-recreate gives it a new pk.
+    const resetResp = await page.context().request.post(
+      '/api/tests/reset-tournament/bracket_unset_winner/',
     );
-    await expect(winButtons.first()).toBeVisible({ timeout: 5000 });
+    expect(resetResp.status()).toBe(200);
+    const tournament = await resetResp.json();
+    tournamentPk = tournament.pk;
+  });
 
-    // Unset Winner button should be hidden again
-    await expect(unsetButton).not.toBeVisible();
+  async function loadBracket(page: Page): Promise<void> {
+    await visitAndWaitForHydration(page, `/tournament/${tournamentPk}/games`);
+    await expect(page.locator('[data-testid="bracketContainer"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForLoadState('networkidle');
+  }
 
-    // Should show unsaved changes
-    await expect(page.locator('text=Unsaved changes')).toBeVisible({ timeout: 5000 });
+  /** Click the target Winners R1 P0 node and return the open modal dialog. */
+  async function openTargetModal(page: Page): Promise<Locator> {
+    const node = page.locator(TARGET_MATCH_SELECTOR);
+    await expect(node).toBeVisible({ timeout: 10000 });
+    await node.click({ force: true });
+    const dialog = page.locator('[data-testid="matchStatsModal"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    return dialog;
+  }
+
+  async function closeModal(page: Page): Promise<void> {
+    // Use the dialog's explicit close button — Escape was flaky when focus
+    // landed on something non-dismissable inside the modal, leaving the
+    // backdrop overlaying the Save button so the next click timed out.
+    const dialog = page.locator('[data-testid="matchStatsModal"]');
+    await dialog.locator('[data-testid="dialog-close-button"]').click();
+    await expect(dialog).toBeHidden({ timeout: 5000 });
+  }
+
+  /** Click Save and wait for the "Unsaved changes" indicator to disappear. */
+  async function clickSaveAndWait(page: Page) {
+    await page.locator('[data-testid="saveBracketButton"]').click();
+    await expect(page.locator('text=Unsaved changes')).toBeHidden({ timeout: 10000 });
+  }
+
+  test('@cicd sanity: staff can set and unset bracket winner (in-memory)', async ({ page }) => {
+    await loadBracket(page);
+
+    const dialog = await openTargetModal(page);
+    await dialog.locator('[data-testid="radiantWinsButton"]').click();
+
+    // Unset Winner appears in the same modal session.
+    await expect(dialog.locator('[data-testid="unsetWinnerButton"]')).toBeVisible({
+      timeout: 5000,
+    });
+
+    await dialog.locator('[data-testid="unsetWinnerButton"]').click();
+
+    // Set Winner buttons return.
+    await expect(dialog.locator('[data-testid="radiantWinsButton"]')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('winner persists across Save + reload and bracket card shows the check', async ({
+    page,
+  }) => {
+    await loadBracket(page);
+
+    // Set radiant as winner.
+    let dialog = await openTargetModal(page);
+    await dialog.locator('[data-testid="radiantWinsButton"]').click();
+    await closeModal(page);
+
+    // Save + reload — the boundary the original test never crossed.
+    await clickSaveAndWait(page);
+    await page.reload();
+    await loadBracket(page).catch(async () => {
+      // visitAndWaitForHydration above already ran via loadBracket; if the
+      // bracketContainer takes longer post-reload, give it the same wait
+      // semantics. Empty catch so the original loadBracket assertion fires.
+    });
+    // Belt-and-suspenders: wait for the bracket again after reload.
+    await expect(page.locator('[data-testid="bracketContainer"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForLoadState('networkidle');
+
+    // Bracket card must render the green check on radiant.
+    const node = page.locator(TARGET_MATCH_SELECTOR);
+    await expect(node.locator('[data-testid="bracket-winner-check-radiant"]')).toBeVisible();
+    await expect(node.locator('[data-testid="bracket-team-slot-radiant"]')).toHaveAttribute(
+      'data-team-status',
+      'winner',
+    );
+    await expect(node.locator('[data-testid="bracket-team-slot-dire"]')).toHaveAttribute(
+      'data-team-status',
+      'loser',
+    );
+
+    // Modal must still let the admin reverse the decision.
+    dialog = await openTargetModal(page);
+    await expect(dialog.locator('[data-testid="unsetWinnerButton"]')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('unset clears the winner on the bracket card after Save + reload', async ({
+    page,
+  }) => {
+    await loadBracket(page);
+
+    // Set + Save so we have a real persisted winner to unset.
+    let dialog = await openTargetModal(page);
+    await dialog.locator('[data-testid="radiantWinsButton"]').click();
+    await closeModal(page);
+    await clickSaveAndWait(page);
+    await page.reload();
+    await expect(page.locator('[data-testid="bracketContainer"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForLoadState('networkidle');
+
+    // Unset → Save → reload.
+    dialog = await openTargetModal(page);
+    await dialog.locator('[data-testid="unsetWinnerButton"]').click();
+    await closeModal(page);
+    await clickSaveAndWait(page);
+    await page.reload();
+    await expect(page.locator('[data-testid="bracketContainer"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForLoadState('networkidle');
+
+    // Bracket card: no winner check on either side, both slots back to pending.
+    const node = page.locator(TARGET_MATCH_SELECTOR);
+    await expect(node.locator('[data-testid="bracket-winner-check-radiant"]')).toHaveCount(0);
+    await expect(node.locator('[data-testid="bracket-winner-check-dire"]')).toHaveCount(0);
+    await expect(node.locator('[data-testid="bracket-team-slot-radiant"]')).toHaveAttribute(
+      'data-team-status',
+      'pending',
+    );
+
+    // Modal: Set Winner buttons must be back.
+    dialog = await openTargetModal(page);
+    await expect(dialog.locator('[data-testid="radiantWinsButton"]')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(dialog.locator('[data-testid="unsetWinnerButton"]')).toBeHidden();
+  });
+
+  test('stuck-state recovery: status=completed with mismatched winning_team can still be unset (issue #235)', async ({
+    page,
+  }) => {
+    await loadBracket(page);
+
+    // Read the target match's game pk off the rendered node.
+    const node = page.locator(TARGET_MATCH_SELECTOR);
+    const matchPkAttr = await node.getAttribute('data-game-pk');
+    const matchPk = matchPkAttr ? Number(matchPkAttr) : NaN;
+    expect(Number.isFinite(matchPk)).toBe(true);
+
+    // Force the production stuck state via test endpoint: Game.status
+    // becomes 'completed' but winning_team is a team that isn't currently
+    // in either slot, so mapApiMatchToMatch can't derive match.winner. This
+    // is exactly the prod state that hid the Unset Winner button before
+    // PR #236.
+    const forced = await page.context().request.post(
+      '/api/tests/bracket/force-mismatched-winning-team/',
+      { data: { game_id: matchPk } },
+    );
+    expect(forced.status()).toBe(200);
+    const forcedBody = await forced.json();
+    expect(forcedBody.winning_team_id).not.toBe(forcedBody.radiant_team_id);
+    expect(forcedBody.winning_team_id).not.toBe(forcedBody.dire_team_id);
+
+    await page.reload();
+    await expect(page.locator('[data-testid="bracketContainer"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForLoadState('networkidle');
+
+    // Bracket card: neither team is marked as winner since the FK doesn't
+    // resolve to either slot. (The defining trait of the stuck state.)
+    await expect(node.locator('[data-testid="bracket-winner-check-radiant"]')).toHaveCount(0);
+    await expect(node.locator('[data-testid="bracket-winner-check-dire"]')).toHaveCount(0);
+
+    // Modal: PR #236 surfaces Unset Winner even when winner is undefined
+    // (gate is now `status === 'completed' || match.winner`). Without the
+    // fix this assertion fails — the regression we want CI to catch.
+    const dialog = await openTargetModal(page);
+    await expect(dialog.locator('[data-testid="unsetWinnerButton"]')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(dialog.locator('[data-testid="radiantWinsButton"]')).toBeHidden();
+
+    // Click Unset → Save → reload. The store's recovery path resets just
+    // status (since there's no winner to clear from downstream slots), so
+    // after save the row is back to pending with Set Winner buttons.
+    await dialog.locator('[data-testid="unsetWinnerButton"]').click();
+    await closeModal(page);
+    await clickSaveAndWait(page);
+    await page.reload();
+    await expect(page.locator('[data-testid="bracketContainer"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForLoadState('networkidle');
+
+    const recoveredDialog = await openTargetModal(page);
+    await expect(
+      recoveredDialog.locator('[data-testid="radiantWinsButton"]'),
+    ).toBeVisible({ timeout: 5000 });
   });
 });

--- a/frontend/tests/playwright/e2e/09-bracket/04-bracket-unset-winner.spec.ts
+++ b/frontend/tests/playwright/e2e/09-bracket/04-bracket-unset-winner.spec.ts
@@ -46,6 +46,15 @@ const TARGET_MATCH_SELECTOR =
   '[data-testid="bracket-match-node"][data-bracket-type="winners"][data-round="1"][data-position="0"]';
 
 test.describe('Bracket Unset Winner (e2e)', () => {
+  // All four tests reset and rebind the *same* tournament key in
+  // beforeEach (the endpoint deletes + recreates it). Default workers=1
+  // serializes this fine, but the project allows PLAYWRIGHT_WORKERS=2
+  // and fullyParallel is on globally, which would let two tests in this
+  // file race on the shared reset endpoint and the module-scoped
+  // tournamentPk. Pin to serial — the cost is zero at workers=1 and
+  // correctness insurance at workers>1.
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async ({ loginStaff, page }) => {
     await loginStaff();
     // Reset the dedicated tournament between tests so each one starts from


### PR DESCRIPTION
Closes #235.

## The bug

A `HeroDraft` holds its captains via `DraftTeam.tournament_team` (FK), captured at draft-creation time. When the underlying `Game`'s `radiant_team` / `dire_team` is later rewritten by **either** of the team-mutation paths in `backend/app/views/bracket.py`:

- `save_bracket()` does a full bracket re-save — see [`bracket.py:198-211`](https://github.com/kettleofketchup/DraftForge/blob/main/backend/app/views/bracket.py#L198-L211): `game.radiant_team_id = …`, `game.dire_team_id = …` on every existing game. The inline comment even calls it out: *"Update existing game (preserves PK and related HeroDraft)"*. Yes — preserved, and now pointing at the wrong captains.
- `advance_winner()` re-advances a different winner into a downstream match — [`bracket.py:446-454`](https://github.com/kettleofketchup/DraftForge/blob/main/backend/app/views/bracket.py#L446-L454).

…the Game's teams change but the existing `DraftTeam` rows still point at the **previous** teams. The draft UI renders the wrong captains and no client reload recovers it; the only workaround is DB intervention mid-tournament.

**Field reproduction (the report that filed #235):** Sunday Turbo Tournament, Losers Round 2. Wrong winner entered upstream → downstream HeroDraft created with **Light vs Heff** → bracket reset and re-entered correctly so the match is now **Light vs noks** → HeroDraft still rendered Light vs Heff.

## Fix: in-place reset (preserves `HeroDraft.pk`)

A `pre_save` receiver on `Game` (`backend/app/signals.py`) catches every team-mutation path in one place. Before the new row commits, compare the new `(radiant_team_id, dire_team_id)` against the DB. If either changed and the game has a `HeroDraft`:

- Repoint each `DraftTeam.tournament_team` at the `Game`'s new team for that slot.
- Wipe `HeroDraftRound` rows (the picks/bans were made by the *wrong* captain).
- Reset `DraftTeam.is_ready` / `is_connected` / `reserve_time_remaining` to defaults; captains must reconnect.
- Transition `HeroDraft.state` back to `WAITING_FOR_CAPTAINS`; clear `roll_winner` / `paused_at` / `resuming_until` / `is_manual_pause`.
- **Keep `HeroDraftEvent` rows** — they're the audit trail of the wrong setup ever happening.
- Broadcast `event_type=draft_reset` on the existing `herodraft_{pk}` channel group so connected `HeroDraftConsumer` clients refetch and stay on the same draft URL.

**The `HeroDraft.pk` is preserved**, so the Discord-posted `/herodraft/{pk}/` link (and anything else holding the pk) keeps working after the reset.

**Why not preserve picks/bans:** they were made by the *wrong* captain, so carrying them over is worse than starting fresh. The audit log (`HeroDraftEvent`) is the historical record.

### Edge case — Game slot cleared to NULL

`DraftTeam.tournament_team` is non-nullable, so the in-place reset can't repoint to `None`. When a Game slot is cleared (e.g. mid-bracket-reset before winners are re-entered), fall back to deleting the `HeroDraft` and broadcast `event_type=draft_invalidated` so the frontend can show a "recreate this draft" message. When the bracket is re-saved with real teams `create_herodraft` rebuilds. The Discord link 404s in this narrow window — acceptable.

## Tests

`backend/app/tests/test_herodraft_stale_purge.py` — 10 cases:

1. `test_changing_dire_team_resets_draft_in_place` — exact reproduction from #235; verifies pk preserved, DraftTeam repointed, rounds cleared, state reset, ready/connected flags cleared.
2. `test_changing_radiant_team_resets_draft_in_place` — radiant slot symmetric.
3. `test_clearing_team_to_none_falls_back_to_delete` — the non-nullable edge case.
4. `test_reset_keeps_herodraft_event_history` — audit log survives the reset.
5. `test_saving_game_with_unchanged_teams_preserves_draft_state` — status / scheduling saves must NOT reset.
6. `test_creating_a_game_does_not_error` — short-circuit cleanly for new Games.
7. `test_game_with_no_herodraft_team_change_is_noop` — most bracket matches change teams before any draft exists.
8. `test_reset_broadcasts_draft_reset_event_with_same_pk` — WS broadcast on the existing channel group with pk preserved.
9. `test_clearing_team_to_none_broadcasts_draft_invalidated` — delete-fallback uses different event_type so frontend can branch.
10. `test_reset_still_succeeds_when_channel_layer_send_fails` — broadcast is best-effort; reset always commits.

Adjacent suites pass unchanged: `test_bracket`, `test_herodraft_functions`, `test_herodraft_models`, `test_team_signals` (41/41).

## Frontend (out of scope for this PR)

The backend broadcasts `draft_reset` (with `metadata.reason="teams_changed"`) and `draft_invalidated` on the existing `herodraft_{pk}` channel group. Wiring the `HeroDraftConsumer` client to handle those event types — refetch on `draft_reset`, prompt "this draft was reset, recreate it" on `draft_invalidated` — is a follow-up patch in the frontend repo.

Similarly, surfacing a "Team X has no captain — assign one to continue" banner when a `DraftTeam.tournament_team.captain` is null is a separate frontend change. The state is observable via the existing `HeroDraftSerializer` output.