### PR TITLE
feat(skills): add /pr lifecycle workflow skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: pr
+description: DraftForge PR lifecycle workflow. Use when the user runs /pr, opens or pushes a pull request, or asks to monitor CI checks and Copilot review on a branch. Creates the PR (or reuses an existing one), polls GitHub Actions and Copilot up to ~15 min, then analyses CI failures and Copilot comments and reports findings grouped by file and skill.
+---
+
+# /pr — PR lifecycle workflow
+
+## Purpose
+
+Drive a PR from "branch pushed" to "actionable review summary" without the user babysitting it. The skill:
+
+1. Resolves PR state (open existing or create new).
+2. Requests Copilot as a reviewer if missing.
+3. Polls GitHub Actions checks and the Copilot review (up to 15 min).
+4. Pulls CI failure logs and Copilot inline comments.
+5. Categorises findings by file → matched `.github/instructions/*.instructions.md` → canonical skill, then surfaces them to the user with concrete next steps.
+
+## When to trigger
+
+- User types `/pr`.
+- User says "open a PR" / "create a PR" / "spin up a PR" on the current branch.
+- User says "watch CI" / "monitor checks" / "wait for Copilot" on a branch with an open PR.
+- A push has just happened and the user is asking what's next.
+
+Do **not** trigger automatically just because a branch has uncommitted work — confirm first.
+
+## Workflow
+
+### Phase 1 — Resolve state
+
+```bash
+branch=$(git branch --show-current)
+pr_json=$(gh pr view --json number,state,headRefName,baseRefName,url,reviewRequests,reviews 2>/dev/null || echo "")
+```
+
+- If `pr_json` is empty → no PR yet → go to Phase 2 (create).
+- If PR exists and is `OPEN` → go to Phase 3 (request Copilot if absent, then monitor).
+- If PR is `MERGED` / `CLOSED` → report and stop; ask whether to open a new one.
+
+Before creating, verify the branch is pushed (`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` succeeds) and is ahead of `main`.
+
+### Phase 2 — Create the PR (if missing)
+
+Pre-fill title/body from commits when the branch has 1–3 commits; otherwise prompt the user once for a title. Always use a HEREDOC body with `## Summary` and `## Test plan` sections, per repo convention. Full patterns and the exact `gh pr create` invocation: [references/creating-the-pr.md](references/creating-the-pr.md).
+
+### Phase 3 — Request Copilot reviewer (idempotent)
+
+```bash
+PR=$(gh pr view --json number -q .number)
+# Skip if Copilot is already in reviewRequests OR has already reviewed
+need_copilot=$(gh pr view $PR --json reviewRequests,reviews \
+  --jq '(.reviewRequests + .reviews) | any(.login // .author.login | tostring | test("copilot"; "i")) | not')
+if [ "$need_copilot" = "true" ]; then
+  gh pr edit $PR --add-reviewer @copilot
+fi
+```
+
+The exact bot login varies (`copilot-pull-request-reviewer[bot]` / `Copilot`). The case-insensitive `test("copilot"; "i")` match is intentional — don't hardcode an exact login.
+
+### Phase 4 — Monitor checks and Copilot review
+
+Poll every 30 s, max 30 iterations = 15 min. Break early when **both** are done. Full polling pattern, jq queries, and "is Copilot done?" heuristics: [references/monitoring-ci-and-copilot.md](references/monitoring-ci-and-copilot.md).
+
+While polling, narrate progress in **single-line updates** ("iter 4/30: 3 checks running, copilot pending"). Do NOT print large JSON blobs to the user — those go to logs.
+
+If the 15 min budget exhausts:
+- If checks are still running: report which jobs and proceed to analysis with what completed.
+- If Copilot is still pending: report and analyse CI-only; tell the user they can re-run `/pr` later to pick up the Copilot review.
+
+### Phase 5 — Analyse and report
+
+Two analyses run in parallel; one merged report:
+
+1. **CI failures** — `gh run view <id> --log-failed` for each failed run, extract the error lines (look for `FAIL`, `Error`, `Traceback`, `assert`, lines ending with `:[0-9]+:` for compiler errors). Cap at 10 lines per failed step.
+2. **Copilot inline comments** — `gh api repos/{owner}/{repo}/pulls/{N}/comments` → for each comment, match the `path` against every `.github/instructions/*.instructions.md` `applyTo` glob and tag it with the matched skill(s).
+
+Output format and severity heuristics: [references/analyzing-results.md](references/analyzing-results.md).
+
+## What this skill does NOT do
+
+- Does not push for the user (assumes branch is already pushed; tells the user to push if not).
+- Does not fix the issues Copilot raises — only surfaces them with the canonical-skill pointer so the user / next skill invocation can act.
+- Does not enable automatic Copilot review at the repo level — that's a one-time UI step (Settings → Rules → Rulesets).
+- Does not stream raw `gh run view --log-failed` output into the chat — extracts just the error lines.
+
+## References
+
+- [creating-the-pr.md](references/creating-the-pr.md) — `gh pr create` patterns, title/body autofill, push-check
+- [monitoring-ci-and-copilot.md](references/monitoring-ci-and-copilot.md) — polling loop, jq queries, "done" heuristics
+- [analyzing-results.md](references/analyzing-results.md) — CI log extraction, Copilot-comment → skill matching, output format

--- a/.claude/skills/pr/references/analyzing-results.md
+++ b/.claude/skills/pr/references/analyzing-results.md
@@ -1,0 +1,132 @@
+# Phase 5 — Analyse and report
+
+Two pulls happen in parallel; one merged report goes to the user.
+
+## CI failures
+
+### Pull failed runs
+
+```bash
+PR=$(gh pr view --json number -q .number)
+branch=$(git branch --show-current)
+failed=$(gh run list --branch "$branch" --status failure \
+  --json databaseId,name,conclusion,url --limit 20)
+```
+
+For each failed run, fetch only the failed steps' log:
+
+```bash
+echo "$failed" | jq -c '.[]' | while read -r run; do
+  id=$(echo "$run" | jq -r .databaseId)
+  name=$(echo "$run" | jq -r .name)
+  echo "=== $name ($id) ==="
+  gh run view "$id" --log-failed 2>/dev/null \
+    | grep -E '(FAIL|FAILED|Error|Traceback|AssertionError|^\s*assert|^\s*[A-Za-z_]+Error:|^\s*\w+: error:|\.\w+:[0-9]+:[0-9]*:?\s)' \
+    | head -10
+done
+```
+
+The `grep -E` is intentionally broad — it catches Python tracebacks, pytest `FAIL` lines, Playwright `Error:` lines, TypeScript compiler errors, and shell `exit 1`-driven failures. Cap at 10 lines per step to keep the chat readable.
+
+### Surface root-cause hints
+
+Look for canonical patterns and tag them:
+
+| Pattern in logs | Likely cause | Suggested next step |
+|-----------------|--------------|---------------------|
+| `OperationalError: no such table` | Migrations not applied in test DB | `just db::reset-test` |
+| `cacheops` / `Redis connection refused` | Redis not up in test stack | `just test::up` |
+| `Error: page.goto: Timeout` | Frontend not ready before Playwright fired | Check `webServer` block in `playwright.config.ts` |
+| `Cannot find module '~/...'` | Path alias broken | Vite/tsconfig path alias regression |
+| `Type 'X' is not assignable` | TypeScript error | Run `npm run typecheck` locally |
+
+This list is starter — extend it whenever a new repeat-offender shows up.
+
+### "Pre-existing vs introduced"
+
+Per repo feedback, **never call a test flaky and never silently skip a pre-existing bug.** If a CI failure looks unrelated to the diff (test name doesn't touch any file in `gh pr diff --name-only`), say so explicitly:
+
+> ⚠ Pre-existing failure: `test_X` failed in `Y.py` but the diff doesn't touch `Y.py` or its dependencies. This is a bug to surface, not flake.
+
+## Copilot inline comments
+
+### Pull comments
+
+```bash
+comments=$(gh api "repos/{owner}/{repo}/pulls/$PR/comments" \
+  --jq '[.[] | select((.user.login // "") | test("copilot"; "i"))
+       | {path, line, body, html_url}]')
+top_review=$(gh api "repos/{owner}/{repo}/pulls/$PR/reviews" \
+  --jq '[.[] | select((.user.login // "") | test("copilot"; "i"))
+       | {state, body, submitted_at}] | last')
+```
+
+### Match each comment to a skill
+
+For every comment, walk each `.github/instructions/*.instructions.md` file, parse its `applyTo` glob, and check whether the comment's `path` matches. A comment can match multiple files (e.g., a frontend component file matches both `react.instructions.md` and `brand.instructions.md`).
+
+```bash
+# Pseudocode — implement inline in the skill turn
+for c in comments:
+  matched_skills = []
+  for inst_file in .github/instructions/*.instructions.md:
+    applyTo = parse_frontmatter(inst_file).applyTo  # comma-separated globs
+    if any(fnmatch(c.path, g) for g in applyTo.split(',')):
+      matched_skills.append(basename(inst_file).removesuffix('.instructions.md'))
+  c.skills = matched_skills
+```
+
+Tag each comment with its matched skill(s) so the user knows which canonical source to consult.
+
+### Severity heuristic
+
+Copilot doesn't expose a severity field. Infer from the comment body:
+
+| Keywords | Severity |
+|----------|----------|
+| "must", "should not", "never", "incorrect", "broken", "wrong" | **block** |
+| "consider", "you may want", "could improve", "suggestion" | **nit** |
+| Everything else | **warn** |
+
+Don't be precious about it — this is a hint to the user, not a contract.
+
+## Output format
+
+Single report, sections in this order:
+
+```
+PR #<N>: <title>
+URL: <html_url>
+
+## CI ({pending}/{total} pending, {failed} failed)
+
+### ❌ <run name> ({id})
+<extracted error lines>
+
+### ❌ <run name> ({id})
+<extracted error lines>
+
+(if no failures: ✓ All checks passing)
+
+## Copilot review ({comment count} comments, top-level state: {state})
+
+Top-level: <one-line summary of top_review.body>
+
+### <path>:<line>  [skills: brand, react]  severity: block
+<comment.body trimmed to ~3 lines>
+→ canonical: .claude/skills/<skill>/SKILL.md
+
+(repeat per comment, grouped by file)
+
+## Recommended next steps
+
+1. <highest-severity / most-actionable item>
+2. ...
+```
+
+## Output discipline
+
+- **No raw JSON dumps in the report.** Use the structured format above.
+- **No more than ~10 inline comments shown.** If Copilot left more, summarise the rest as "+N more in <files>".
+- **Skill-pointer lines must be valid paths.** If `.claude/skills/<name>/` doesn't exist locally, drop the pointer rather than print a broken path.
+- **End with actionable next steps**, not a flat list of every issue.

--- a/.claude/skills/pr/references/creating-the-pr.md
+++ b/.claude/skills/pr/references/creating-the-pr.md
@@ -1,0 +1,75 @@
+# Phase 2 — Create the PR
+
+## Pre-flight
+
+Before any `gh pr create`:
+
+```bash
+branch=$(git branch --show-current)
+[ "$branch" = "main" ] && { echo "refusing: on main"; exit 1; }
+
+# Ensure pushed
+git rev-parse --abbrev-ref --symbolic-full-name @{upstream} >/dev/null 2>&1 \
+  || git push -u origin "$branch"
+
+# Confirm ahead of main
+ahead=$(git rev-list --count "origin/main..$branch")
+[ "$ahead" -eq 0 ] && { echo "no commits ahead of main"; exit 1; }
+```
+
+If push fails (auth, pre-push hook), surface the error and stop — do not retry blindly.
+
+## Title and body
+
+### Autofill from commits (1–3 commits ahead)
+
+```bash
+commits=$(git log --format='%s' "origin/main..$branch")
+n=$(echo "$commits" | wc -l)
+if [ "$n" -le 3 ]; then
+  title=$(echo "$commits" | head -1)
+  summary_bullets=$(echo "$commits" | awk '{print "- " $0}')
+fi
+```
+
+If `n > 3`, ask the user once for a title rather than guessing.
+
+### Body template (HEREDOC, always)
+
+```bash
+gh pr create --base main --head "$branch" --title "$title" --body "$(cat <<EOF
+## Summary
+
+$summary_bullets
+
+## Test plan
+
+- [ ] [fill in based on what changed]
+EOF
+)"
+```
+
+For trivial chore branches (one-liner docs / config), still include a `## Test plan` checklist — leave it empty if nothing to test, but the section must exist (project convention).
+
+## After creation
+
+Capture the PR number for later phases:
+
+```bash
+PR=$(gh pr view --json number -q .number)
+url=$(gh pr view --json url -q .url)
+```
+
+Then output one user-facing line: `Opened PR #<N>: <url>` — do not paste the full PR JSON.
+
+## When NOT to create
+
+- Branch is `main` / `master` / `release/*`.
+- No commits ahead of `origin/main`.
+- A PR already exists for this `headRefName` (regardless of state). If the existing PR is `MERGED` or `CLOSED`, ask the user before opening a new one.
+
+## Edge cases
+
+- **Pre-commit hook blocked the push earlier** → the working tree is clean but the branch is not pushed. Run `git push -u origin "$branch"` and surface any hook output. Don't bypass hooks.
+- **`gh auth status` shows expired token** → tell the user to `gh auth refresh` themselves; don't try to handle auth flow.
+- **Force-pushed history** → `gh pr create` will rebuild associations; nothing extra needed.

--- a/.claude/skills/pr/references/monitoring-ci-and-copilot.md
+++ b/.claude/skills/pr/references/monitoring-ci-and-copilot.md
@@ -1,0 +1,86 @@
+# Phase 4 — Monitor CI + Copilot
+
+## Polling loop (single source of truth)
+
+15-min ceiling, 30 s cadence = 30 iterations. Break early when both axes are done.
+
+```bash
+PR=$(gh pr view --json number -q .number)
+for i in $(seq 1 30); do
+  state=$(gh pr view "$PR" --json statusCheckRollup,reviews,reviewRequests --jq '
+    {
+      checks_total:   (.statusCheckRollup | length),
+      checks_pending: (.statusCheckRollup | map(select((.status // "COMPLETED") != "COMPLETED")) | length),
+      checks_failed:  (.statusCheckRollup | map(select(.conclusion == "FAILURE")) | length),
+      copilot_pending: (.reviewRequests | any((.login // "") | test("copilot"; "i"))),
+      copilot_done:    (.reviews        | any((.author.login // "") | test("copilot"; "i")))
+    }
+  ')
+  echo "iter $i/30: $(echo "$state" | jq -c '{checks_pending, checks_failed, copilot_pending, copilot_done}')"
+
+  done=$(echo "$state" | jq -r '(.checks_pending == 0) and (.copilot_pending == false or .copilot_done == true)')
+  [ "$done" = "true" ] && break
+  sleep 30
+done
+```
+
+## "Done" rules
+
+| Axis | Done when… |
+|------|-----------|
+| CI checks | `checks_pending == 0` (every check has `status: COMPLETED`) |
+| Copilot review | `copilot_pending == false` OR `copilot_done == true` |
+
+Both axes must be `done` for early-break. If only one is done, keep polling for the other within the 15 min budget.
+
+## Bot-login matching is fuzzy on purpose
+
+`@copilot` resolves to one of:
+- `copilot-pull-request-reviewer[bot]` (most common)
+- `Copilot` (some org configs)
+- a third-party reviewer integration named `*copilot*`
+
+Always match case-insensitively on substring `copilot`. Never hardcode the exact login — it changes and breaks the skill silently.
+
+## Why polling, not `gh pr checks --watch`
+
+`gh pr checks <N> --watch` blocks until checks finish but ignores Copilot review state. We need both axes in one loop, so polling wins. If checks alone are interesting (rare), `gh pr checks <N> --watch --interval 30` is fine.
+
+## Narration rules (what to print to the user)
+
+During polling, output **one short line per iteration** so the user sees progress. Acceptable:
+
+```
+iter 4/30: {"checks_pending":3,"checks_failed":0,"copilot_pending":true,"copilot_done":false}
+```
+
+NOT acceptable:
+- Dumping the full `gh pr view` JSON every iteration.
+- Streaming `gh run view --log` output during polling — those go to Phase 5.
+- Silent polling (>30 s of no output makes the user think it's hung).
+
+## Timeout behaviour
+
+If the loop exits without `done=true`:
+
+```bash
+[ "$i" -eq 30 ] && echo "timeout after 15 min — proceeding to analysis with partial data"
+```
+
+Phase 5 still runs against whatever state is available — there's almost always *something* useful (failed checks already visible, Copilot's review may have arrived in the last 30 s, etc.).
+
+## Refresh / re-review
+
+If the user wants to re-trigger Copilot after pushing new commits:
+
+```bash
+gh pr edit "$PR" --remove-reviewer @copilot
+gh pr edit "$PR" --add-reviewer @copilot
+```
+
+The remove-then-add cycle is the most reliable way; just `--add-reviewer` on an already-requested reviewer is a no-op.
+
+## Caveats
+
+- **June 1, 2026:** Copilot review runs consume GitHub Actions minutes. Surface this if the user asks to run `/pr` repeatedly on the same PR — repeated re-reviews are not free.
+- **Required-status-check rules** can leave a check in `PENDING` indefinitely if a required external check never runs. The polling loop will time out and the report will list the still-pending checks by name.


### PR DESCRIPTION
## Summary

Adds a DraftForge project skill `/pr` that drives a PR from "branch pushed" to "actionable review summary" without babysitting. Triggers when the user runs `/pr`, opens or pushes a pull request, or asks to monitor CI checks and Copilot review on a branch.

**5-phase workflow:**
1. Resolve state (open existing or create new — handles both)
2. Create the PR if missing (HEREDOC body with `## Summary` + `## Test plan`)
3. Idempotent `@copilot` reviewer request (case-insensitive bot-login match)
4. Single polling loop (30 s × 30 iters = 15 min ceiling) covering both GitHub Actions checks and Copilot review state
5. Analyse and report — CI failure log extraction with broad error-line grep, Copilot inline comments matched to `.github/instructions/*.instructions.md` `applyTo` globs, severity heuristics, structured report

**Files (project skill, 383 lines total):**
- `.claude/skills/pr/SKILL.md` — workflow
- `.claude/skills/pr/references/creating-the-pr.md` — pre-flight + `gh pr create` patterns
- `.claude/skills/pr/references/monitoring-ci-and-copilot.md` — polling loop, jq queries, narration discipline
- `.claude/skills/pr/references/analyzing-results.md` — log extraction, comment-to-skill matching, output format

Pairs with the global `/copilot` skill (dotfiles) and the per-skill `.github/instructions/*.instructions.md` files from #242.

## Test plan

- [ ] `/pr` on a branch with no PR yet → skill opens one, requests `@copilot`, polls, reports
- [ ] `/pr` on a branch with an existing open PR → skill detects, requests `@copilot` if missing, monitors, reports
- [ ] `/pr` on a branch with a merged/closed PR → skill stops and asks before opening a new one
- [ ] Skill cites canonical `.claude/skills/<name>/` pointers when matching Copilot comments to skills
- [ ] Skill does NOT spawn headed Playwright, does NOT bypass `just`, does NOT call tests flaky