### PR TITLE
chore(copilot): scope PR-review instructions per skill via applyTo globs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Copilot guidance for DraftForge
+
+DraftForge is a platform for managing Dota 2 tournaments, teams, and competitive gaming. Django REST + Daphne (Channels) backend; React + TypeScript + Vite frontend; Redis for cache; everything runs through Docker Compose driven by `just`.
+
+## Repo-wide rules
+
+- **Task runner is `just`.** Never invoke `pytest`, `python manage.py`, or `npm test` directly in CI / scripts / docs. Always go through a `just` recipe (e.g., `just test::run '<cmd>'`, `just db::makemigrations <app>`, `just dev::debug`). The venv auto-activates.
+- **WebSockets share the HTTP URL.** Daphne / Channels routes both protocols on the same `/api/...` path — there is no `/ws/...` namespace. WebSocket routes live in `backend/app/routing.py`; the frontend connects to the same path with `protocol = ws|wss`.
+- **No secrets in this repo.** `.env` files are excluded; never propose committing one.
+- **Frontend stack is Vite + React Router v7 (NOT Next.js).** Server Components do not apply; everything is a Client Component.
+
+## Project conventions (canonical: `.claude/skills/`)
+
+Each rule set below is canonical at `.claude/skills/<name>/SKILL.md`. The matching `.github/instructions/<name>.instructions.md` files contain short summaries scoped via `applyTo:` so Copilot's PR review picks up the right rules for each file path.
+
+| Skill | Canonical | Scope (Copilot `applyTo`) |
+|-------|-----------|---------------------------|
+| Backend caching | `.claude/skills/django-redis-caching/SKILL.md` | `backend/**/*.py` |
+| Brand / theming | `.claude/skills/brand/SKILL.md` (+ `docs/THEMING-GUIDE.md`) | `frontend/app/components/**`, `routes/**`, `features/**`, `app.css` |
+| React patterns | global `react` skill | `frontend/**/*.{ts,tsx}` |
+| shadcn/ui | global `shadcn` skill (+ `frontend/components.json`) | `frontend/app/components/**/*.{ts,tsx}` |
+| Zustand stores | global `zustand` skill | `frontend/app/store/**/*.ts` |
+
+Update the canonical skill first; mirror the relevant bullets into the `.instructions.md` file in the same PR.
+
+## What review comments should look like
+
+- Cite the rule by skill name (e.g., "brand: raw `<button>` — use `<PrimaryButton>`") so the author knows which canonical source to consult.
+- Prefer concrete fixes over abstract guidance. If the rule has a substitution table (brand), use the named replacement.
+- Don't comment on `package.json`, lockfiles, log files, or SVGs — Copilot already skips these.

--- a/.github/instructions/brand.instructions.md
+++ b/.github/instructions/brand.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: "frontend/app/components/**,frontend/app/routes/**,frontend/app/features/**,frontend/app/**/*.css"
+---
+
+# DraftForge brand & theming
+
+Canonical: `.claude/skills/brand/SKILL.md` and `docs/THEMING-GUIDE.md` (single source of truth for palette, button system, base scale, gradients, glow effects). DraftForge visual identity = "Neon Cyber Esports" — violet/indigo primary with cyan accents, dark-mode first.
+
+## Component substitutions (block-level rule — flag with severity `block`)
+
+- **Raw `<button>` is forbidden.** Use `PrimaryButton`, `SecondaryButton`, `ConfirmButton`, or `EditButton` from `frontend/app/components/ui/buttons/`. Pick based on intent, not color.
+- **Raw `<img>` for a user avatar is forbidden.** Use `<UserAvatar>`.
+- **Hand-rolled breadcrumb markup is forbidden.** Use `<EntityBreadcrumb>`.
+
+## Styling rules
+
+- **No inline `style={{}}` for colors / spacing / sizing.** Move to Tailwind classes or to the brand style constants in `frontend/app/components/ui/buttons/styles.ts` (`brandGradient`, `brandSecondary`, `brandBg`, `button3DBase`, etc.).
+- **No hardcoded violet/slate hex values, no `bg-slate-*` / `text-slate-*`.** Use the `bg-base-*` scale and brand tokens defined in `frontend/app/app.css`.
+- **No `space-x-*` / `space-y-*`.** Use `flex` + `gap-*` (or `flex flex-col gap-*`).
+- **No `w-N h-N` when width and height are equal.** Use `size-N`.
+- **Use `cn(...)` for conditional classes.** Don't write manual ternary template literals.
+
+## Where to look for the canonical rule
+
+- Palette / tokens / gradients: `frontend/app/app.css`.
+- Button style constants: `frontend/app/components/ui/buttons/styles.ts`.
+- Substitution table (every raw element → replacement component): `docs/theming-guide/ai/references/component-substitutions.md`.
+- Severity rubric (`block` / `warn` / `nit`): `docs/theming-guide/ai/references/severity-rubric.md`.
+
+When a brand violation is found, cite the canonical section and propose the named replacement (don't just say "use the brand button" — say *which* brand button).

--- a/.github/instructions/django-redis-caching.instructions.md
+++ b/.github/instructions/django-redis-caching.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "backend/**/*.py"
+---
+
+# Django + Redis caching (django-cacheops)
+
+Canonical: `.claude/skills/django-redis-caching/SKILL.md`. Verify what is/isn't cached against the `CACHEOPS` dict in `backend/app/settings.py` — that is the source of truth, not any summary table.
+
+## Rules
+
+- **Never call `cache.delete(...)` directly.** Cacheops invalidates on model `save()` for any model registered in `CACHEOPS`. Manual invalidation is a code smell and almost always wrong.
+- **Inside a `transaction.atomic()` block (or any deferred-write context like signal handlers): use `invalidate_after_commit(...)` from `app.cache_utils`.** Direct `invalidate_obj` during a transaction invalidates before the write commits and re-populates the cache with stale data.
+- **Outside transactions (e.g., right after a M2M `.add()` / `.remove()`): `invalidate_obj` is fine.** That's the only place it's the right call.
+- **View-level caching uses `@cached_as(Model1, Model2, ..., extra=cache_key, timeout=...)`.** The `extra` must include `request.get_full_path()` (or equivalent discriminator) — otherwise different query strings collide on the same key.
+- **Cache timeouts come from `settings.CACHEOPS`.** Don't hard-code timeouts on individual views unless there's a documented reason; let the model-level config govern.
+- **New models that need caching must be added to `CACHEOPS`** in `settings.py`. A view that caches a queryset over an unregistered model will not invalidate on writes.
+- **DRF list/retrieve methods overriding `.list()` / `.retrieve()` should follow the inner `@cached_as` helper pattern** shown in the skill — outer method assembles the request-scoped `cache_key`, inner function does the actual work and is the one decorated.
+
+## Out of scope here
+
+Logging, testing, migrations, and Celery/task-queue patterns are not covered by this file — see their own `.instructions.md` (if present) or the matching `.claude/skills/` skill.

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -1,0 +1,32 @@
+---
+applyTo: "frontend/**/*.{ts,tsx}"
+---
+
+# React patterns
+
+Canonical: global `react` skill. DraftForge frontend is **Vite + React Router v7** — there are no Server Components and no `'use client'` directive. Every component is a Client Component.
+
+## Hooks
+
+- **No conditional hooks.** Hook calls must run in the same order on every render — never call inside `if` / loops / early returns.
+- **`useEffect` must return a cleanup when it subscribes / opens a timer / opens a WebSocket.** Memory leaks here cause flaky tests and stale state on hot-reload.
+- **`useMemo` / `useCallback` only when there's a measured reason** — referenced as a stable dep elsewhere, expensive computation, or to satisfy a child's memoization contract. Don't wrap every value.
+- **Prefer React 19 hooks where applicable**: `useTransition` for non-urgent state updates, `useOptimistic` for optimistic UI, `use()` for unwrapping context or a promise passed as a prop.
+
+## Components
+
+- **Functional components only.** No class components in new code.
+- **Component files export the component as a named export** matching the filename (PascalCase). Default-exporting components makes them harder to grep and refactor.
+- **Keep components small and single-purpose.** If a component has more than ~3 distinct concerns (data fetch + form + dialog + side effects), split it.
+- **Error boundaries belong at route / feature boundaries**, not on every leaf component.
+
+## TypeScript
+
+- **No `any`.** If a value's type is genuinely unknown, use `unknown` and narrow.
+- **Prefer `interface` for object shapes, `type` for unions / mapped types.** Pick one and stay consistent within a file.
+- **Use `as const` for literal-typed config objects** so downstream code can discriminate on string literal unions.
+
+## Data / async
+
+- **Don't fetch in `useEffect` when there's a route loader / data hook available.** React Router v7 loaders are the canonical place to fetch.
+- **AbortControllers on in-component fetches.** Abort on unmount so cancelled responses don't `setState` on a dead component.

--- a/.github/instructions/shadcn.instructions.md
+++ b/.github/instructions/shadcn.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: "frontend/app/components/**/*.{ts,tsx}"
+---
+
+# shadcn/ui composition
+
+Canonical: global `shadcn` skill. Project config lives in `frontend/components.json`; primitives live in `frontend/app/components/ui/`.
+
+## Compose, don't reinvent
+
+- **Use existing shadcn primitives from `frontend/app/components/ui/` first.** A "settings page" composes `Tabs` + `Card` + form controls; a "dashboard" composes `Sidebar` + `Card` + `Table` / `Chart`. Don't hand-roll alternatives.
+- **Use built-in variants before custom styling.** `variant="outline"`, `size="sm"`, etc. — defined on each shadcn component.
+
+## Styling — what `className` may and may not do
+
+- **`className` is for layout, not styling.** Override layout (positioning, margins, sizing) but never override component colors, typography, or border radius — those come from the design tokens.
+- **No manual `dark:` colour overrides.** Use semantic tokens (`bg-background`, `text-foreground`, `text-muted-foreground`, `border-input`) so dark mode flips automatically.
+- **No manual `z-index` on overlay components.** `Dialog`, `Sheet`, `Popover`, `DropdownMenu`, `Tooltip`, `Toast` manage their own stacking — overriding breaks the stack.
+
+## Forms (interacts with brand and `zod-form-validation`)
+
+- **`FieldGroup` + `Field` for form layout** — never raw `div` with `space-y-*` or `grid gap-*`.
+- **Inside `InputGroup`, use `InputGroupInput` / `InputGroupTextarea`** — never raw `Input` / `Textarea`.
+- **Option sets of 2–7 choices use `ToggleGroup`** — don't loop `Button` with manual active state.
+- **`FieldSet` + `FieldLegend` for groups of related checkboxes / radios** — not a `div` with a heading.
+- **Validation: `data-invalid` on `Field`, `aria-invalid` on the control.** For disabled: `data-disabled` on `Field`, `disabled` on the control.
+
+## Interactions with the brand skill
+
+When `frontend/app/components/ui/buttons/` is involved, brand rules win — use `PrimaryButton` / `SecondaryButton` / `ConfirmButton` / `EditButton` rather than raw shadcn `Button`. shadcn `Button` is the underlying primitive but should not be reached for directly in product UI.

--- a/.github/instructions/zustand.instructions.md
+++ b/.github/instructions/zustand.instructions.md
@@ -1,0 +1,29 @@
+---
+applyTo: "frontend/app/store/**/*.ts"
+---
+
+# Zustand stores
+
+Canonical: global `zustand` skill. DraftForge stores live in `frontend/app/store/` (`userStore`, `orgStore`, `leagueStore`, `tournamentStore`, `bracketStore`, `heroDraftStore`, `draftWebSocketStore`, `pageNavStore`, `gameTypeStore`, `userCacheStore`).
+
+## Store definition
+
+- **Typed via a state interface, created with `create<State>()`**. Untyped `create(...)` defeats the type system for every consumer.
+- **One concern per store.** Don't conflate user identity with tournament navigation — that's why we have multiple stores. If a new piece of state doesn't fit any existing store, add a new file in `store/` rather than expanding an existing one.
+- **Async actions live on the store**, not in components. The component calls `useStore.getState().fetchX()`; the store handles fetch + error + loading state.
+- **Persisted state uses the `persist` middleware** with an explicit `name` and `partialize` so we don't serialize huge derived blobs into localStorage.
+
+## Consuming from components
+
+- **Always select specific state**: `useStore((s) => s.user)` — never `useStore()` (the whole store), which re-renders the component on every state change.
+- **Multi-field selectors must use `useShallow`** from `zustand/react/shallow`:
+  ```ts
+  import { useShallow } from 'zustand/react/shallow';
+  const { user, org } = useStore(useShallow((s) => ({ user: s.user, org: s.org })));
+  ```
+  Otherwise the returned object identity changes every render and you get an infinite loop.
+- **Reading state outside React (event handlers, async callbacks) uses `useStore.getState()`** — don't call the hook outside a component.
+
+## Outside the `frontend/app/store/` folder
+
+Components that *consume* stores live outside this `applyTo` scope; the React / shadcn / brand instructions cover them. Rules in this file are scoped to the store definitions themselves.


### PR DESCRIPTION
## Summary

Add path-scoped Copilot custom instructions so PR review activates the right rule set for each touched folder. Each `.instructions.md` summarises the canonical Claude skill via a short bullet list and points back to it — no duplication, no drift.

## Files

| File | `applyTo` | Canonical |
|------|-----------|-----------|
| `.github/copilot-instructions.md` | (repo-wide) | — repo overview + skill index |
| `.github/instructions/django-redis-caching.instructions.md` | `backend/**/*.py` | `.claude/skills/django-redis-caching/` |
| `.github/instructions/brand.instructions.md` | `frontend/app/components/**,routes/**,features/**,*.css` | `.claude/skills/brand/` + `docs/THEMING-GUIDE.md` |
| `.github/instructions/react.instructions.md` | `frontend/**/*.{ts,tsx}` | global `react` skill |
| `.github/instructions/shadcn.instructions.md` | `frontend/app/components/**/*.{ts,tsx}` | global `shadcn` skill |
| `.github/instructions/zustand.instructions.md` | `frontend/app/store/**/*.ts` | global `zustand` skill |

Total: 172 lines across 6 files; each file is 21–32 lines (well under Copilot's ~2-page guidance).

## Why per-skill (not bundled backend/frontend)

Path-scoped files mean Copilot only loads the rules relevant to the changed files. A PR that only touches `frontend/app/store/userStore.ts` activates `react.instructions.md` + `zustand.instructions.md` and skips brand / shadcn / backend — keeping the review focused.

## Out of scope (potential follow-ups)

- The existing `.github/instructions/*.md` files (without the `.instructions.md` suffix) are **not** loaded by Copilot. Some are stale (e.g., `daisyui.md` — daisyUI isn't in the stack). Cleaning them up is a separate pass.
- **Automatic Copilot review is not enabled yet.** To turn it on: `Settings → Rules → Rulesets → New branch ruleset → "Automatically request Copilot code review"`. Note: starting **June 1, 2026**, Copilot review runs consume GitHub Actions minutes — leave "Review new pushes" off unless the cost is justified.

## Test plan

- [ ] Add `@copilot` as a reviewer on this PR (`gh pr edit <N> --add-reviewer @copilot`) to dogfood the new instructions against the very files that define them.
- [ ] Verify Copilot's review comments cite the right skill / canonical source.
- [ ] After merging to `main`, future PRs touching backend or frontend should pick up the scoped rules on their next review.