### PR TITLE
fix(types): resolve pre-existing TypeScript errors

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     ['html', { open: 'never' }],
     ['list'],
     ['./tests/playwright/reporters/health-probe-reporter.ts'],
-    ...(process.env.CI ? [['github' as const]] : []),
+    ...(process.env.CI ? [['github', {}] as ['github', Record<string, unknown>]] : []),
   ],
 
   use: {

--- a/frontend/tests/playwright/e2e/07-draft/01-captain-pick.spec.ts
+++ b/frontend/tests/playwright/e2e/07-draft/01-captain-pick.spec.ts
@@ -45,7 +45,7 @@ test.describe('Captain Draft Pick', () => {
     if (firstTeam && firstTeam.captain) {
       captainPk = typeof firstTeam.captain === 'number'
         ? firstTeam.captain
-        : firstTeam.captain.pk;
+        : (firstTeam.captain as { pk: number }).pk;
     } else {
       throw new Error('Could not find captain for first team');
     }

--- a/frontend/tests/playwright/e2e/08-shuffle-draft/01-full-draft.spec.ts
+++ b/frontend/tests/playwright/e2e/08-shuffle-draft/01-full-draft.spec.ts
@@ -315,7 +315,7 @@ test.describe('Shuffle Draft - Captain Login Scenarios', () => {
 
     // Login as the second captain using loginAsUser
     // captain is now a PK (number) from the slim serializer
-    const captainPk = typeof secondCaptain === 'number' ? secondCaptain : secondCaptain.pk;
+    const captainPk: number = typeof secondCaptain === 'number' ? secondCaptain : (secondCaptain as { pk: number }).pk;
     const response = await loginAsUser(captainPk);
     console.log(`Logged in as: ${response.user?.username}`);
 

--- a/frontend/tests/playwright/e2e/09-bracket/02-bracket-match-linking.spec.ts
+++ b/frontend/tests/playwright/e2e/09-bracket/02-bracket-match-linking.spec.ts
@@ -12,6 +12,7 @@
  * Ported from Cypress: frontend/tests/cypress/e2e/09-bracket/02-bracket-match-linking.cy.ts
  */
 
+import type { Page } from '@playwright/test';
 import {
   test,
   expect,
@@ -45,7 +46,7 @@ test.describe.skip('Bracket Match Linking (e2e)', () => {
    * Helper to open the link modal for a specific team captain name.
    */
   async function openLinkModalForTeam(
-    page: typeof import('@playwright/test').Page,
+    page: Page,
     captainName: string
   ): Promise<void> {
     await page.locator(`text=${captainName}`).click();

--- a/frontend/tests/playwright/e2e/11-org-mmr/01-tournament-user-membership.spec.ts
+++ b/frontend/tests/playwright/e2e/11-org-mmr/01-tournament-user-membership.spec.ts
@@ -107,12 +107,15 @@ test.describe('Organization-Scoped MMR - Tournament User Membership', () => {
     expect(tournament!.league).not.toBeNull();
 
     const league = tournament!.league!;
-    const org = league.organization;
-    expect(org).not.toBeNull();
+    expect(league.organization).not.toBeNull();
+    const org = league.organization!;
 
     // Find a user not in this tournament
     // users is now an array of PKs (not full objects)
-    const tournamentUserPks = tournament!.users as number[];
+    const tournamentUsersRaw = tournament!.users as unknown as Array<number | { pk: number }>;
+    const tournamentUserPks: number[] = tournamentUsersRaw.map((u) =>
+      typeof u === 'number' ? u : u.pk
+    );
     const userToAdd = await findUserNotInTournament(context, tournamentUserPks);
     expect(userToAdd).not.toBeNull();
 

--- a/frontend/tests/playwright/e2e/herodraft-captain-connection.spec.ts
+++ b/frontend/tests/playwright/e2e/herodraft-captain-connection.spec.ts
@@ -1,11 +1,13 @@
-import { test as base, expect, BrowserContext, Page } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 import {
   loginAsUser,
   waitForHydration,
   DOCKER_HOST,
   API_URL,
 } from '../fixtures/auth';
-import { getHeroDraftByKey, resetHeroDraft, HeroDraftInfo } from '../fixtures/herodraft';
+import { getHeroDraftByKey, resetHeroDraft } from '../fixtures/herodraft';
+import type { HeroDraftInfo } from '../fixtures/herodraft';
 
 /**
  * Test captain connection management for HeroDraft.

--- a/frontend/tests/playwright/e2e/herodraft/stale-connection.spec.ts
+++ b/frontend/tests/playwright/e2e/herodraft/stale-connection.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, chromium, BrowserContext, Page, WebSocket as PWWebSocket, WebSocketRoute } from '@playwright/test';
+import { test, expect, chromium } from '@playwright/test';
+import type { BrowserContext, Page, WebSocket as PWWebSocket, WebSocketRoute } from '@playwright/test';
 import { loginAsDiscordId, loginUser, waitForHydration } from '../../fixtures/auth';
 import { HeroDraftPage } from '../../helpers/HeroDraftPage';
 

--- a/frontend/tests/playwright/e2e/herodraft/two-captains-full-draft.spec.ts
+++ b/frontend/tests/playwright/e2e/herodraft/two-captains-full-draft.spec.ts
@@ -407,8 +407,12 @@ test.describe('Two Captains Full Draft', () => {
     ]);
 
     // Verify WebSocket connections were established
-    console.log(`   Captain A WebSocket: ${wsConnectionA ? 'connected to ' + wsConnectionA.url : 'NOT CONNECTED'}`);
-    console.log(`   Captain B WebSocket: ${wsConnectionB ? 'connected to ' + wsConnectionB.url : 'NOT CONNECTED'}`);
+    // Cast through unknown because TypeScript narrows these to `null` based on the
+    // initial assignment — the closures that mutate them run later at runtime.
+    const wsA = wsConnectionA as unknown as { url: string; closed: boolean } | null;
+    const wsB = wsConnectionB as unknown as { url: string; closed: boolean } | null;
+    console.log(`   Captain A WebSocket: ${wsA ? 'connected to ' + wsA.url : 'NOT CONNECTED'}`);
+    console.log(`   Captain B WebSocket: ${wsB ? 'connected to ' + wsB.url : 'NOT CONNECTED'}`);
 
     if (!wsConnectionA || !wsConnectionB) {
       throw new Error('WebSocket connections not established for both captains');
@@ -591,9 +595,9 @@ test.describe('Two Captains Full Draft', () => {
     ];
 
     // Set first pick based on who won the flip (winner chose 'first_pick')
-    const firstPickCaptain: CaptainContext = flipWinnerCaptain;
-    const secondPickCaptain: CaptainContext = flipWinnerCaptain === captainA ? captainB : captainA;
-    const firstPickDetermined = true;
+    let firstPickCaptain: CaptainContext = flipWinnerCaptain;
+    let secondPickCaptain: CaptainContext = flipWinnerCaptain === captainA ? captainB : captainA;
+    let firstPickDetermined = true;
     console.log(`   First pick captain: ${firstPickCaptain.username}`);
 
     // Helper to determine which captain should pick based on round number

--- a/frontend/tests/playwright/e2e/herodraft/websocket-reconnect-fuzz.spec.ts
+++ b/frontend/tests/playwright/e2e/herodraft/websocket-reconnect-fuzz.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, chromium, BrowserContext, Page } from '@playwright/test';
+import { test, expect, chromium } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 import { loginAsDiscordId, waitForHydration } from '../../fixtures/auth';
 import { HeroDraftPage } from '../../helpers/HeroDraftPage';
 

--- a/frontend/tests/playwright/fixtures/auth.ts
+++ b/frontend/tests/playwright/fixtures/auth.ts
@@ -7,7 +7,8 @@
  * Ports the Cypress login commands to Playwright.
  */
 
-import { test as base, expect, BrowserContext, Page } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 
 // Use localhost by default (matches playwright.config.ts baseURL)
 // Can be overridden with DOCKER_HOST for running inside Docker containers
@@ -153,6 +154,12 @@ export async function loginAdmin(context: BrowserContext): Promise<void> {
   console.log(`[auth] loginAdmin response: ${status} ${statusText}`);
 
   if (!response.ok()) {
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      body = '[could not read body]';
+    }
     console.error(`[auth] loginAdmin FAILED: ${status} ${statusText}`);
     console.error(`[auth] This usually means:`);
     console.error(`[auth]   - 403: TEST=true not set or IP not whitelisted`);

--- a/frontend/tests/playwright/fixtures/demo-utils.ts
+++ b/frontend/tests/playwright/fixtures/demo-utils.ts
@@ -1,4 +1,5 @@
-import { Page, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 /**
  * Demo-specific utilities for ensuring content is fully loaded before recording.

--- a/frontend/tests/playwright/fixtures/herodraft.ts
+++ b/frontend/tests/playwright/fixtures/herodraft.ts
@@ -1,5 +1,7 @@
-import { test as base, expect, Browser, BrowserContext, Page } from '@playwright/test';
-import { loginAsUser, waitForHydration, UserInfo } from './auth';
+import { test as base, expect } from '@playwright/test';
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+import { loginAsUser, waitForHydration } from './auth';
+import type { UserInfo } from './auth';
 
 const API_URL = 'https://localhost/api';
 

--- a/frontend/tests/playwright/global-setup.ts
+++ b/frontend/tests/playwright/global-setup.ts
@@ -1,4 +1,5 @@
-import { chromium, FullConfig } from '@playwright/test';
+import { chromium } from '@playwright/test';
+import type { FullConfig } from '@playwright/test';
 
 async function globalSetup(config: FullConfig) {
   console.log('Global setup: Pre-fetching test data...');

--- a/frontend/tests/playwright/helpers/HeroDraftPage.ts
+++ b/frontend/tests/playwright/helpers/HeroDraftPage.ts
@@ -1,4 +1,5 @@
-import { Page, Locator, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { Page, Locator } from '@playwright/test';
 
 /**
  * Page Object for the HeroDraft (Captain's Mode) interface.

--- a/frontend/tests/playwright/helpers/add-user.ts
+++ b/frontend/tests/playwright/helpers/add-user.ts
@@ -1,4 +1,5 @@
-import { Page, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 /**
  * Shared helpers for interacting with AddUserModal across tests.

--- a/frontend/tests/playwright/helpers/league.ts
+++ b/frontend/tests/playwright/helpers/league.ts
@@ -1,4 +1,5 @@
-import { Page, Locator, BrowserContext, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { Page, Locator, BrowserContext } from '@playwright/test';
 
 const API_URL = 'https://localhost/api';
 

--- a/frontend/tests/playwright/helpers/tournament.ts
+++ b/frontend/tests/playwright/helpers/tournament.ts
@@ -1,4 +1,5 @@
-import { Page, Locator, BrowserContext, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { Page, Locator, BrowserContext } from '@playwright/test';
 
 const API_URL = 'https://localhost/api';
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,19 +3,15 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-const ReactCompilerConfig = {
-  // Compile all files in app/ directory
-  sources: (filename: string) => filename.includes('/app/'),
-};
+// Note: `reactRouter()` no longer accepts a babel option in current versions;
+// React Compiler integration (babel-plugin-react-compiler) must be configured
+// via the React Router config file (react-router.config.ts) or a dedicated
+// babel plugin if reintroduced.
 
 export default defineConfig({
   plugins: [
     tailwindcss(),
-    reactRouter({
-      babel: {
-        plugins: [['babel-plugin-react-compiler', ReactCompilerConfig]],
-      },
-    }),
+    reactRouter(),
     tsconfigPaths(),
   ],
   build: {


### PR DESCRIPTION
## Summary

Drives `npm run typecheck` toward zero errors across `frontend/tests/playwright/**`, `frontend/vite.config.ts`, and `frontend/playwright.config.ts`. None of these errors are caused by recent application code — they were already failing on `main` and were blocking the in-progress i18n branch's tsc gates from being meaningful.

## What this fixes

**Category A — `TS1484` "type-only import"** (15 test/fixture/helper files):
Mechanical migration to `import type { ... }` for types under `verbatimModuleSyntax: true`. Types affected: `BrowserContext`, `Page`, `Browser`, `Locator`, `FullConfig`, `WebSocket`, `WebSocketRoute`, `UserInfo`, `HeroDraftInfo`.

**Category B — real bugs:**

- `tests/playwright/fixtures/auth.ts:162` — `'body' not defined` in the `loginAdmin` error path. Added a small try/catch that mirrors the pattern used in neighbouring login helpers.
- `tests/playwright/e2e/07-draft/01-captain-pick.spec.ts` and `08-shuffle-draft/01-full-draft.spec.ts` — `captain.pk` on `never` (the slim-serializer field is `number`, so the `typeof === 'object'` branch is unreachable but TS still narrows to `never`). Cast through `{ pk: number }` to appease TS without changing runtime behavior.
- `tests/playwright/e2e/09-bracket/02-bracket-match-linking.spec.ts` — `Page` import switched to `import type { Page }`.
- `tests/playwright/e2e/11-org-mmr/01-tournament-user-membership.spec.ts` — replaced an opaque `as number[]` cast with `.map(u => typeof u === 'number' ? u : u.pk)`; added non-null assertion on `league.organization` immediately after the existing `expect(...).not.toBeNull()` so TS narrows the local binding.
- `tests/playwright/e2e/herodraft/two-captains-full-draft.spec.ts` — `const` → `let` for `firstPickCaptain`, `secondPickCaptain`, `firstPickDetermined` (they are reassigned a few lines later); `wsConnectionA/B.url` lines defeated closure-based null narrowing via `as unknown as ...` aliases (the runtime null-guard at L413 remains untouched).
- `frontend/vite.config.ts:14` — `reactRouter()` no longer accepts a `babel` option; removed the now-deprecated argument and the unused `ReactCompilerConfig` const. **See concerns below.**
- `frontend/playwright.config.ts:49` — reporter tuple shape needs `[name, options]`; changed `['github' as const]` → `['github', {}] as ['github', Record<string, unknown>]`.

## Concerns the reviewer should weigh

1. **`babel-plugin-react-compiler` is no longer wired through `vite.config.ts`.** The current `reactRouter()` signature takes 0 args. If the project depends on the React Compiler being active in builds, it needs to be re-wired via `react-router.config.ts` future-mode flags or a separate vite plugin (e.g., `vite-plugin-babel`). This PR removes the broken wiring; it does not add a working replacement. If the compiler was already inert because the option was being silently ignored, this is a no-op. Worth confirming before merge.

2. **`app/` source still has ~100 errors** (mostly `react-hook-form` `Resolver`/`Control` covariance mismatches across form modals — `CreateEventModal`, `EditRepeaterModal`, `EditOrganizationModal`, etc.). Those look like a project-wide regression from an `@hookform/resolvers` or `react-hook-form` major bump. **Not fixed in this PR** — they need their own scoped fix and review.

3. **`node_modules/dotaconstants/index.ts`** trips 24 `TS2823` (import attributes) errors against the current `module` setting. Out of scope; would require either a `tsconfig.json` `module` bump or a `skipLibCheck`/exclusion. **Not addressed here.**

After merge, `npm run typecheck` will still report errors — but only from (2) and (3) above. The test/fixture/helper noise is eliminated.

## Test plan

- [x] `cd frontend && npm run typecheck` — Category A and B errors gone (verified by the implementing agent during preparation)
- [ ] Reviewer reproduces by checking out the branch and running `npm run typecheck` — should see only `app/` form-resolver errors + `dotaconstants` namespace errors remaining
- [ ] Reviewer confirms whether the React Compiler wiring removal is acceptable

## Why isolated

This work was kicked off as a prerequisite for the i18n PR (`feature/frontend-i18n-navbar-es`) but is independent of i18n. Splitting it out keeps the i18n PR reviewable on its own merits and gives the React Compiler / hook-form-resolver concerns their proper attention.