### PR TITLE
feat(herodraft): client-side countdown + wall-to-wall telemetry

### DIFF
--- a/backend/app/consumers.py
+++ b/backend/app/consumers.py
@@ -270,17 +270,29 @@ class HeroDraftConsumer(BaseDraftConsumer):
     # --- Receive ---
 
     async def receive(self, text_data):
-        """Handle incoming WebSocket messages from clients."""
+        """Handle incoming WebSocket messages from clients.
+
+        Wrapped in a `ws.message` span via `traced_message` so each
+        incoming WS message appears as its own trace in Tempo with
+        `ws.message_type` set. Handler spans (e.g. `ws.heartbeat`)
+        become children of this span — Tempo shows the full waterfall
+        of "message dispatch overhead → handler work" without needing
+        to instrument every handler separately.
+        """
         if not self._is_captain:
             return  # Only process messages from captains
 
         try:
             data = json.loads(text_data)
-            msg_type = data.get("type")
+            msg_type = data.get("type", "unknown")
 
-            if msg_type == "heartbeat":
-                await self.handle_heartbeat()
+            async with self.traced_message(msg_type):
+                if msg_type == "heartbeat":
+                    await self.handle_heartbeat()
         except json.JSONDecodeError:
+            # Span deliberately NOT opened — there's no message type to
+            # tag the span with, and a `ws.message[type=unknown]` span on
+            # every byte of garbage would just pollute Tempo. Log only.
             log.warning(
                 "ws_malformed_message",
                 system="herodraft",

--- a/backend/app/consumers.py
+++ b/backend/app/consumers.py
@@ -516,19 +516,30 @@ class HeroDraftConsumer(BaseDraftConsumer):
         await self.send(text_data=json.dumps(message))
 
     async def herodraft_tick(self, event):
-        """Handle tick updates during active drafting."""
+        """Forward tick anchors from the channel layer to this WS client.
+
+        Anchor fields (server_time + round_started_at + round_grace_time_ms
+        + raw team reserves + resuming_until) drive the client-side rAF
+        countdown. See `backend/app/tasks/herodraft_tick.py::broadcast_tick`
+        for the producer side.
+        """
         await self.send(
             text_data=json.dumps(
                 {
                     "type": "herodraft_tick",
+                    "draft_state": event.get("draft_state"),
+                    "server_time": event.get("server_time"),
+                    # DRAFTING anchors
                     "current_round": event.get("current_round"),
                     "active_team_id": event.get("active_team_id"),
-                    "grace_time_remaining_ms": event.get("grace_time_remaining_ms"),
+                    "round_started_at": event.get("round_started_at"),
+                    "round_grace_time_ms": event.get("round_grace_time_ms"),
                     "team_a_id": event.get("team_a_id"),
                     "team_a_reserve_ms": event.get("team_a_reserve_ms"),
                     "team_b_id": event.get("team_b_id"),
                     "team_b_reserve_ms": event.get("team_b_reserve_ms"),
-                    "draft_state": event.get("draft_state"),
+                    # RESUMING anchor
+                    "resuming_until": event.get("resuming_until"),
                 }
             )
         )

--- a/backend/app/consumers_base.py
+++ b/backend/app/consumers_base.py
@@ -3,20 +3,48 @@ Base WebSocket consumer for draft-related connections.
 
 Provides shared infrastructure for heartbeat processing, captain tracking,
 connection counting, and server-side ping keepalive.
+
+# OpenTelemetry tracing
+
+Key lifecycle methods (connect, disconnect, heartbeat, captain register/
+unregister) are wrapped in OTel spans so each WebSocket operation shows
+up in Tempo as its own trace. Spans share `ws.conn_id` as an attribute,
+so you can find every operation for a given session by querying spans
+on that key — even though each operation is its own independent trace.
+
+We do NOT wrap `connect→disconnect` in a single long-lived parent span:
+OTel only exports spans on `End()`, so a 30-min WS session would show
+nothing in Tempo until disconnect, and a process crash mid-session
+would lose the whole trace. Short spans per operation export
+immediately and survive crashes.
+
+Logs emitted inside a span automatically get `trace_id` / `span_id`
+attributes (via `telemetry.logging._add_otel_trace_context`). The
+Loki datasource's `traceID` derived field turns those into clickable
+links to the Tempo trace view.
+
+Subclasses that want to trace their own per-message handlers should
+use `BaseDraftConsumer.traced_message(message_type, **attrs)` as an
+async context manager — see its docstring for details.
 """
 
 import asyncio
+import contextlib
 import json
 import time
 from abc import abstractmethod
+from typing import Any
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 
 from telemetry.logging import get_logger
 from telemetry.websocket import TelemetryConsumerMixin
 
 log = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # Heartbeat expires after 30 seconds without renewal
 HEARTBEAT_TTL = 30
@@ -94,59 +122,78 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
 
     async def handle_heartbeat(self):
         """Process a heartbeat message from a captain. Updates Redis TTL."""
-        from app.tasks.herodraft_tick import get_redis_client
+        with tracer.start_as_current_span(
+            "ws.heartbeat",
+            attributes=self._base_span_attrs(),
+        ) as span:
+            from app.tasks.herodraft_tick import get_redis_client
 
-        r = get_redis_client()
-        heartbeat_key = self._heartbeat_key(self.draft_id, self.user.id)
-        r.set(heartbeat_key, str(time.time()), ex=HEARTBEAT_TTL)
-        log.debug(
-            "heartbeat_received",
-            system="websocket",
-            subsystem="heartbeat",
-            draft_id=self.draft_id,
-            user_id=self.user.id,
-            ttl=HEARTBEAT_TTL,
-        )
+            r = get_redis_client()
+            heartbeat_key = self._heartbeat_key(self.draft_id, self.user.id)
+            r.set(heartbeat_key, str(time.time()), ex=HEARTBEAT_TTL)
+            span.set_attribute("ws.heartbeat_ttl_s", HEARTBEAT_TTL)
+            log.debug(
+                "heartbeat_received",
+                system="websocket",
+                subsystem="heartbeat",
+                draft_id=self.draft_id,
+                user_id=self.user.id,
+                ttl=HEARTBEAT_TTL,
+            )
 
     # --- Captain channel registration ---
 
     async def _register_captain(self):
         """Register this connection as the captain's active channel in Redis."""
-        from app.tasks.herodraft_tick import get_redis_client
+        with tracer.start_as_current_span(
+            "ws.captain_register",
+            attributes=self._base_span_attrs(),
+        ):
+            from app.tasks.herodraft_tick import get_redis_client
 
-        r = get_redis_client()
-        channel_key = self._captain_channel_key(self.draft_id, self.user.id)
-        r.set(channel_key, self.channel_name, ex=CAPTAIN_CHANNEL_TTL)
-        # Initialize heartbeat
-        await self.handle_heartbeat()
-        log.info(
-            "captain_registered",
-            system="websocket",
-            subsystem="heartbeat",
-            draft_id=self.draft_id,
-            user_id=self.user.id,
-            channel=self.channel_name,
-        )
-
-    async def _unregister_captain_if_current(self):
-        """Unregister captain channel only if it's still this connection."""
-        from app.tasks.herodraft_tick import get_redis_client
-
-        r = get_redis_client()
-        channel_key = self._captain_channel_key(self.draft_id, self.user.id)
-        heartbeat_key = self._heartbeat_key(self.draft_id, self.user.id)
-
-        current_channel = r.get(channel_key)
-        if current_channel == self.channel_name:
-            r.delete(channel_key)
-            r.delete(heartbeat_key)
+            r = get_redis_client()
+            channel_key = self._captain_channel_key(self.draft_id, self.user.id)
+            r.set(channel_key, self.channel_name, ex=CAPTAIN_CHANNEL_TTL)
+            # Initialize heartbeat (nested span)
+            await self.handle_heartbeat()
             log.info(
-                "captain_unregistered",
+                "captain_registered",
                 system="websocket",
                 subsystem="heartbeat",
                 draft_id=self.draft_id,
                 user_id=self.user.id,
+                channel=self.channel_name,
             )
+
+    async def _unregister_captain_if_current(self):
+        """Unregister captain channel only if it's still this connection."""
+        with tracer.start_as_current_span(
+            "ws.captain_unregister",
+            attributes=self._base_span_attrs(),
+        ) as span:
+            from app.tasks.herodraft_tick import get_redis_client
+
+            r = get_redis_client()
+            channel_key = self._captain_channel_key(self.draft_id, self.user.id)
+            heartbeat_key = self._heartbeat_key(self.draft_id, self.user.id)
+
+            current_channel = r.get(channel_key)
+            if current_channel == self.channel_name:
+                r.delete(channel_key)
+                r.delete(heartbeat_key)
+                span.set_attribute("ws.captain_unregistered", True)
+                log.info(
+                    "captain_unregistered",
+                    system="websocket",
+                    subsystem="heartbeat",
+                    draft_id=self.draft_id,
+                    user_id=self.user.id,
+                )
+            else:
+                # Another connection has taken over; nothing to clean up
+                # for this connection. Tag so trace shows the no-op.
+                span.set_attribute("ws.captain_unregistered", False)
+                span.set_attribute("ws.skipped_reason", "not_current_channel")
 
     # --- Connection count tracking ---
 
@@ -207,6 +254,62 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
         except Exception as e:
             log.debug(f"Ping loop ended for draft {self.draft_id}: {e}")
 
+    # --- Span helpers ---
+
+    def _base_span_attrs(self) -> dict[str, Any]:
+        """Attributes attached to every WS-lifecycle span.
+
+        Pulled into its own helper because Tempo correlation works by
+        attribute (we don't share a parent span across operations) —
+        every span MUST carry `ws.conn_id` so a Tempo query like
+        `{.ws.conn_id="abc..."}` finds the whole session. Missing this
+        on even one span breaks the correlation path.
+        """
+        attrs: dict[str, Any] = {
+            "ws.consumer": self.__class__.__name__,
+        }
+        # `ws_conn_id` is set by TelemetryConsumerMixin.telemetry_connect;
+        # base_connect() may invoke a heartbeat span before that runs in
+        # error paths, so guard.
+        conn_id = getattr(self, "ws_conn_id", None)
+        if conn_id:
+            attrs["ws.conn_id"] = conn_id
+        draft_id = getattr(self, "draft_id", None)
+        if draft_id is not None:
+            attrs["ws.draft_id"] = draft_id
+        user = getattr(self, "user", None)
+        if user is not None and getattr(user, "is_authenticated", False):
+            attrs["user.id"] = user.pk
+        return attrs
+
+    @contextlib.asynccontextmanager
+    async def traced_message(self, message_type: str, **extra_attrs: Any):
+        """Async context manager for tracing a received WS message.
+
+        Subclasses that handle messages should wrap their per-message
+        logic with this so each message becomes a `ws.message` span in
+        Tempo. Logs inside the block automatically get the trace_id.
+
+        Usage in a subclass's `receive` / `receive_json`::
+
+            async def receive(self, text_data=None, **kwargs):
+                msg = json.loads(text_data)
+                async with self.traced_message(msg.get("type", "unknown"),
+                                               **{"ws.event": msg.get("event")}):
+                    # subclass-specific handler logic
+                    ...
+
+        Exceptions propagate normally. OTel's `start_as_current_span`
+        auto-records exceptions and sets the span status to ERROR on
+        context exit (record_exception=True, set_status_on_exception=True
+        are SDK defaults), so we don't need to do it manually.
+        """
+        attrs = self._base_span_attrs()
+        attrs["ws.message_type"] = message_type
+        attrs.update(extra_attrs)
+        with tracer.start_as_current_span("ws.message", attributes=attrs) as span:
+            yield span
+
     # --- Base connect/disconnect ---
 
     async def base_connect(self):
@@ -227,62 +330,78 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
         self._is_captain = False
         self._ping_task = None
 
-        # Validate draft exists
-        exists = await self.draft_exists(self.draft_id)
-        if not exists:
-            log.warning(f"{prefix} {self.draft_id} not found, closing connection")
-            await self.close()
-            return False
+        with tracer.start_as_current_span(
+            "ws.connect",
+            attributes={**self._base_span_attrs(), "ws.path": self.scope.get("path", "")},
+        ) as span:
+            # OTel's start_as_current_span auto-records propagating
+            # exceptions and sets ERROR status on context exit, so no
+            # outer try/except is needed here. The inner try/except for
+            # initial_state catches + returns False instead of raising,
+            # so it has to set the status manually.
 
-        # Check if this user is a captain
-        if self.user and self.user.is_authenticated:
-            draft_team = await self.get_captain_draft_team(self.draft_id, self.user)
-            if draft_team is not None:
-                self._is_captain = True
+            # Validate draft exists
+            exists = await self.draft_exists(self.draft_id)
+            if not exists:
+                span.set_attribute("ws.connect_outcome", "draft_not_found")
+                log.warning(f"{prefix} {self.draft_id} not found, closing connection")
+                await self.close()
+                return False
 
-        # Join room group
-        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
-        await self.accept()
+            # Check if this user is a captain
+            if self.user and self.user.is_authenticated:
+                draft_team = await self.get_captain_draft_team(self.draft_id, self.user)
+                if draft_team is not None:
+                    self._is_captain = True
+            span.set_attribute("ws.is_captain", self._is_captain)
 
-        # Track connection count
-        await self._increment_connection_count()
+            # Join room group
+            await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+            await self.accept()
 
-        # Register captain's channel for future kick detection
-        if self._is_captain:
-            await self._register_captain()
+            # Track connection count
+            await self._increment_connection_count()
 
-        # Send initial state
-        try:
-            initial_state = await self.get_initial_state_data(self.draft_id)
-            await self.send(
-                text_data=json.dumps(
-                    {
-                        "type": "initial_state",
-                        "draft_state": initial_state,
-                    }
+            # Register captain's channel for future kick detection
+            # (nested span — ws.captain_register)
+            if self._is_captain:
+                await self._register_captain()
+
+            # Send initial state
+            try:
+                initial_state = await self.get_initial_state_data(self.draft_id)
+                await self.send(
+                    text_data=json.dumps(
+                        {
+                            "type": "initial_state",
+                            "draft_state": initial_state,
+                        }
+                    )
                 )
-            )
 
-            # Start tick broadcaster if draft is in an active state
-            if (
-                initial_state
-                and initial_state.get("state") in self.get_active_draft_state_values()
-            ):
-                await self._maybe_start_tick_broadcaster()
+                # Start tick broadcaster if draft is in an active state
+                if (
+                    initial_state
+                    and initial_state.get("state") in self.get_active_draft_state_values()
+                ):
+                    await self._maybe_start_tick_broadcaster()
 
-        except Exception as e:
-            log.error(f"Failed to send initial state for {prefix} {self.draft_id}: {e}")
-            await self.close()
-            return False
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, "initial_state_failed"))
+                log.error(f"Failed to send initial state for {prefix} {self.draft_id}: {e}")
+                await self.close()
+                return False
 
-        # Notify subclass of captain connection state
-        if self._is_captain:
-            await self.on_captain_state_change(self.draft_id, self.user, True)
+            # Notify subclass of captain connection state
+            if self._is_captain:
+                await self.on_captain_state_change(self.draft_id, self.user, True)
 
-        # Start server-side ping loop
-        self._ping_task = asyncio.ensure_future(self._ping_loop())
+            # Start server-side ping loop
+            self._ping_task = asyncio.ensure_future(self._ping_loop())
 
-        return True
+            span.set_attribute("ws.connect_outcome", "ok")
+            return True
 
     async def base_disconnect(self, close_code):
         """Shared disconnection cleanup. Call from subclass disconnect().
@@ -290,51 +409,64 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
         Handles: cancel ping, kicked connections, decrement count, unregister
         captain, mark disconnected, leave group, telemetry.
         """
-        await self.telemetry_disconnect(close_code)
+        with tracer.start_as_current_span(
+            "ws.disconnect",
+            attributes={
+                **self._base_span_attrs(),
+                "ws.close_code": close_code if close_code is not None else -1,
+            },
+        ) as span:
+            await self.telemetry_disconnect(close_code)
 
-        # Cancel ping loop and wait for clean shutdown
-        if getattr(self, "_ping_task", None):
-            self._ping_task.cancel()
-            try:
-                await self._ping_task
-            except asyncio.CancelledError:
-                pass
-            self._ping_task = None
+            # Cancel ping loop and wait for clean shutdown
+            if getattr(self, "_ping_task", None):
+                self._ping_task.cancel()
+                try:
+                    await self._ping_task
+                except asyncio.CancelledError:
+                    pass
+                self._ping_task = None
 
-        # Track disconnection
-        if hasattr(self, "_connection_tracked") and self._connection_tracked:
-            await self._decrement_connection_count()
+            # Track disconnection
+            if hasattr(self, "_connection_tracked") and self._connection_tracked:
+                await self._decrement_connection_count()
 
-        # If this connection was kicked by a new connection, don't mark as disconnected
-        was_kicked = getattr(self, "_was_kicked", False)
-        if was_kicked:
-            log.info(
-                f"Skipping disconnect handling for kicked connection "
-                f"(user {getattr(self, 'user', None)}, draft {getattr(self, 'draft_id', None)})"
-            )
+            # If this connection was kicked by a new connection, don't mark as disconnected
+            was_kicked = getattr(self, "_was_kicked", False)
+            if was_kicked:
+                span.set_attribute("ws.kicked", True)
+                log.info(
+                    f"Skipping disconnect handling for kicked connection "
+                    f"(user {getattr(self, 'user', None)}, draft {getattr(self, 'draft_id', None)})"
+                )
+                if hasattr(self, "room_group_name"):
+                    await self.channel_layer.group_discard(
+                        self.room_group_name, self.channel_name
+                    )
+                return
+
+            # Clean up captain channel registration and mark as disconnected
+            # (nested span — ws.captain_unregister)
+            if (
+                hasattr(self, "_is_captain")
+                and self._is_captain
+                and hasattr(self, "user")
+                and hasattr(self, "draft_id")
+            ):
+                try:
+                    await self._unregister_captain_if_current()
+                    await self.on_captain_state_change(self.draft_id, self.user, False)
+                except Exception as e:
+                    # Don't mark the whole disconnect as ERROR — cleanup
+                    # failure is recoverable. Record the exception so
+                    # Tempo shows what failed.
+                    span.record_exception(e)
+                    log.error(
+                        f"Failed to mark captain disconnected for draft {self.draft_id}: {e}"
+                    )
+
+            # Leave room group
             if hasattr(self, "room_group_name"):
                 await self.channel_layer.group_discard(
                     self.room_group_name, self.channel_name
                 )
-            return
-
-        # Clean up captain channel registration and mark as disconnected
-        if (
-            hasattr(self, "_is_captain")
-            and self._is_captain
-            and hasattr(self, "user")
-            and hasattr(self, "draft_id")
-        ):
-            try:
-                await self._unregister_captain_if_current()
-                await self.on_captain_state_change(self.draft_id, self.user, False)
-            except Exception as e:
-                log.error(
-                    f"Failed to mark captain disconnected for draft {self.draft_id}: {e}"
-                )
-
-        # Leave room group
-        if hasattr(self, "room_group_name"):
-            await self.channel_layer.group_discard(
-                self.room_group_name, self.channel_name
-            )

--- a/backend/app/functions/herodraft.py
+++ b/backend/app/functions/herodraft.py
@@ -1,10 +1,12 @@
 """Functions for Captain's Mode hero draft."""
 
-import logging
 import random
 
 from django.db import transaction
 from django.utils import timezone
+from opentelemetry import trace
+
+from telemetry.logging import get_logger
 
 from app.models import (
     DraftTeam,
@@ -14,7 +16,8 @@ from app.models import (
     HeroDraftState,
 )
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 # Updated Captain's Mode sequence (2024 patch)
@@ -167,21 +170,49 @@ def submit_choice(draft: HeroDraft, team: DraftTeam, choice_type: str, value: st
 CLIENT_PICK_TIME_MAX_AGE_S = 2.0
 
 
-def _effective_pick_time(server_now, client_picked_at):
-    """Trust the client-reported pick time if it's within the sanity window.
+def _evaluate_client_pick_time(server_now, client_picked_at, draft_id):
+    """Decide whether to trust the client's pick time + log any weirdness.
 
-    Client sends `client_picked_at = new Date().toISOString()` at the moment
-    they confirmed the pick. The message takes some network time to arrive.
-    Using server-receive time would penalise slow networks; trusting the
-    client time absorbs that latency. The 2s cap prevents a clock-skewed
-    or hostile client from "winding back" their pick arbitrarily.
+    Returns (effective_time, source, age_ms) where:
+        effective_time: datetime to compute elapsed from
+        source: "client" if we trusted it, "server_now" otherwise
+        age_ms: client→server delta in ms (or None when no client_picked_at)
     """
     if not client_picked_at:
-        return server_now
+        return server_now, "server_now", None
+
     age_s = (server_now - client_picked_at).total_seconds()
-    if 0 <= age_s <= CLIENT_PICK_TIME_MAX_AGE_S:
-        return client_picked_at
-    return server_now
+    age_ms = int(age_s * 1000)
+
+    if age_s < 0:
+        # Client clock is in the future relative to server. Most often
+        # clock skew (laptop with bad NTP), occasionally a hostile client
+        # trying to win back time. Falls through to server time.
+        log.warning(
+            "pick_time_in_future",
+            system="herodraft",
+            subsystem="timing",
+            draft_id=draft_id,
+            future_by_ms=-age_ms,
+        )
+        return server_now, "server_now", age_ms
+
+    if age_s > CLIENT_PICK_TIME_MAX_AGE_S:
+        # Pick payload arrived more than the sanity window after the
+        # client sent it. Network was slow or the client buffered the
+        # request. We discard the client timestamp to prevent abuse;
+        # this means the captain eats the network latency on this pick.
+        log.warning(
+            "pick_time_too_old",
+            system="herodraft",
+            subsystem="timing",
+            draft_id=draft_id,
+            age_ms=age_ms,
+            max_age_ms=int(CLIENT_PICK_TIME_MAX_AGE_S * 1000),
+        )
+        return server_now, "server_now", age_ms
+
+    return client_picked_at, "client", age_ms
 
 
 def submit_pick(
@@ -195,12 +226,25 @@ def submit_pick(
 
     Args:
         client_picked_at: Optional datetime from the client (browser
-            `Date.now()` at confirm). Used when within 2s of server now,
-            ignored otherwise — see `_effective_pick_time`.
+            `Date.now()` at confirm, in SERVER-clock reference via the
+            offset learned from tick.server_time). Trusted when within
+            2s of server now; otherwise we fall back to server-receive
+            time and log a `pick_time_*` warning.
 
     Returns the completed round.
     """
-    with transaction.atomic():
+    span = tracer.start_as_current_span(
+        "herodraft.submit_pick",
+        attributes={
+            "ws.draft_id": draft.id,
+            "draft.team_id": team.id,
+            "draft.hero_id": hero_id,
+            "draft.client_picked_at": (
+                client_picked_at.isoformat() if client_picked_at else "none"
+            ),
+        },
+    )
+    with span as active_span, transaction.atomic():
         draft = HeroDraft.objects.select_for_update().get(id=draft.id)
         team = DraftTeam.objects.select_for_update().get(id=team.id)
         current_round = draft.rounds.select_for_update().filter(state="active").first()
@@ -218,21 +262,95 @@ def submit_pick(
         if hero_id in used_heroes:
             raise ValueError("Hero already picked or banned")
 
-        # Calculate time spent and update reserve time
+        # Determine effective pick time + emit telemetry for any anomaly
         now = timezone.now()
-        effective_pick_time = _effective_pick_time(now, client_picked_at)
+        effective_pick_time, pick_time_source, pick_time_age_ms = (
+            _evaluate_client_pick_time(now, client_picked_at, draft.id)
+        )
+
         elapsed_ms = int(
             (effective_pick_time - current_round.started_at).total_seconds() * 1000
         )
+
+        if elapsed_ms < 0:
+            # `started_at` is in the future relative to our pick time.
+            # Possible causes: server clock jump backwards, manual DB
+            # tampering, or a race where the pick lands before the round
+            # was marked active. Clamp to 0 to keep the math sane.
+            log.error(
+                "pick_elapsed_negative",
+                system="herodraft",
+                subsystem="timing",
+                draft_id=draft.id,
+                round_started_at=current_round.started_at.isoformat(),
+                pick_time=effective_pick_time.isoformat(),
+                elapsed_ms=elapsed_ms,
+            )
+            elapsed_ms = 0
+
         grace_used = min(elapsed_ms, current_round.grace_time_ms)
         # Floor reserve consumption to whole seconds so sub-second
-        # over-grace (typically network jitter) doesn't nibble the
-        # team's reserve.
+        # over-grace (typically network jitter) doesn't nibble reserve.
         over_grace_ms = max(0, elapsed_ms - current_round.grace_time_ms)
         reserve_used = (over_grace_ms // 1000) * 1000
 
-        team.reserve_time_remaining = max(0, team.reserve_time_remaining - reserve_used)
+        reserve_before = team.reserve_time_remaining
+
+        if reserve_used > reserve_before:
+            # Captain ran out of reserve mid-round; auto-pick should
+            # have fired but didn't. Almost always means the tick
+            # broadcaster wasn't running for this draft (no captains
+            # connected, lock contention, crashed loop).
+            log.warning(
+                "pick_reserve_exhausted",
+                system="herodraft",
+                subsystem="timing",
+                draft_id=draft.id,
+                team_id=team.id,
+                reserve_used_ms=reserve_used,
+                reserve_before_ms=reserve_before,
+                elapsed_ms=elapsed_ms,
+            )
+
+        team.reserve_time_remaining = max(0, reserve_before - reserve_used)
         team.save()
+
+        # Annotate the span so Tempo shows all the key values at a glance
+        active_span.set_attribute("draft.round_number", current_round.round_number)
+        active_span.set_attribute("draft.action_type", current_round.action_type)
+        active_span.set_attribute("draft.elapsed_ms", elapsed_ms)
+        active_span.set_attribute("draft.grace_used_ms", grace_used)
+        active_span.set_attribute("draft.reserve_used_ms", reserve_used)
+        active_span.set_attribute("draft.reserve_before_ms", reserve_before)
+        active_span.set_attribute("draft.reserve_after_ms", team.reserve_time_remaining)
+        active_span.set_attribute("draft.pick_time_source", pick_time_source)
+        if pick_time_age_ms is not None:
+            active_span.set_attribute("draft.pick_time_age_ms", pick_time_age_ms)
+
+        # Central diagnostic log — every pick emits one of these with
+        # the full timing context. Query by event=pick_submitted in
+        # Loki to walk the entire draft's pick history with one filter.
+        log.info(
+            "pick_submitted",
+            system="herodraft",
+            subsystem="pick",
+            draft_id=draft.id,
+            round_number=current_round.round_number,
+            action_type=current_round.action_type,
+            team_id=team.id,
+            hero_id=hero_id,
+            round_started_at=current_round.started_at.isoformat(),
+            server_now=now.isoformat(),
+            effective_pick_time=effective_pick_time.isoformat(),
+            elapsed_ms=elapsed_ms,
+            grace_time_ms=current_round.grace_time_ms,
+            grace_used_ms=grace_used,
+            reserve_used_ms=reserve_used,
+            reserve_before_ms=reserve_before,
+            reserve_after_ms=team.reserve_time_remaining,
+            pick_time_source=pick_time_source,
+            pick_time_age_ms=pick_time_age_ms,
+        )
 
         # Complete the round
         current_round.hero_id = hero_id
@@ -250,6 +368,13 @@ def submit_pick(
                 "action_type": current_round.action_type,
                 "time_elapsed_ms": elapsed_ms,
                 "reserve_used_ms": reserve_used,
+                # Per-pick timing provenance — supports replay/debug of
+                # any specific pick. `pick_time_source` is "client" when
+                # we trusted client_picked_at, "server_now" otherwise.
+                # `pick_time_age_ms` is the client→server delta (or null
+                # when no client timestamp was supplied).
+                "pick_time_source": pick_time_source,
+                "pick_time_age_ms": pick_time_age_ms,
             },
         )
 
@@ -269,6 +394,17 @@ def submit_pick(
                     "action_type": next_round.action_type,
                 },
             )
+            log.info(
+                "round_started",
+                system="herodraft",
+                subsystem="round",
+                draft_id=draft.id,
+                round_number=next_round.round_number,
+                action_type=next_round.action_type,
+                team_id=next_round.draft_team_id,
+                started_at=next_round.started_at.isoformat(),
+            )
+            active_span.set_attribute("draft.next_round_number", next_round.round_number)
         else:
             draft.state = HeroDraftState.COMPLETED
             draft.save()
@@ -276,6 +412,14 @@ def submit_pick(
             HeroDraftEvent.objects.create(
                 draft=draft, event_type="draft_completed", metadata={}
             )
+            log.info(
+                "draft_completed",
+                system="herodraft",
+                subsystem="state",
+                draft_id=draft.id,
+                total_rounds=draft.rounds.count(),
+            )
+            active_span.set_attribute("draft.completed", True)
 
         return current_round
 

--- a/backend/app/functions/herodraft.py
+++ b/backend/app/functions/herodraft.py
@@ -164,9 +164,39 @@ def submit_choice(draft: HeroDraft, team: DraftTeam, choice_type: str, value: st
             first_round.save()
 
 
-def submit_pick(draft: HeroDraft, team: DraftTeam, hero_id: int) -> HeroDraftRound:
+CLIENT_PICK_TIME_MAX_AGE_S = 2.0
+
+
+def _effective_pick_time(server_now, client_picked_at):
+    """Trust the client-reported pick time if it's within the sanity window.
+
+    Client sends `client_picked_at = new Date().toISOString()` at the moment
+    they confirmed the pick. The message takes some network time to arrive.
+    Using server-receive time would penalise slow networks; trusting the
+    client time absorbs that latency. The 2s cap prevents a clock-skewed
+    or hostile client from "winding back" their pick arbitrarily.
+    """
+    if not client_picked_at:
+        return server_now
+    age_s = (server_now - client_picked_at).total_seconds()
+    if 0 <= age_s <= CLIENT_PICK_TIME_MAX_AGE_S:
+        return client_picked_at
+    return server_now
+
+
+def submit_pick(
+    draft: HeroDraft,
+    team: DraftTeam,
+    hero_id: int,
+    client_picked_at=None,
+) -> HeroDraftRound:
     """
     Submit a hero pick or ban for the current round.
+
+    Args:
+        client_picked_at: Optional datetime from the client (browser
+            `Date.now()` at confirm). Used when within 2s of server now,
+            ignored otherwise — see `_effective_pick_time`.
 
     Returns the completed round.
     """
@@ -190,9 +220,16 @@ def submit_pick(draft: HeroDraft, team: DraftTeam, hero_id: int) -> HeroDraftRou
 
         # Calculate time spent and update reserve time
         now = timezone.now()
-        elapsed_ms = int((now - current_round.started_at).total_seconds() * 1000)
+        effective_pick_time = _effective_pick_time(now, client_picked_at)
+        elapsed_ms = int(
+            (effective_pick_time - current_round.started_at).total_seconds() * 1000
+        )
         grace_used = min(elapsed_ms, current_round.grace_time_ms)
-        reserve_used = max(0, elapsed_ms - current_round.grace_time_ms)
+        # Floor reserve consumption to whole seconds so sub-second
+        # over-grace (typically network jitter) doesn't nibble the
+        # team's reserve.
+        over_grace_ms = max(0, elapsed_ms - current_round.grace_time_ms)
+        reserve_used = (over_grace_ms // 1000) * 1000
 
         team.reserve_time_remaining = max(0, team.reserve_time_remaining - reserve_used)
         team.save()

--- a/backend/app/functions/herodraft.py
+++ b/backend/app/functions/herodraft.py
@@ -181,6 +181,18 @@ def _evaluate_client_pick_time(server_now, client_picked_at, draft_id):
     if not client_picked_at:
         return server_now, "server_now", None
 
+    # Subtracting a naive datetime from a tz-aware one raises TypeError.
+    # The view layer also filters these out; this is a defense-in-depth
+    # guard for tests or future direct callers.
+    if client_picked_at.tzinfo is None:
+        log.warning(
+            "pick_time_naive_datetime",
+            system="herodraft",
+            subsystem="timing",
+            draft_id=draft_id,
+        )
+        return server_now, "server_now", None
+
     age_s = (server_now - client_picked_at).total_seconds()
     age_ms = int(age_s * 1000)
 

--- a/backend/app/functions/herodraft_views.py
+++ b/backend/app/functions/herodraft_views.py
@@ -1,6 +1,5 @@
 """API views for Captain's Mode hero draft."""
 
-import logging
 from datetime import timedelta
 
 from django.shortcuts import get_object_or_404
@@ -9,6 +8,8 @@ from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+
+from telemetry.logging import get_logger
 
 from app.broadcast import broadcast_herodraft_event
 from app.functions.herodraft import (
@@ -21,7 +22,7 @@ from app.models import DraftTeam, Game, HeroDraft, HeroDraftEvent, HeroDraftStat
 from app.permissions_org import IsTournamentStaff
 from app.serializers import HeroDraftEventSerializer, HeroDraftSerializer
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def _get_draft_with_prefetch(draft_pk: int) -> HeroDraft:
@@ -653,14 +654,22 @@ def pause_draft(request, draft_pk):
     draft_team = _get_draft_team_for_user(draft, request.user) if is_captain else None
 
     # Transition to paused state
+    prev_state = draft.state
     draft.state = HeroDraftState.PAUSED
     draft.paused_at = timezone.now()
     draft.is_manual_pause = True
     draft.save()
 
     log.info(
-        f"HeroDraft {draft.pk} manually paused by user {request.user.pk} "
-        f"(captain={is_captain}, staff={is_staff})"
+        "draft_paused",
+        system="herodraft",
+        subsystem="state",
+        draft_id=draft.id,
+        from_state=prev_state,
+        paused_by_user_id=request.user.pk,
+        is_captain=is_captain,
+        is_staff=is_staff,
+        paused_at=draft.paused_at.isoformat(),
     )
 
     # Create event for audit trail
@@ -725,20 +734,33 @@ def resume_draft(request, draft_pk):
     draft_team = _get_draft_team_for_user(draft, request.user) if is_captain else None
 
     # Calculate pause duration and adjust active round timing
+    pause_duration_s = None
+    adjustment_s = None
+    adjusted_round_number = None
     if draft.paused_at:
         pause_duration = timezone.now() - draft.paused_at
+        pause_duration_s = round(pause_duration.total_seconds(), 3)
         current_round = draft.rounds.filter(state="active").first()
         if current_round and current_round.started_at:
             # Add 3 seconds for countdown to total adjustment
             total_adjustment = pause_duration + timedelta(seconds=3)
             current_round.started_at += total_adjustment
             current_round.save(update_fields=["started_at"])
+            adjustment_s = round(total_adjustment.total_seconds(), 3)
+            adjusted_round_number = current_round.round_number
             log.info(
-                f"HeroDraft {draft.pk} adjusted round {current_round.round_number} "
-                f"started_at by {total_adjustment.total_seconds():.2f}s (includes 3s countdown)"
+                "round_started_at_adjusted",
+                system="herodraft",
+                subsystem="timing",
+                draft_id=draft.id,
+                round_number=current_round.round_number,
+                pause_duration_s=pause_duration_s,
+                total_adjustment_s=adjustment_s,
+                new_started_at=current_round.started_at.isoformat(),
             )
 
     # Enter RESUMING state with 3-second countdown
+    prev_state = draft.state
     draft.state = HeroDraftState.RESUMING
     draft.resuming_until = timezone.now() + timedelta(seconds=3)
     draft.paused_at = None
@@ -746,8 +768,18 @@ def resume_draft(request, draft_pk):
     draft.save()
 
     log.info(
-        f"HeroDraft {draft.pk} manually resumed by user {request.user.pk} "
-        f"(captain={is_captain}, staff={is_staff})"
+        "draft_resumed",
+        system="herodraft",
+        subsystem="state",
+        draft_id=draft.id,
+        from_state=prev_state,
+        resumed_by_user_id=request.user.pk,
+        is_captain=is_captain,
+        is_staff=is_staff,
+        resuming_until=draft.resuming_until.isoformat(),
+        pause_duration_s=pause_duration_s,
+        round_started_at_adjustment_s=adjustment_s,
+        adjusted_round_number=adjusted_round_number,
     )
 
     # Create event for audit trail

--- a/backend/app/functions/herodraft_views.py
+++ b/backend/app/functions/herodraft_views.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import status
@@ -631,62 +632,61 @@ def pause_draft(request, draft_pk):
     """
     from app.permissions_org import can_edit_tournament
 
+    # Authorize against an unlocked read first so we can return 403/404 without
+    # holding a row lock. State mutation runs under select_for_update below.
     draft = get_object_or_404(HeroDraft, pk=draft_pk)
-
-    # Can only pause during drafting
-    if draft.state != HeroDraftState.DRAFTING:
-        return Response(
-            {"error": f"Cannot pause draft in state '{draft.state}'"},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-
-    # Check authorization: must be captain or tournament staff
     is_captain = _user_is_captain_in_draft(draft, request.user)
     is_staff = False
     if draft.game and draft.game.tournament:
         is_staff = can_edit_tournament(request.user, draft.game.tournament)
-
     if not is_captain and not is_staff:
         return Response(
             {"error": "You are not authorized to pause this draft"},
             status=status.HTTP_403_FORBIDDEN,
         )
-
-    # Get the draft team if user is captain
     draft_team = _get_draft_team_for_user(draft, request.user) if is_captain else None
 
-    # Transition to paused state
-    prev_state = draft.state
-    draft.state = HeroDraftState.PAUSED
-    draft.paused_at = timezone.now()
-    draft.is_manual_pause = True
-    draft.save()
+    with transaction.atomic():
+        draft = HeroDraft.objects.select_for_update().get(pk=draft_pk)
 
-    log.info(
-        "draft_paused",
-        system="herodraft",
-        subsystem="state",
-        draft_id=draft.id,
-        from_state=prev_state,
-        paused_by_user_id=request.user.pk,
-        is_captain=is_captain,
-        is_staff=is_staff,
-        paused_at=draft.paused_at.isoformat(),
-    )
+        # Re-check inside the lock: concurrent resume / heartbeat-stale pause
+        # could have flipped state between the unlocked read and here.
+        if draft.state != HeroDraftState.DRAFTING:
+            return Response(
+                {"error": f"Cannot pause draft in state '{draft.state}'"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-    # Create event for audit trail
-    HeroDraftEvent.objects.create(
-        draft=draft,
-        event_type="draft_paused",
-        draft_team=draft_team,
-        metadata={
-            "reason": "manual",
-            "paused_by": request.user.pk,
-            "paused_by_username": request.user.username,
-            "is_captain": is_captain,
-            "is_staff": is_staff,
-        },
-    )
+        prev_state = draft.state
+        draft.state = HeroDraftState.PAUSED
+        draft.paused_at = timezone.now()
+        draft.is_manual_pause = True
+        draft.save()
+
+        log.info(
+            "draft_paused",
+            system="herodraft",
+            subsystem="state",
+            draft_id=draft.id,
+            from_state=prev_state,
+            paused_by_user_id=request.user.pk,
+            is_captain=is_captain,
+            is_staff=is_staff,
+            paused_at=draft.paused_at.isoformat(),
+        )
+
+        HeroDraftEvent.objects.create(
+            draft=draft,
+            event_type="draft_paused",
+            draft_team=draft_team,
+            metadata={
+                "reason": "manual",
+                "paused_by": request.user.pk,
+                "paused_by_username": request.user.username,
+                "is_captain": is_captain,
+                "is_staff": is_staff,
+            },
+        )
 
     broadcast_herodraft_event(draft, "draft_paused", draft_team)
 
@@ -712,92 +712,90 @@ def resume_draft(request, draft_pk):
     from app.permissions_org import can_edit_tournament
 
     draft = get_object_or_404(HeroDraft, pk=draft_pk)
-
-    # Can only resume from paused state
-    if draft.state != HeroDraftState.PAUSED:
-        return Response(
-            {"error": f"Cannot resume draft in state '{draft.state}'"},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-
-    # Check authorization: must be captain or tournament staff
     is_captain = _user_is_captain_in_draft(draft, request.user)
     is_staff = False
     if draft.game and draft.game.tournament:
         is_staff = can_edit_tournament(request.user, draft.game.tournament)
-
     if not is_captain and not is_staff:
         return Response(
             {"error": "You are not authorized to resume this draft"},
             status=status.HTTP_403_FORBIDDEN,
         )
-
-    # Get the draft team if user is captain
     draft_team = _get_draft_team_for_user(draft, request.user) if is_captain else None
 
-    # Calculate pause duration and adjust active round timing
     pause_duration_s = None
     adjustment_s = None
     adjusted_round_number = None
-    if draft.paused_at:
-        pause_duration = timezone.now() - draft.paused_at
-        pause_duration_s = round(pause_duration.total_seconds(), 3)
-        current_round = draft.rounds.filter(state="active").first()
-        if current_round and current_round.started_at:
-            # Add 3 seconds for countdown to total adjustment
-            total_adjustment = pause_duration + timedelta(seconds=3)
-            current_round.started_at += total_adjustment
-            current_round.save(update_fields=["started_at"])
-            adjustment_s = round(total_adjustment.total_seconds(), 3)
-            adjusted_round_number = current_round.round_number
-            log.info(
-                "round_started_at_adjusted",
-                system="herodraft",
-                subsystem="timing",
-                draft_id=draft.id,
-                round_number=current_round.round_number,
-                pause_duration_s=pause_duration_s,
-                total_adjustment_s=adjustment_s,
-                new_started_at=current_round.started_at.isoformat(),
+
+    with transaction.atomic():
+        draft = HeroDraft.objects.select_for_update().get(pk=draft_pk)
+
+        if draft.state != HeroDraftState.PAUSED:
+            return Response(
+                {"error": f"Cannot resume draft in state '{draft.state}'"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
-    # Enter RESUMING state with 3-second countdown
-    prev_state = draft.state
-    draft.state = HeroDraftState.RESUMING
-    draft.resuming_until = timezone.now() + timedelta(seconds=3)
-    draft.paused_at = None
-    draft.is_manual_pause = False
-    draft.save()
+        # Lock the active round too so check_timeout can't race against the
+        # started_at adjustment below.
+        if draft.paused_at:
+            pause_duration = timezone.now() - draft.paused_at
+            pause_duration_s = round(pause_duration.total_seconds(), 3)
+            current_round = (
+                draft.rounds.select_for_update().filter(state="active").first()
+            )
+            if current_round and current_round.started_at:
+                total_adjustment = pause_duration + timedelta(seconds=3)
+                current_round.started_at += total_adjustment
+                current_round.save(update_fields=["started_at"])
+                adjustment_s = round(total_adjustment.total_seconds(), 3)
+                adjusted_round_number = current_round.round_number
+                log.info(
+                    "round_started_at_adjusted",
+                    system="herodraft",
+                    subsystem="timing",
+                    draft_id=draft.id,
+                    round_number=current_round.round_number,
+                    pause_duration_s=pause_duration_s,
+                    total_adjustment_s=adjustment_s,
+                    new_started_at=current_round.started_at.isoformat(),
+                )
 
-    log.info(
-        "draft_resumed",
-        system="herodraft",
-        subsystem="state",
-        draft_id=draft.id,
-        from_state=prev_state,
-        resumed_by_user_id=request.user.pk,
-        is_captain=is_captain,
-        is_staff=is_staff,
-        resuming_until=draft.resuming_until.isoformat(),
-        pause_duration_s=pause_duration_s,
-        round_started_at_adjustment_s=adjustment_s,
-        adjusted_round_number=adjusted_round_number,
-    )
+        prev_state = draft.state
+        draft.state = HeroDraftState.RESUMING
+        draft.resuming_until = timezone.now() + timedelta(seconds=3)
+        draft.paused_at = None
+        draft.is_manual_pause = False
+        draft.save()
 
-    # Create event for audit trail
-    HeroDraftEvent.objects.create(
-        draft=draft,
-        event_type="resume_countdown",
-        draft_team=draft_team,
-        metadata={
-            "countdown_seconds": 3,
-            "reason": "manual",
-            "resumed_by": request.user.pk,
-            "resumed_by_username": request.user.username,
-            "is_captain": is_captain,
-            "is_staff": is_staff,
-        },
-    )
+        log.info(
+            "draft_resumed",
+            system="herodraft",
+            subsystem="state",
+            draft_id=draft.id,
+            from_state=prev_state,
+            resumed_by_user_id=request.user.pk,
+            is_captain=is_captain,
+            is_staff=is_staff,
+            resuming_until=draft.resuming_until.isoformat(),
+            pause_duration_s=pause_duration_s,
+            round_started_at_adjustment_s=adjustment_s,
+            adjusted_round_number=adjusted_round_number,
+        )
+
+        HeroDraftEvent.objects.create(
+            draft=draft,
+            event_type="resume_countdown",
+            draft_team=draft_team,
+            metadata={
+                "countdown_seconds": 3,
+                "reason": "manual",
+                "resumed_by": request.user.pk,
+                "resumed_by_username": request.user.username,
+                "is_captain": is_captain,
+                "is_staff": is_staff,
+            },
+        )
 
     broadcast_herodraft_event(draft, "resume_countdown", draft_team)
 

--- a/backend/app/functions/herodraft_views.py
+++ b/backend/app/functions/herodraft_views.py
@@ -383,7 +383,9 @@ def do_submit_pick(request, draft_pk):
     Submit a hero pick or ban for the current round.
 
     Request body:
-        hero_id: int - The hero ID to pick/ban
+        hero_id: int — The hero ID to pick/ban
+        client_picked_at: str (ISO 8601, optional) — client's Date.now() at
+            confirm. Used to credit network latency when within 2s of server now.
 
     Returns:
         200: Updated draft data
@@ -391,6 +393,8 @@ def do_submit_pick(request, draft_pk):
         404: Draft not found
         400: Invalid state, hero already picked, or invalid hero
     """
+    from django.utils.dateparse import parse_datetime
+
     draft = get_object_or_404(HeroDraft, pk=draft_pk)
 
     if draft.state != HeroDraftState.DRAFTING:
@@ -419,6 +423,16 @@ def do_submit_pick(request, draft_pk):
             {"error": "hero_id must be an integer"}, status=status.HTTP_400_BAD_REQUEST
         )
 
+    # Optional — submit_pick handles None and out-of-window timestamps
+    # internally, so a malformed value just degrades to server-receive time.
+    client_picked_at = None
+    raw = request.data.get("client_picked_at")
+    if raw:
+        try:
+            client_picked_at = parse_datetime(raw)
+        except (ValueError, TypeError):
+            client_picked_at = None
+
     # Check hero is available
     available = get_available_heroes(draft)
     if hero_id not in available:
@@ -428,7 +442,9 @@ def do_submit_pick(request, draft_pk):
         )
 
     try:
-        completed_round = submit_pick(draft, draft_team, hero_id)
+        completed_round = submit_pick(
+            draft, draft_team, hero_id, client_picked_at=client_picked_at
+        )
     except ValueError as e:
         return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/backend/app/functions/herodraft_views.py
+++ b/backend/app/functions/herodraft_views.py
@@ -424,15 +424,17 @@ def do_submit_pick(request, draft_pk):
             {"error": "hero_id must be an integer"}, status=status.HTTP_400_BAD_REQUEST
         )
 
-    # Optional — submit_pick handles None and out-of-window timestamps
-    # internally, so a malformed value just degrades to server-receive time.
+    # Optional — submit_pick degrades to server-receive time if missing.
+    # `parse_datetime` returns None for malformed input (doesn't raise) and
+    # can return a naive datetime when the string omits a tz offset;
+    # subtracting a naive value from `timezone.now()` raises TypeError, so
+    # reject both up front.
     client_picked_at = None
     raw = request.data.get("client_picked_at")
-    if raw:
-        try:
-            client_picked_at = parse_datetime(raw)
-        except (ValueError, TypeError):
-            client_picked_at = None
+    if isinstance(raw, str) and raw:
+        parsed = parse_datetime(raw)
+        if parsed is not None and parsed.tzinfo is not None:
+            client_picked_at = parsed
 
     # Check hero is available
     available = get_available_heroes(draft)

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -1,8 +1,10 @@
-"""Background task to broadcast tick updates during active drafts.
+"""Tick broadcaster. One thread + asyncio loop per active draft, Redis-locked.
 
-Uses Redis distributed locking to prevent duplicate broadcasters across
-multiple Django instances, and connection tracking to stop when no
-WebSocket clients are connected.
+Diagnostic events when ticks misbehave:
+  tick_step_slow      — any sub-step >300ms
+  tick_loop_stalled   — gap between consecutive ticks >1.5s (event-loop blocked)
+  tick_slow           — whole iteration >1.5s
+Tempo: herodraft.tick.iteration with child herodraft.tick.<step> spans.
 """
 
 import asyncio
@@ -17,10 +19,16 @@ from channels.db import database_sync_to_async
 from channels.layers import get_channel_layer
 from django.conf import settings
 from django.utils import timezone
+from opentelemetry import trace
 
 from telemetry.logging import get_logger
 
 log = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
+
+TICK_STEP_SLOW_THRESHOLD_S = 0.3       # 30% of the 1s budget
+TICK_GAP_STALL_THRESHOLD_S = 1.5       # expected gap is 1.0s
+TICK_ITERATION_SLOW_THRESHOLD_S = 1.5  # backstop if no single step crossed
 
 # Redis client for locking and connection tracking
 _redis_client = None
@@ -79,7 +87,14 @@ def get_connection_count(draft_id: int) -> int:
 
 
 async def broadcast_tick(draft_id: int):
-    """Broadcast current timing state to all connected clients."""
+    """Broadcast timing anchors to all connected clients.
+
+    Sends ANCHORS (timestamps + durations) not computed remainders.
+    Clients render countdowns locally via requestAnimationFrame using
+    `server_time` to compute clock offset. Decouples timer smoothness
+    from broadcast cadence and eliminates the "everyone freezes for a
+    few seconds" bug class.
+    """
     from app.models import HeroDraft, HeroDraftState
 
     channel_layer = get_channel_layer()
@@ -102,18 +117,16 @@ async def broadcast_tick(draft_id: int):
             )
             return None
 
-        # Handle RESUMING state - broadcast countdown remaining
-        if draft.state == HeroDraftState.RESUMING:
-            now = timezone.now()
-            countdown_remaining_ms = 0
-            if draft.resuming_until:
-                remaining = (draft.resuming_until - now).total_seconds() * 1000
-                countdown_remaining_ms = max(0, int(remaining))
+        now = timezone.now()
 
+        if draft.state == HeroDraftState.RESUMING:
             return {
                 "type": "herodraft.tick",
                 "draft_state": draft.state,
-                "countdown_remaining_ms": countdown_remaining_ms,
+                "server_time": now.isoformat(),
+                "resuming_until": (
+                    draft.resuming_until.isoformat() if draft.resuming_until else None
+                ),
             }
 
         if draft.state != HeroDraftState.DRAFTING:
@@ -138,35 +151,10 @@ async def broadcast_tick(draft_id: int):
             )
             return None
 
-        # Use explicit ordering by ID for deterministic team order
+        # Deterministic team order by ID (matches frontend assumption)
         teams = list(draft.draft_teams.all().order_by("id"))
         team_a = teams[0] if teams else None
         team_b = teams[1] if len(teams) > 1 else None
-
-        # Calculate grace time remaining and reserve time being consumed
-        now = timezone.now()
-        elapsed_ms = 0
-        grace_remaining = current_round.grace_time_ms
-
-        if current_round.started_at:
-            elapsed_ms = int((now - current_round.started_at).total_seconds() * 1000)
-            grace_remaining = max(0, current_round.grace_time_ms - elapsed_ms)
-
-        # Calculate how much reserve time has been consumed (time past grace period)
-        reserve_consumed_ms = max(0, elapsed_ms - current_round.grace_time_ms)
-
-        # Calculate real-time reserve time for each team
-        # Only the active team's reserve is being consumed
-        active_team_id = current_round.draft_team_id
-        team_a_reserve = team_a.reserve_time_remaining if team_a else 0
-        team_b_reserve = team_b.reserve_time_remaining if team_b else 0
-
-        # Calculate remaining reserve for the active team (for broadcast only)
-        # Database is updated when pick is submitted in herodraft.py
-        if team_a and team_a.id == active_team_id:
-            team_a_reserve = max(0, team_a_reserve - reserve_consumed_ms)
-        elif team_b and team_b.id == active_team_id:
-            team_b_reserve = max(0, team_b_reserve - reserve_consumed_ms)
 
         log.debug(
             "tick_broadcast",
@@ -174,25 +162,38 @@ async def broadcast_tick(draft_id: int):
             subsystem="timer",
             draft_id=draft_id,
             round=current_round.round_number,
-            elapsed_ms=elapsed_ms,
-            grace_remaining_ms=grace_remaining,
-            reserve_consumed_ms=reserve_consumed_ms,
-            team_a_reserve_ms=team_a_reserve,
-            team_b_reserve_ms=team_b_reserve,
+            server_time=now.isoformat(),
+            round_started_at=(
+                current_round.started_at.isoformat() if current_round.started_at else None
+            ),
         )
 
         return {
             "type": "herodraft.tick",
-            "current_round": current_round.round_number
-            - 1,  # 0-indexed to match state serializer
-            "active_team_id": active_team_id,
-            "grace_time_remaining_ms": grace_remaining,
-            # Include team IDs so frontend can match reserve times correctly
-            "team_a_id": team_a.id if team_a else None,
-            "team_a_reserve_ms": team_a_reserve,
-            "team_b_id": team_b.id if team_b else None,
-            "team_b_reserve_ms": team_b_reserve,
             "draft_state": draft.state,
+            # Clock anchor for client-side rAF countdown
+            "server_time": now.isoformat(),
+            # Round anchors — client computes elapsed/grace/reserve locally
+            "current_round": current_round.round_number - 1,  # 0-indexed
+            "active_team_id": current_round.draft_team_id,
+            "round_started_at": (
+                current_round.started_at.isoformat() if current_round.started_at else None
+            ),
+            "round_grace_time_ms": current_round.grace_time_ms,
+            # DraftTeam.reserve_time_remaining — the team's cumulative
+            # reserve in the DB. Stable between picks; server debits
+            # `max(0, round_elapsed - grace)` at pick submission, so the
+            # next round's broadcast carries the lower value forward.
+            # The client subtracts the IN-ROUND consumption locally for
+            # display on the active team only.
+            "team_a_id": team_a.id if team_a else None,
+            "team_a_reserve_ms": (
+                team_a.reserve_time_remaining if team_a else None
+            ),
+            "team_b_id": team_b.id if team_b else None,
+            "team_b_reserve_ms": (
+                team_b.reserve_time_remaining if team_b else None
+            ),
         }
 
     tick_data = await get_tick_data()
@@ -543,53 +544,103 @@ async def run_tick_loop(draft_id: int, stop_event: threading.Event):
         "tick_loop_started", system="herodraft", subsystem="timer", draft_id=draft_id
     )
     tick_count = 0
+    last_tick_start: float | None = None
+
+    async def _timed_step(step_name: str, coro):
+        """Span + duration log per sub-step. Warns past TICK_STEP_SLOW_THRESHOLD_S."""
+        with tracer.start_as_current_span(
+            f"herodraft.tick.{step_name}",
+            attributes={
+                "ws.draft_id": draft_id,
+                "tick.step": step_name,
+                "tick.iteration": tick_count + 1,
+            },
+        ) as span:
+            step_start = time.time()
+            await coro
+            step_duration = time.time() - step_start
+            span.set_attribute("tick.step_duration_s", round(step_duration, 4))
+            if step_duration > TICK_STEP_SLOW_THRESHOLD_S:
+                log.warning(
+                    "tick_step_slow",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                    tick_step=step_name,
+                    tick_count=tick_count + 1,
+                    duration_s=round(step_duration, 3),
+                )
 
     while not stop_event.is_set():
         tick_start = time.time()
 
-        should_continue, reason = await check_continue()
-        if not should_continue:
-            log.info(
-                "tick_loop_stopping",
-                system="herodraft",
-                subsystem="timer",
-                draft_id=draft_id,
-                reason=reason,
-                tick_count=tick_count,
-            )
-            break
+        # gap > expected = event loop was blocked outside per-step work
+        if last_tick_start is not None:
+            gap = tick_start - last_tick_start
+            if gap > TICK_GAP_STALL_THRESHOLD_S:
+                log.error(
+                    "tick_loop_stalled",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                    tick_count=tick_count,
+                    expected_gap_s=1.0,
+                    actual_gap_s=round(gap, 3),
+                    stall_s=round(gap - 1.0, 3),
+                )
 
-        # Check if RESUMING countdown is complete first
-        await check_resume_countdown(draft_id)
-        # Check for stale captain heartbeats (zombie connections)
-        await check_captain_heartbeats(draft_id)
-        await broadcast_tick(draft_id)
-        await check_timeout(draft_id)
-        await extend_lock()
+        with tracer.start_as_current_span(
+            "herodraft.tick.iteration",
+            attributes={
+                "ws.draft_id": draft_id,
+                "tick.iteration": tick_count + 1,
+            },
+        ) as iter_span:
+            should_continue, reason = await check_continue()
+            if not should_continue:
+                iter_span.set_attribute("tick.outcome", "stopping")
+                iter_span.set_attribute("tick.stop_reason", reason)
+                log.info(
+                    "tick_loop_stopping",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                    reason=reason,
+                    tick_count=tick_count,
+                )
+                break
 
-        tick_duration = time.time() - tick_start
-        tick_count += 1
+            await _timed_step("resume_countdown", check_resume_countdown(draft_id))
+            await _timed_step("captain_heartbeats", check_captain_heartbeats(draft_id))
+            await _timed_step("broadcast_tick", broadcast_tick(draft_id))
+            await _timed_step("check_timeout", check_timeout(draft_id))
+            await _timed_step("extend_lock", extend_lock())
 
-        # Log every 30 ticks (~30s) as a health check, or if a tick was slow
-        if tick_duration > 2.0:
-            log.warning(
-                "tick_slow",
-                system="herodraft",
-                subsystem="timer",
-                draft_id=draft_id,
-                tick_count=tick_count,
-                duration_s=round(tick_duration, 2),
-            )
-        elif tick_count % 30 == 0:
-            log.info(
-                "tick_loop_healthy",
-                system="herodraft",
-                subsystem="timer",
-                draft_id=draft_id,
-                tick_count=tick_count,
-                duration_s=round(tick_duration, 3),
-            )
+            tick_duration = time.time() - tick_start
+            tick_count += 1
+            iter_span.set_attribute("tick.duration_s", round(tick_duration, 4))
+            iter_span.set_attribute("tick.outcome", "completed")
 
+            if tick_duration > TICK_ITERATION_SLOW_THRESHOLD_S:
+                log.warning(
+                    "tick_slow",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                    tick_count=tick_count,
+                    duration_s=round(tick_duration, 2),
+                )
+            elif tick_count % 30 == 0:
+                log.info(
+                    "tick_loop_healthy",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                    tick_count=tick_count,
+                    duration_s=round(tick_duration, 3),
+                )
+
+        last_tick_start = tick_start
         await asyncio.sleep(1)
 
     log.info(

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -688,11 +688,15 @@ def start_tick_broadcaster(draft_id: int) -> bool:
             log.error(f"Tick broadcaster error for draft {draft_id}: {e}")
         finally:
             loop.close()
-            # Release lock and cleanup
             try:
                 r.delete(lock_key)
-            except Exception:
-                pass
+            except Exception as e:
+                log.debug(
+                    "tick_lock_release_failed",
+                    draft_id=draft_id,
+                    phase="run_in_thread",
+                    error=str(e),
+                )
             with _lock:
                 _active_tick_tasks.pop(draft_id, None)
 
@@ -725,11 +729,15 @@ def stop_tick_broadcaster(draft_id: int):
         task_info.stop_event.set()
         task_info.thread.join(timeout=2.0)
 
-    # Release lock (in case local thread didn't clean up)
     try:
         r.delete(lock_key)
-    except Exception:
-        pass
+    except Exception as e:
+        log.debug(
+            "tick_lock_release_failed",
+            draft_id=draft_id,
+            phase="stop_tick_broadcaster",
+            error=str(e),
+        )
 
     with _lock:
         _active_tick_tasks.pop(draft_id, None)

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -641,7 +641,12 @@ async def run_tick_loop(draft_id: int, stop_event: threading.Event):
                 )
 
         last_tick_start = tick_start
-        await asyncio.sleep(1)
+        # Sleep just enough to maintain a 1Hz cadence. Sleeping a flat 1s
+        # would push the next tick out to `1s + work_duration`, which
+        # made `tick_loop_stalled` over-report (it compares start-to-start
+        # gaps against 1s expected). max(0, ...) absorbs a slow tick by
+        # firing immediately on the next iteration to catch up.
+        await asyncio.sleep(max(0.0, 1.0 - tick_duration))
 
     log.info(
         "tick_loop_ended",

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -120,6 +120,16 @@ async def broadcast_tick(draft_id: int):
         now = timezone.now()
 
         if draft.state == HeroDraftState.RESUMING:
+            # Include the round anchors too so the client can render the
+            # frozen grace + reserve values that the timer will land on
+            # when RESUMING completes — server has already pushed
+            # round.started_at forward by pause_duration + 3s, so
+            # `grace_time_ms - (resuming_until - round_started_at)`
+            # equals the grace remaining at the moment of pause.
+            current_round = draft.rounds.filter(state="active").first()
+            teams = list(draft.draft_teams.all().order_by("id"))
+            team_a = teams[0] if teams else None
+            team_b = teams[1] if len(teams) > 1 else None
             return {
                 "type": "herodraft.tick",
                 "draft_state": draft.state,
@@ -127,6 +137,24 @@ async def broadcast_tick(draft_id: int):
                 "resuming_until": (
                     draft.resuming_until.isoformat() if draft.resuming_until else None
                 ),
+                "current_round": (
+                    current_round.round_number - 1 if current_round else None
+                ),
+                "active_team_id": (
+                    current_round.draft_team_id if current_round else None
+                ),
+                "round_started_at": (
+                    current_round.started_at.isoformat()
+                    if current_round and current_round.started_at
+                    else None
+                ),
+                "round_grace_time_ms": (
+                    current_round.grace_time_ms if current_round else None
+                ),
+                "team_a_id": team_a.id if team_a else None,
+                "team_a_reserve_ms": team_a.reserve_time_remaining if team_a else None,
+                "team_b_id": team_b.id if team_b else None,
+                "team_b_reserve_ms": team_b.reserve_time_remaining if team_b else None,
             }
 
         if draft.state != HeroDraftState.DRAFTING:

--- a/backend/app/tests/test_consumers_base.py
+++ b/backend/app/tests/test_consumers_base.py
@@ -1,6 +1,16 @@
 """Unit tests for BaseDraftConsumer abstract class."""
 
+import asyncio
+from types import SimpleNamespace
+from unittest import mock
+
 from django.test import SimpleTestCase
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 
 from app.consumers_base import BaseDraftConsumer
 
@@ -116,3 +126,115 @@ class TestRedisKeyGeneration(SimpleTestCase):
         key_a = self.consumer._heartbeat_key(draft_id=1, user_id=1)
         key_b = self.consumer._heartbeat_key(draft_id=1, user_id=2)
         self.assertNotEqual(key_a, key_b)
+
+
+class TestSpanInstrumentation(SimpleTestCase):
+    """Verify lifecycle methods emit OTel spans with expected attributes.
+
+    The dashboard's per-user/per-conn-id correlation relies on every
+    span carrying `ws.conn_id`. A future refactor that drops that
+    attribute would silently break Tempo lookups — this test catches
+    that regression at the unit level.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # OTel installs `set_tracer_provider` as a one-shot — once a
+        # provider is set (e.g. by Django's app startup), subsequent
+        # `set_tracer_provider` calls are no-ops with a warning. So we
+        # piggyback on whatever's current: if it's a real
+        # `TracerProvider`, attach our in-memory processor to it; if
+        # it's the proxy (telemetry disabled in this test env), install
+        # ours as the first real provider.
+        super().setUpClass()
+        cls.exporter = InMemorySpanExporter()
+        cls.processor = SimpleSpanProcessor(cls.exporter)
+        provider = trace.get_tracer_provider()
+        if hasattr(provider, "add_span_processor"):
+            provider.add_span_processor(cls.processor)
+        else:
+            provider = TracerProvider()
+            provider.add_span_processor(cls.processor)
+            trace.set_tracer_provider(provider)
+
+    def setUp(self):
+        # Each test starts with a clean span buffer so assertions on
+        # span counts don't see leftovers from previous tests.
+        self.exporter.clear()
+        self.consumer = ConcreteDraftConsumer()
+        self.consumer.ws_conn_id = "test-conn-1234"
+        self.consumer.draft_id = 42
+        # Consumer code reads both `user.id` (Django auth API) and
+        # `user.pk` depending on path — populate both.
+        self.consumer.user = SimpleNamespace(is_authenticated=True, pk=99, id=99)
+
+    def _spans_by_name(self, name):
+        return [s for s in self.exporter.get_finished_spans() if s.name == name]
+
+    def test_handle_heartbeat_emits_span_with_conn_id(self):
+        """ws.heartbeat span carries ws.conn_id + ws.draft_id + user.id."""
+        with mock.patch(
+            "app.tasks.herodraft_tick.get_redis_client"
+        ) as mock_get_redis:
+            mock_get_redis.return_value = mock.MagicMock()
+            asyncio.run(self.consumer.handle_heartbeat())
+
+        spans = self._spans_by_name("ws.heartbeat")
+        self.assertEqual(len(spans), 1)
+        attrs = spans[0].attributes
+        self.assertEqual(attrs["ws.conn_id"], "test-conn-1234")
+        self.assertEqual(attrs["ws.draft_id"], 42)
+        self.assertEqual(attrs["user.id"], 99)
+        self.assertEqual(attrs["ws.consumer"], "ConcreteDraftConsumer")
+        # heartbeat-specific
+        self.assertIn("ws.heartbeat_ttl_s", attrs)
+
+    def test_base_span_attrs_skips_missing_conn_id(self):
+        """No conn_id set yet → attribute is absent, not None.
+
+        OTel SpanAttributes don't accept None values. The early-error
+        path in `base_connect` could fire a heartbeat span before
+        `telemetry_connect` runs, so `_base_span_attrs` must defensively
+        omit `ws.conn_id` when it isn't bound.
+        """
+        consumer = ConcreteDraftConsumer()
+        attrs = consumer._base_span_attrs()
+        self.assertNotIn("ws.conn_id", attrs)
+        self.assertNotIn("ws.draft_id", attrs)
+        # consumer class is the one universal attribute
+        self.assertEqual(attrs["ws.consumer"], "ConcreteDraftConsumer")
+
+    def test_traced_message_records_message_type(self):
+        """traced_message wraps subclass receive handlers with ws.message."""
+
+        async def run():
+            async with self.consumer.traced_message(
+                "captain_pick", **{"ws.event": "hero_selected"}
+            ):
+                pass
+
+        asyncio.run(run())
+        spans = self._spans_by_name("ws.message")
+        self.assertEqual(len(spans), 1)
+        attrs = spans[0].attributes
+        self.assertEqual(attrs["ws.message_type"], "captain_pick")
+        self.assertEqual(attrs["ws.event"], "hero_selected")
+        self.assertEqual(attrs["ws.conn_id"], "test-conn-1234")
+
+    def test_traced_message_records_exception(self):
+        """Exceptions inside traced_message land on the span as errors."""
+
+        async def run():
+            async with self.consumer.traced_message("explode"):
+                raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            asyncio.run(run())
+
+        spans = self._spans_by_name("ws.message")
+        self.assertEqual(len(spans), 1)
+        # OTel SpanKind.STATUS_CODE.ERROR == 2
+        self.assertEqual(spans[0].status.status_code.value, 2)
+        # Exception event recorded
+        exc_events = [e for e in spans[0].events if e.name == "exception"]
+        self.assertEqual(len(exc_events), 1)

--- a/backend/app/tests/test_consumers_base.py
+++ b/backend/app/tests/test_consumers_base.py
@@ -238,3 +238,39 @@ class TestSpanInstrumentation(SimpleTestCase):
         # Exception event recorded
         exc_events = [e for e in spans[0].events if e.name == "exception"]
         self.assertEqual(len(exc_events), 1)
+
+    def test_handler_span_is_child_of_traced_message(self):
+        """Inner handler spans nest under the traced_message parent span.
+
+        This is the value-add of wrapping `receive()` with
+        `traced_message` even when handlers already span themselves —
+        Tempo's waterfall view shows dispatch overhead vs. handler work
+        as parent/child instead of two unrelated traces. Catches a
+        future refactor that accidentally opens the inner span outside
+        the message context (which would re-parent it to no-op root).
+        """
+
+        async def run():
+            with mock.patch("app.tasks.herodraft_tick.get_redis_client") as g:
+                g.return_value = mock.MagicMock()
+                async with self.consumer.traced_message("heartbeat"):
+                    await self.consumer.handle_heartbeat()
+
+        asyncio.run(run())
+
+        message_spans = self._spans_by_name("ws.message")
+        heartbeat_spans = self._spans_by_name("ws.heartbeat")
+        self.assertEqual(len(message_spans), 1)
+        self.assertEqual(len(heartbeat_spans), 1)
+
+        # Heartbeat span's parent should be the message span — verified
+        # via trace_id match (same trace) AND parent.span_id match (same
+        # parent within the trace).
+        self.assertEqual(
+            heartbeat_spans[0].context.trace_id,
+            message_spans[0].context.trace_id,
+        )
+        self.assertEqual(
+            heartbeat_spans[0].parent.span_id,
+            message_spans[0].context.span_id,
+        )

--- a/backend/tests/test_herodraft.py
+++ b/backend/tests/test_herodraft.py
@@ -4,7 +4,10 @@ Test endpoints for HeroDraft E2E testing (TEST ONLY).
 These endpoints are only available when TEST_ENDPOINTS=true in settings.
 """
 
+from datetime import timedelta
+
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
 from rest_framework.decorators import (
@@ -18,6 +21,9 @@ from rest_framework.response import Response
 from app.models import DraftTeam, Game, HeroDraft, HeroDraftEvent
 from app.serializers import HeroDraftSerializer
 from common.utils import isTestEnvironment
+from telemetry.logging import get_logger
+
+log = get_logger(__name__)
 
 # Test key to tournament/game mapping for herodraft scenarios
 # Uses existing bracket games from Real Tournament 38:
@@ -183,8 +189,8 @@ def reset_herodraft(request, draft_pk):
                     f"herodraft:{draft.pk}:captain:{captain.pk}:heartbeat",
                 ]:
                     r.delete(key_pattern)
-    except Exception:
-        pass  # Redis may not be available in some test environments
+    except Exception as e:
+        log.debug("reset_herodraft_redis_cleanup_failed", draft_id=draft.pk, error=str(e))
 
     # Log reset event
     HeroDraftEvent.objects.create(
@@ -211,9 +217,6 @@ def warp_herodraft_round(request, draft_pk):
     against them. Does NOT trigger auto-pick — caller is responsible
     for keeping elapsed_ms < (grace + reserve) if they don't want one.
     """
-    from django.utils import timezone
-    from datetime import timedelta
-
     draft = get_object_or_404(HeroDraft, pk=draft_pk)
 
     if draft.state != "drafting":

--- a/backend/tests/test_herodraft.py
+++ b/backend/tests/test_herodraft.py
@@ -196,6 +196,66 @@ def reset_herodraft(request, draft_pk):
     return Response(HeroDraftSerializer(draft).data)
 
 
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([AllowAny])
+def warp_herodraft_round(request, draft_pk):
+    """TEST ONLY. Warp active round timing to exercise urgency-state UI.
+
+    Body:
+        elapsed_ms (int, required): sets active_round.started_at = now() - elapsed_ms
+        active_reserve_ms (int, optional): overrides active team's reserve_time_remaining
+
+    Leaves grace_time_ms and the non-active team alone. Next 1Hz tick
+    broadcast carries the new anchors so the client re-derives elapsed
+    against them. Does NOT trigger auto-pick — caller is responsible
+    for keeping elapsed_ms < (grace + reserve) if they don't want one.
+    """
+    from django.utils import timezone
+    from datetime import timedelta
+
+    draft = get_object_or_404(HeroDraft, pk=draft_pk)
+
+    if draft.state != "drafting":
+        return Response(
+            {"error": f"Cannot warp round in state '{draft.state}'"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    current_round = draft.rounds.filter(state="active").first()
+    if not current_round:
+        return Response(
+            {"error": "No active round to warp"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        elapsed_ms = int(request.data.get("elapsed_ms"))
+    except (TypeError, ValueError):
+        return Response(
+            {"error": "elapsed_ms (int) is required"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    current_round.started_at = timezone.now() - timedelta(milliseconds=elapsed_ms)
+    current_round.save(update_fields=["started_at"])
+
+    active_reserve_ms = request.data.get("active_reserve_ms")
+    if active_reserve_ms is not None:
+        try:
+            active_team = DraftTeam.objects.get(pk=current_round.draft_team_id)
+            active_team.reserve_time_remaining = int(active_reserve_ms)
+            active_team.save(update_fields=["reserve_time_remaining"])
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "active_reserve_ms must be int when provided"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+    draft.refresh_from_db()
+    return Response(HeroDraftSerializer(draft).data)
+
+
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def get_herodraft_by_key(request, key: str):

--- a/backend/tests/urls.py
+++ b/backend/tests/urls.py
@@ -42,6 +42,7 @@ from .test_herodraft import (
     force_herodraft_timeout,
     get_herodraft_by_key,
     reset_herodraft,
+    warp_herodraft_round,
 )
 from .test_steam import create_test_match
 
@@ -156,6 +157,11 @@ urlpatterns = [
         "herodraft/<int:draft_pk>/reset/",
         reset_herodraft,
         name="test-herodraft-reset",
+    ),
+    path(
+        "herodraft/<int:draft_pk>/warp/",
+        warp_herodraft_round,
+        name="test-herodraft-warp",
     ),
     path(
         "herodraft-by-key/<str:key>/",

--- a/docs/dev/telemetry/index.md
+++ b/docs/dev/telemetry/index.md
@@ -39,3 +39,9 @@ def my_function():
 - [Context Guide](context.md) - Adding context to new endpoints
 - [Local Observability](local-observability.md) - Local tracing setup
 - [Reference](reference.md) - Environment variable reference
+
+## Per-feature observability
+
+Some features document their span/log inventory and recommended queries alongside the feature itself:
+
+- [HeroDraft](../../features/herodraft.md#observability) - WebSocket draft timer spans (`herodraft.tick.*`, `herodraft.submit_pick`), pause/resume log events, and LogQL/TraceQL examples.

--- a/docs/features/herodraft.md
+++ b/docs/features/herodraft.md
@@ -38,7 +38,8 @@ Hero Draft runs through several phases:
 | `rolling` | Coin flip phase |
 | `choosing` | Winner/loser making pick order and side choices |
 | `drafting` | Active ban/pick phase with timers |
-| `paused` | Draft paused due to captain disconnect |
+| `paused` | Draft paused (captain disconnect or manual via captain/staff). Server stops broadcasting ticks. |
+| `resuming` | 3-second countdown between PAUSED → DRAFTING. `resuming_until` carries the target timestamp. |
 | `completed` | Draft finished successfully |
 | `abandoned` | Draft cancelled |
 
@@ -99,14 +100,19 @@ Clients connect via WebSocket to `/api/herodraft/<draft_id>/`. The `HeroDraftCon
 
 ### Tick Updates
 
-During drafting phase, the server broadcasts `herodraft_tick` every second:
+During `drafting` and `resuming` phases, the server broadcasts `herodraft_tick` at 1Hz. Ticks carry **anchors** (server timestamps + durations), not pre-computed remainders — the client derives the countdown locally via `requestAnimationFrame` so the displayed timer stays smooth even when ticks are delayed, batched, or dropped.
+
+**DRAFTING tick:**
 
 ```json
 {
   "type": "herodraft_tick",
+  "draft_state": "drafting",
+  "server_time": "2026-05-21T18:42:13.421Z",
   "current_round": 0,
   "active_team_id": 123,
-  "grace_time_remaining_ms": 25000,
+  "round_started_at": "2026-05-21T18:42:08.000Z",
+  "round_grace_time_ms": 30000,
   "team_a_id": 123,
   "team_a_reserve_ms": 90000,
   "team_b_id": 456,
@@ -114,35 +120,56 @@ During drafting phase, the server broadcasts `herodraft_tick` every second:
 }
 ```
 
+**RESUMING tick** (during the 3s countdown after pause):
+
+```json
+{
+  "type": "herodraft_tick",
+  "draft_state": "resuming",
+  "server_time": "2026-05-21T18:43:11.005Z",
+  "resuming_until": "2026-05-21T18:43:14.000Z"
+}
+```
+
+`team_a_reserve_ms` / `team_b_reserve_ms` are the team's **cumulative reserve at round start** (stable for the duration of the round). The active team's display value is computed client-side as `max(0, reserve - max(0, elapsed - grace))`. The server debits actual usage at pick-submit time, so the *next* round's tick carries the lower value forward.
+
+### Client-Side Countdown
+
+The store captures `serverClockOffsetMs = server_time - Date.now()` once on every tick receive. `useDraftCountdown` runs a `requestAnimationFrame` loop and recomputes the display values each frame against `Date.now() + serverClockOffsetMs` and the current tick's anchors. This decouples timer smoothness from broadcast cadence — even a 5-second tick gap doesn't freeze the UI.
+
+**While paused, the server stops broadcasting ticks**, so the cached tick keeps reading `drafting` with a stale `round_started_at`. The hook reads the live `draft.state` from the store and skips its `setState` call while paused, freezing the displayed values until the next tick arrives (during RESUMING).
+
+**Outbound timestamps** use `getServerNowISO()` (also derived from the offset). `submitPick` sends `client_picked_at` so the server can credit reserve against the picker's local clock rather than the server-receive time. The server applies a 2-second sanity window: stamps older than 2s or in the future fall back to server-receive.
+
 ## Pause/Resume System
 
 ### Trigger Conditions
 
 The draft **pauses immediately** when:
-- Any captain disconnects during the `drafting` phase
-- This ensures fairness - no picks can be made while a captain is absent
+- Any captain's heartbeat goes stale (>9s without keepalive) during `drafting`
+- A captain or tournament staff member POSTs to `/api/herodraft/<pk>/pause/` (manual pause; sets `is_manual_pause=true`)
 
 The draft **resumes** when:
-- All captains are reconnected
-- A 3-second countdown is shown before timer resumes
+- POST to `/api/herodraft/<pk>/resume/` by a captain or tournament staff
+- Server transitions PAUSED → RESUMING with a 3-second countdown anchor (`resuming_until`)
+- After 3s the tick loop transitions RESUMING → DRAFTING
 
 ### Backend Logic
 
-**On Captain Disconnect (during DRAFTING):**
+**On Pause (heartbeat-stale or manual):**
 
 1. Set `draft.state = PAUSED`
 2. Store `draft.paused_at = now()`
 3. Broadcast `draft_paused` event to all clients
-4. Tick broadcaster stops (checks state != DRAFTING)
+4. Tick broadcaster stops on next iteration (`should_continue_ticking` returns False)
 
-**On All Captains Reconnected (during PAUSED):**
+**On Resume (manual):**
 
 1. Calculate `pause_duration = now() - draft.paused_at`
-2. Broadcast `resume_countdown` with `{countdown_seconds: 3}`
-3. Adjust active round's `started_at` forward by `pause_duration + 3 seconds`
-4. Set `draft.state = DRAFTING`, clear `paused_at`
-5. Broadcast `draft_resumed` event
-6. Restart tick broadcaster
+2. Adjust active round's `started_at` forward by `pause_duration + 3 seconds` and `save(update_fields=["started_at"])`
+3. Set `draft.state = RESUMING`, `resuming_until = now() + 3s`, clear `paused_at` and `is_manual_pause`
+4. Restart tick broadcaster — first ticks carry the RESUMING anchor; clients display "Resuming in N…"
+5. After `resuming_until` passes, the tick loop's `check_resume_countdown` flips the draft to `DRAFTING` and broadcasts `draft_resumed`. Subsequent ticks carry the new `round_started_at`
 
 **Timer Adjustment:**
 
@@ -166,6 +193,90 @@ For responsive UX:
 - Pause overlay should appear within 100ms of disconnect
 - Resume countdown should start within 100ms of all captains connected
 - Timer should resume exactly where it paused (no drift)
+
+## Observability
+
+Telemetry plumbing is shared across the whole backend (see [dev/telemetry/](../dev/telemetry/index.md)). This section documents what herodraft-specific signals you can expect and how to query them.
+
+### Spans (Tempo)
+
+| Span | Emitted by | Useful attributes |
+|------|-----------|-------------------|
+| `ws.connect`, `ws.disconnect`, `ws.heartbeat`, `ws.message` | `consumers_base.py` | `ws.draft_id`, `ws.user_id`, `ws.conn_id` |
+| `ws.captain_register`, `ws.captain_unregister` | `consumers.py` | `ws.draft_id`, `ws.user_id`, `ws.draft_team_id` |
+| `herodraft.submit_pick` | `functions/herodraft.py` | `draft.id`, `team.id`, `hero.id`, `round.number`, `elapsed_ms`, `over_grace_ms`, `reserve_used_ms`, `pick_time_source` (`client_now`, `server_now`, fallback reason) |
+| `herodraft.tick.iteration` | `tasks/herodraft_tick.py` | `ws.draft_id`, `tick.iteration`, `tick.duration_s`, `tick.outcome`, `tick.stop_reason` |
+| `herodraft.tick.<step>` | `tasks/herodraft_tick.py` | child of `tick.iteration`. Steps: `resume_countdown`, `captain_heartbeats`, `broadcast_tick`, `check_timeout`, `extend_lock`. Each carries `tick.step_duration_s` |
+
+`herodraft.submit_pick` runs inside the parent `ws.message` span, so a single trace shows: client message arrives → handler dispatches → pick logic → DB commit → broadcast. Look for the trace by `ws.draft_id` or via the `traceID` derived field on any associated log line.
+
+**Sample TraceQL (Tempo Explore):**
+
+```traceql
+# Every pick in a draft
+{ name = "herodraft.submit_pick" && .draft.id = 123 }
+
+# Slow tick iterations
+{ name = "herodraft.tick.iteration" && duration > 1500ms }
+
+# Picks where the server fell back from client_picked_at
+{ name = "herodraft.submit_pick" && .pick_time_source != "client_now" }
+```
+
+### Log events (Loki)
+
+All logs carry `system="herodraft"` plus a `subsystem` discriminator. Filter by `service_name="backend"` for the relevant stream.
+
+| `subsystem` | Event | Level | Trigger |
+|-------------|-------|-------|---------|
+| `state` | `draft_paused` | info | Manual pause (captain/staff POST to `/pause/`) |
+| `state` | `draft_resumed` | info | Manual resume; includes `pause_duration_s`, `round_started_at_adjustment_s` |
+| `timing` | `round_started_at_adjusted` | info | Round anchor pushed forward by pause duration + 3s countdown |
+| `heartbeat` | `heartbeat_missing` | warning | No heartbeat key in Redis for a connected captain |
+| `heartbeat` | `heartbeat_stale` | warning | Heartbeat older than 9s |
+| `heartbeat` | `heartbeat_triggered_pause` | info | Heartbeat-stale forced a state → PAUSED transition |
+| `timer` | `tick_loop_started` / `tick_loop_stopping` / `tick_loop_ended` | info | Broadcaster lifecycle. `tick_loop_stopping.reason` is `no_connections`, `draft_state_paused`, `draft_state_completed`, etc. |
+| `timer` | `tick_loop_healthy` | info | Heartbeat log every 30 ticks with `duration_s` |
+| `timer` | `tick_loop_stalled` | error | Gap between consecutive ticks >1.5s (event loop blocked) |
+| `timer` | `tick_skipped` | info / warning | `reason` ∈ {`wrong_state`, `no_active_round`, `not_found`} |
+| `timer` | `tick_step_slow` / `tick_slow` | warning | Sub-step >300ms or whole iteration >1.5s |
+| `timer` | `timeout_auto_pick` / `timeout_auto_pick_broadcast` | info | Auto-random fired (over grace + reserve) |
+| `pick` | `pick_submitted` | info | Includes `elapsed_ms`, `over_grace_ms`, `reserve_used_ms`, `pick_time_source` |
+| `pick` | `pick_time_too_old` / `pick_time_in_future` / `pick_time_naive_datetime` | warning | Server rejected `client_picked_at` and fell back to receive-time |
+| `pick` | `pick_reserve_exhausted` | warning | Active team finished pick with reserve_time_remaining ≤ 0 |
+| `pick` | `pick_elapsed_negative` | error | `now - round_started_at` < 0 (clock skew or DB clock drift) |
+
+**Sample LogQL queries:**
+
+```logql
+# Full lifecycle of a specific draft
+{service_name="backend"} | json | draft_id="123"
+
+# Every pause/resume event across the cluster, with timing
+{service_name="backend"} | json | event_name=~"draft_paused|draft_resumed|round_started_at_adjusted"
+
+# Tick health for a draft (cadence, slow steps, stalls)
+{service_name="backend"} | json | system="herodraft" | subsystem="timer" | draft_id="123"
+
+# Captains whose heartbeat went stale (potential disconnect leading to pause)
+{service_name="backend"} | json | event_name=~"heartbeat_(stale|missing|triggered_pause)"
+
+# Picks that crossed grace and burned reserve, sorted by burn amount
+{service_name="backend"} | json | event_name="pick_submitted" | reserve_used_ms > 0
+```
+
+### Derived fields → one-click navigation
+
+The Loki datasource is configured (see [`docs/dev/telemetry/datasources/grafanacloud-logs.json`](../dev/telemetry/datasources/grafanacloud-logs.json)) so the following IDs in any log line become clickable:
+
+| Field | Click action |
+|-------|--------------|
+| `trace_id` (any spelling: `traceID`, `trace_id`, body or label) | Open the trace in Tempo |
+| `ws_conn_id` | Internal Loki query showing every event for that WebSocket from connect → disconnect |
+| `user_id` | Internal Loki query for all events involving that user |
+| `draft_id` | Internal Loki query for the entire herodraft session |
+
+When debugging a pause complaint, the typical loop is: open Loki → filter by `draft_id` → find the `draft_paused` event → click its `trace_id` → see the `ws.message` → `herodraft.submit_pick` (or pause-endpoint) span in Tempo.
 
 ## API Endpoints
 

--- a/docs/features/herodraft.md
+++ b/docs/features/herodraft.md
@@ -200,11 +200,13 @@ Telemetry plumbing is shared across the whole backend (see [dev/telemetry/](../d
 
 ### Spans (Tempo)
 
+Every WS-lifecycle span carries `ws.conn_id` (plus `ws.draft_id` and `user.id` when known) so Tempo correlation can stitch a session together with `{ .ws.conn_id = "abc..." }`.
+
 | Span | Emitted by | Useful attributes |
 |------|-----------|-------------------|
-| `ws.connect`, `ws.disconnect`, `ws.heartbeat`, `ws.message` | `consumers_base.py` | `ws.draft_id`, `ws.user_id`, `ws.conn_id` |
-| `ws.captain_register`, `ws.captain_unregister` | `consumers.py` | `ws.draft_id`, `ws.user_id`, `ws.draft_team_id` |
-| `herodraft.submit_pick` | `functions/herodraft.py` | `draft.id`, `team.id`, `hero.id`, `round.number`, `elapsed_ms`, `over_grace_ms`, `reserve_used_ms`, `pick_time_source` (`client_now`, `server_now`, fallback reason) |
+| `ws.connect`, `ws.disconnect`, `ws.heartbeat`, `ws.message` | `consumers_base.py` | `ws.conn_id`, `ws.draft_id`, `user.id`, `ws.consumer` |
+| `ws.captain_register`, `ws.captain_unregister` | `consumers_base.py` | same base attrs; unregister also tags `ws.captain_unregistered` (bool) and `ws.skipped_reason` |
+| `herodraft.submit_pick` | `functions/herodraft.py` | `ws.draft_id`, `draft.team_id`, `draft.hero_id`, `draft.client_picked_at`, `draft.round_number`, `draft.action_type`, `draft.elapsed_ms`, `draft.grace_used_ms`, `draft.reserve_used_ms`, `draft.reserve_before_ms`, `draft.reserve_after_ms`, `draft.pick_time_source` (`client` or `server_now`), `draft.pick_time_age_ms`, `draft.next_round_number`, `draft.completed` |
 | `herodraft.tick.iteration` | `tasks/herodraft_tick.py` | `ws.draft_id`, `tick.iteration`, `tick.duration_s`, `tick.outcome`, `tick.stop_reason` |
 | `herodraft.tick.<step>` | `tasks/herodraft_tick.py` | child of `tick.iteration`. Steps: `resume_countdown`, `captain_heartbeats`, `broadcast_tick`, `check_timeout`, `extend_lock`. Each carries `tick.step_duration_s` |
 
@@ -214,13 +216,16 @@ Telemetry plumbing is shared across the whole backend (see [dev/telemetry/](../d
 
 ```traceql
 # Every pick in a draft
-{ name = "herodraft.submit_pick" && .draft.id = 123 }
+{ name = "herodraft.submit_pick" && .ws.draft_id = 123 }
 
 # Slow tick iterations
 { name = "herodraft.tick.iteration" && duration > 1500ms }
 
 # Picks where the server fell back from client_picked_at
-{ name = "herodraft.submit_pick" && .pick_time_source != "client_now" }
+{ name = "herodraft.submit_pick" && .draft.pick_time_source = "server_now" }
+
+# Picks that ran into reserve time (grace_used_ms == grace_time_ms means the team burned reserve)
+{ name = "herodraft.submit_pick" && .draft.reserve_used_ms > 0 }
 ```
 
 ### Log events (Loki)
@@ -231,6 +236,8 @@ All logs carry `system="herodraft"` plus a `subsystem` discriminator. Filter by 
 |-------------|-------|-------|---------|
 | `state` | `draft_paused` | info | Manual pause (captain/staff POST to `/pause/`) |
 | `state` | `draft_resumed` | info | Manual resume; includes `pause_duration_s`, `round_started_at_adjustment_s` |
+| `state` | `draft_completed` | info | Final pick committed and draft state flipped to COMPLETED |
+| `round` | `round_started` | info | A new round transitioned to `state="active"` (carries `round_number`, `action_type`) |
 | `timing` | `round_started_at_adjusted` | info | Round anchor pushed forward by pause duration + 3s countdown |
 | `heartbeat` | `heartbeat_missing` | warning | No heartbeat key in Redis for a connected captain |
 | `heartbeat` | `heartbeat_stale` | warning | Heartbeat older than 9s |
@@ -241,7 +248,7 @@ All logs carry `system="herodraft"` plus a `subsystem` discriminator. Filter by 
 | `timer` | `tick_skipped` | info / warning | `reason` ∈ {`wrong_state`, `no_active_round`, `not_found`} |
 | `timer` | `tick_step_slow` / `tick_slow` | warning | Sub-step >300ms or whole iteration >1.5s |
 | `timer` | `timeout_auto_pick` / `timeout_auto_pick_broadcast` | info | Auto-random fired (over grace + reserve) |
-| `pick` | `pick_submitted` | info | Includes `elapsed_ms`, `over_grace_ms`, `reserve_used_ms`, `pick_time_source` |
+| `pick` | `pick_submitted` | info | Includes `elapsed_ms`, `grace_used_ms`, `reserve_used_ms`, `reserve_before_ms`, `reserve_after_ms`, `pick_time_source`, `pick_time_age_ms` |
 | `pick` | `pick_time_too_old` / `pick_time_in_future` / `pick_time_naive_datetime` | warning | Server rejected `client_picked_at` and fell back to receive-time |
 | `pick` | `pick_reserve_exhausted` | warning | Active team finished pick with reserve_time_remaining ≤ 0 |
 | `pick` | `pick_elapsed_negative` | error | `now - round_started_at` < 0 (clock skew or DB clock drift) |

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -1136,7 +1136,8 @@ button:focus-visible {
 }
 
 /* Reserve critical: grace burned, reserve <30s. Faster, bigger, brighter
-   than grace-urgent. Red ↔ white with a glow halo to draw the eye. */
+   than grace-urgent. Red ↔ white with a glow halo to draw the eye.
+   Mobile uses a tighter scale to avoid bleeding into adjacent grid cells. */
 @keyframes pulse-reserve-critical {
   0%, 100% {
     transform: scale(1);
@@ -1144,12 +1145,36 @@ button:focus-visible {
     text-shadow: 0 0 6px var(--color-red-500);
   }
   50% {
-    transform: scale(1.25);
+    transform: scale(1.15);
     color: var(--color-white);
     text-shadow: 0 0 14px var(--color-red-400);
   }
 }
 
+@media (min-width: 640px) {
+  @keyframes pulse-reserve-critical {
+    0%, 100% {
+      transform: scale(1);
+      color: var(--color-red-500);
+      text-shadow: 0 0 6px var(--color-red-500);
+    }
+    50% {
+      transform: scale(1.25);
+      color: var(--color-white);
+      text-shadow: 0 0 14px var(--color-red-400);
+    }
+  }
+}
+
 .animate-reserve-critical {
   animation: pulse-reserve-critical 0.6s ease-in-out infinite;
+}
+
+/* Respect OS-level motion preferences (WCAG 2.3.3). */
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse-scale,
+  .animate-grace-urgent,
+  .animate-reserve-critical {
+    animation: none;
+  }
 }

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -1118,3 +1118,38 @@ button:focus-visible {
 .animate-pulse-scale {
   animation: pulse-scale 1.5s ease-in-out infinite;
 }
+
+/* Grace timer urgency: simultaneous size pulse + red ↔ yellow color cycle. */
+@keyframes pulse-grace-urgent {
+  0%, 100% {
+    transform: scale(1);
+    color: var(--color-red-400);
+  }
+  50% {
+    transform: scale(1.15);
+    color: var(--color-yellow-400);
+  }
+}
+
+.animate-grace-urgent {
+  animation: pulse-grace-urgent 1s ease-in-out infinite;
+}
+
+/* Reserve critical: grace burned, reserve <30s. Faster, bigger, brighter
+   than grace-urgent. Red ↔ white with a glow halo to draw the eye. */
+@keyframes pulse-reserve-critical {
+  0%, 100% {
+    transform: scale(1);
+    color: var(--color-red-500);
+    text-shadow: 0 0 6px var(--color-red-500);
+  }
+  50% {
+    transform: scale(1.25);
+    color: var(--color-white);
+    text-shadow: 0 0 14px var(--color-red-400);
+  }
+}
+
+.animate-reserve-critical {
+  animation: pulse-reserve-critical 0.6s ease-in-out infinite;
+}

--- a/frontend/app/components/herodraft/DraftTopBar.tsx
+++ b/frontend/app/components/herodraft/DraftTopBar.tsx
@@ -8,6 +8,7 @@ import { DisplayName } from "~/components/user/avatar";
 import { UserAvatar } from "~/components/user/UserAvatar";
 import { useHeroDraftStore, heroDraftSelectors } from "~/store/heroDraftStore";
 import { useUserStore } from "~/store/userStore";
+import { useDraftCountdown } from "~/components/herodraft/useDraftCountdown";
 
 interface DraftTopBarProps {
   draft: HeroDraft;
@@ -68,14 +69,21 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
   const activeTeamId = draft.state === "drafting"
     ? (tick?.active_team_id ?? currentRound?.draft_team ?? null)
     : null;
-  const graceRemaining = tick?.grace_time_remaining_ms ?? 0;
 
-  // Match reserve times by team ID for correctness
+  // rAF-driven countdown — recomputes every animation frame from the
+  // tick's anchors (round_started_at, round_grace_time_ms, reserves).
+  // Smooth 60fps display that keeps counting down even when ticks are
+  // delayed or dropped.
+  const countdown = useDraftCountdown(tick);
+  const graceRemaining = countdown.graceRemainingMs;
+
+  // Map team's reserve to the correct slot. Hook already accounted for
+  // active-team consumption (only the active team's reserve burns down).
   const getTeamReserve = (team: typeof teamA): number => {
     const defaultReserve = team?.reserve_time_remaining ?? 90000;
     if (!team || !tick) return defaultReserve;
-    if (tick.team_a_id === team.id) return tick.team_a_reserve_ms ?? defaultReserve;
-    if (tick.team_b_id === team.id) return tick.team_b_reserve_ms ?? defaultReserve;
+    if (tick.team_a_id === team.id) return countdown.teamAReserveMs;
+    if (tick.team_b_id === team.id) return countdown.teamBReserveMs;
     return defaultReserve;
   };
 

--- a/frontend/app/components/herodraft/DraftTopBar.tsx
+++ b/frontend/app/components/herodraft/DraftTopBar.tsx
@@ -16,7 +16,11 @@ interface DraftTopBarProps {
 }
 
 function formatTime(ms: number): string {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  // Round-to-nearest so each integer second displays for a full 1s window
+  // centered on it (e.g. "0:30" shows for ms in [29500, 30500]). Math.floor
+  // would only show 30 for the single ms at the round start, then flip
+  // immediately to 29 — visually jittery for low-precision countdowns.
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;

--- a/frontend/app/components/herodraft/DraftTopBar.tsx
+++ b/frontend/app/components/herodraft/DraftTopBar.tsx
@@ -22,6 +22,12 @@ function formatTime(ms: number): string {
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
+// Animation thresholds (ms). Grace pulses red↔yellow when low; the active
+// team's reserve pulses red↔white once grace is exhausted AND the reserve
+// is in the danger zone.
+const GRACE_URGENT_MS = 10_000;
+const RESERVE_CRITICAL_MS = 30_000;
+
 /**
  * Convert draft captain data to UserType for PlayerPopover/AvatarUrl compatibility
  */
@@ -70,11 +76,7 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
     ? (tick?.active_team_id ?? currentRound?.draft_team ?? null)
     : null;
 
-  // rAF-driven countdown — recomputes every animation frame from the
-  // tick's anchors (round_started_at, round_grace_time_ms, reserves).
-  // Smooth 60fps display that keeps counting down even when ticks are
-  // delayed or dropped.
-  const countdown = useDraftCountdown(tick);
+  const countdown = useDraftCountdown();
   const graceRemaining = countdown.graceRemainingMs;
 
   // Map team's reserve to the correct slot. Hook already accounted for
@@ -89,6 +91,22 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
 
   const teamAReserve = getTeamReserve(teamA);
   const teamBReserve = getTeamReserve(teamB);
+
+  // Critical-reserve pulse fires only on the team whose reserve is
+  // actually burning down — gating on the topbar's team identity (not the
+  // tick's team_a/team_b ordering, which is by ID) avoids both teams
+  // pulsing in unison when both happen to start a round under 30s, and
+  // avoids a brief flash after `hero_selected` nulls active_team_id.
+  const teamAIsCritical =
+    graceRemaining === 0 &&
+    teamAReserve < RESERVE_CRITICAL_MS &&
+    tick?.active_team_id != null &&
+    teamA?.id === tick.active_team_id;
+  const teamBIsCritical =
+    graceRemaining === 0 &&
+    teamBReserve < RESERVE_CRITICAL_MS &&
+    tick?.active_team_id != null &&
+    teamB?.id === tick.active_team_id;
 
   // Get current action type from round data
   const currentAction = currentRound?.action_type ?? "pick";
@@ -253,8 +271,8 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
         {/* Team A Reserve */}
         <div
           className={cn(
-            "text-center font-mono text-sm sm:text-lg",
-            teamAReserve < 30000 && "text-red-400"
+            "text-center font-mono text-sm sm:text-lg overflow-visible",
+            teamAReserve < RESERVE_CRITICAL_MS && "text-red-400"
           )}
           data-testid="herodraft-team-a-reserve"
         >
@@ -262,7 +280,7 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
           <span
             className={cn(
               "inline-block origin-center",
-              graceRemaining === 0 && teamAReserve < 30000 && "animate-reserve-critical"
+              teamAIsCritical && "animate-reserve-critical"
             )}
             data-testid="herodraft-team-a-reserve-time"
           >
@@ -280,7 +298,7 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
           <span
             className={cn(
               "font-mono text-xl sm:text-2xl font-bold inline-block origin-center",
-              graceRemaining < 10000
+              graceRemaining < GRACE_URGENT_MS
                 ? "text-red-400 animate-grace-urgent"
                 : "text-yellow-400"
             )}
@@ -295,8 +313,8 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
         {/* Team B Reserve */}
         <div
           className={cn(
-            "text-center font-mono text-sm sm:text-lg",
-            teamBReserve < 30000 && "text-red-400"
+            "text-center font-mono text-sm sm:text-lg overflow-visible",
+            teamBReserve < RESERVE_CRITICAL_MS && "text-red-400"
           )}
           data-testid="herodraft-team-b-reserve"
         >
@@ -304,7 +322,7 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
           <span
             className={cn(
               "inline-block origin-center",
-              graceRemaining === 0 && teamBReserve < 30000 && "animate-reserve-critical"
+              teamBIsCritical && "animate-reserve-critical"
             )}
             data-testid="herodraft-team-b-reserve-time"
           >

--- a/frontend/app/components/herodraft/DraftTopBar.tsx
+++ b/frontend/app/components/herodraft/DraftTopBar.tsx
@@ -259,7 +259,15 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
           data-testid="herodraft-team-a-reserve"
         >
           <span className="text-[10px] sm:text-xs text-muted-foreground block">Reserve</span>
-          <span data-testid="herodraft-team-a-reserve-time">{formatTime(teamAReserve)}</span>
+          <span
+            className={cn(
+              "inline-block origin-center",
+              graceRemaining === 0 && teamAReserve < 30000 && "animate-reserve-critical"
+            )}
+            data-testid="herodraft-team-a-reserve-time"
+          >
+            {formatTime(teamAReserve)}
+          </span>
         </div>
 
         <div className="hidden sm:block" />
@@ -271,8 +279,10 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
           </span>
           <span
             className={cn(
-              "font-mono text-xl sm:text-2xl font-bold",
-              graceRemaining < 10000 ? "text-red-400" : "text-yellow-400"
+              "font-mono text-xl sm:text-2xl font-bold inline-block origin-center",
+              graceRemaining < 10000
+                ? "text-red-400 animate-grace-urgent"
+                : "text-yellow-400"
             )}
             data-testid="herodraft-grace-time"
           >
@@ -291,7 +301,15 @@ export function DraftTopBar({ draft, tick }: DraftTopBarProps) {
           data-testid="herodraft-team-b-reserve"
         >
           <span className="text-[10px] sm:text-xs text-muted-foreground block">Reserve</span>
-          <span data-testid="herodraft-team-b-reserve-time">{formatTime(teamBReserve)}</span>
+          <span
+            className={cn(
+              "inline-block origin-center",
+              graceRemaining === 0 && teamBReserve < 30000 && "animate-reserve-critical"
+            )}
+            data-testid="herodraft-team-b-reserve-time"
+          >
+            {formatTime(teamBReserve)}
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/app/components/herodraft/api.ts
+++ b/frontend/app/components/herodraft/api.ts
@@ -1,6 +1,9 @@
 import api from '~/components/api/axios';
+import { getLogger } from '~/lib/logger';
 import { getServerNowISO } from '~/store/heroDraftStore';
 import type { HeroDraft } from './types';
+
+const log = getLogger('herodraft:api');
 
 export interface CreateHeroDraftOptions {
   radiantTeamId?: number;
@@ -54,11 +57,33 @@ export async function submitPick(
   // with a skewed local clock still sends a timestamp the server can
   // trust. Server's 2s sanity window absorbs the residual one-way
   // network latency.
-  const response = await api.post(`/herodraft/${draftId}/submit-pick/`, {
+  const clientPickedAt = getServerNowISO();
+  const startedAtMs = performance.now();
+  log.info('pick_submit_started', {
+    draft_id: draftId,
     hero_id: heroId,
-    client_picked_at: getServerNowISO(),
+    client_picked_at: clientPickedAt,
   });
-  return response.data;
+  try {
+    const response = await api.post(`/herodraft/${draftId}/submit-pick/`, {
+      hero_id: heroId,
+      client_picked_at: clientPickedAt,
+    });
+    log.info('pick_submit_succeeded', {
+      draft_id: draftId,
+      hero_id: heroId,
+      duration_ms: Math.round(performance.now() - startedAtMs),
+    });
+    return response.data;
+  } catch (err) {
+    log.error('pick_submit_failed', {
+      draft_id: draftId,
+      hero_id: heroId,
+      duration_ms: Math.round(performance.now() - startedAtMs),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
 }
 
 export interface HeroDraftEventResponse {

--- a/frontend/app/components/herodraft/api.ts
+++ b/frontend/app/components/herodraft/api.ts
@@ -1,4 +1,5 @@
 import api from '~/components/api/axios';
+import { getServerNowISO } from '~/store/heroDraftStore';
 import type { HeroDraft } from './types';
 
 export interface CreateHeroDraftOptions {
@@ -48,8 +49,14 @@ export async function submitPick(
   draftId: number,
   heroId: number
 ): Promise<HeroDraft> {
+  // `client_picked_at` is in SERVER-clock reference (via offset learned
+  // from tick.server_time), not raw browser time. This way a client
+  // with a skewed local clock still sends a timestamp the server can
+  // trust. Server's 2s sanity window absorbs the residual one-way
+  // network latency.
   const response = await api.post(`/herodraft/${draftId}/submit-pick/`, {
     hero_id: heroId,
+    client_picked_at: getServerNowISO(),
   });
   return response.data;
 }

--- a/frontend/app/components/herodraft/schemas.ts
+++ b/frontend/app/components/herodraft/schemas.ts
@@ -53,24 +53,25 @@ export const HeroDraftSchema = z.object({
   updated_at: z.string(),
 });
 
-// WebSocket message schemas for runtime validation
-// Tick message fields vary by state:
-// - DRAFTING: has current_round, active_team_id, grace_time_remaining_ms, team reserves
-// - RESUMING: has countdown_remaining_ms only
+// Tick messages carry ANCHORS (timestamps + durations), not computed
+// remainders. The client uses `server_time` to derive a clock offset
+// and renders countdowns locally via requestAnimationFrame.
 export const HeroDraftTickSchema = z.object({
   type: z.literal("herodraft_tick"),
   draft_state: z.string(),
-  // DRAFTING-specific fields — nullable because backend sends null (not undefined)
-  // during RESUMING state when these fields aren't applicable
+  // Clock anchor — present on every tick regardless of state
+  server_time: z.string(),
+  // DRAFTING anchors
   current_round: z.number().nullable().optional(),
   active_team_id: z.number().nullable().optional(),
-  grace_time_remaining_ms: z.number().nullable().optional(),
+  round_started_at: z.string().nullable().optional(),
+  round_grace_time_ms: z.number().nullable().optional(),
   team_a_id: z.number().nullable().optional(),
   team_a_reserve_ms: z.number().nullable().optional(),
   team_b_id: z.number().nullable().optional(),
   team_b_reserve_ms: z.number().nullable().optional(),
-  // RESUMING-specific field
-  countdown_remaining_ms: z.number().nullable().optional(),
+  // RESUMING anchor
+  resuming_until: z.string().nullable().optional(),
 });
 
 // Metadata schema for hero_selected events

--- a/frontend/app/components/herodraft/useDraftCountdown.ts
+++ b/frontend/app/components/herodraft/useDraftCountdown.ts
@@ -38,48 +38,61 @@ function deriveCountdown(
   // when a new tick arrived (1Hz), not the 60fps we want.
   const serverNowMs = Date.now() + serverClockOffsetMs;
 
-  // RESUMING — single countdown to draft.resuming_until
+  // RESUMING — single countdown to draft.resuming_until. The grace and
+  // reserve values are FROZEN at what they'll be when RESUMING completes:
+  // server has already pushed round_started_at forward by pause_duration
+  // + 3s, so evaluating elapsed at resuming_until reproduces the values
+  // from the moment of pause.
   if (tick.draft_state === "resuming" && tick.resuming_until) {
     const target = new Date(tick.resuming_until).getTime();
+    const resumingRemainingMs = Math.max(0, target - serverNowMs);
+    const frozen = computeDraftingValues(tick, target);
     return {
-      ...ZERO,
-      resumingRemainingMs: Math.max(0, target - serverNowMs),
+      ...frozen,
+      resumingRemainingMs,
     };
   }
 
   // DRAFTING — compute grace + per-team reserve from anchors
-  if (
-    tick.draft_state === "drafting" &&
-    tick.round_started_at &&
-    typeof tick.round_grace_time_ms === "number"
-  ) {
-    const startedAtMs = new Date(tick.round_started_at).getTime();
-    const elapsedMs = Math.max(0, serverNowMs - startedAtMs);
-    const graceRemainingMs = Math.max(0, tick.round_grace_time_ms - elapsedMs);
-
-    // Active team's reserve burns down once elapsed exceeds grace.
-    // Non-active team's reserve stays at its round-start value.
-    const reserveConsumedMs = Math.max(0, elapsedMs - tick.round_grace_time_ms);
-    const teamAAtStart = tick.team_a_reserve_ms ?? 0;
-    const teamBAtStart = tick.team_b_reserve_ms ?? 0;
-    const teamAReserveMs =
-      tick.team_a_id === tick.active_team_id
-        ? Math.max(0, teamAAtStart - reserveConsumedMs)
-        : teamAAtStart;
-    const teamBReserveMs =
-      tick.team_b_id === tick.active_team_id
-        ? Math.max(0, teamBAtStart - reserveConsumedMs)
-        : teamBAtStart;
-
+  if (tick.draft_state === "drafting") {
     return {
-      graceRemainingMs,
-      teamAReserveMs,
-      teamBReserveMs,
+      ...computeDraftingValues(tick, serverNowMs),
       resumingRemainingMs: 0,
     };
   }
 
   return ZERO;
+}
+
+function computeDraftingValues(
+  tick: HeroDraftTick,
+  serverNowMs: number,
+): Omit<DraftCountdown, "resumingRemainingMs"> {
+  if (
+    !tick.round_started_at ||
+    typeof tick.round_grace_time_ms !== "number"
+  ) {
+    return { graceRemainingMs: 0, teamAReserveMs: 0, teamBReserveMs: 0 };
+  }
+  const startedAtMs = new Date(tick.round_started_at).getTime();
+  const elapsedMs = Math.max(0, serverNowMs - startedAtMs);
+  const graceRemainingMs = Math.max(0, tick.round_grace_time_ms - elapsedMs);
+
+  // Active team's reserve burns down once elapsed exceeds grace.
+  // Non-active team's reserve stays at its round-start value.
+  const reserveConsumedMs = Math.max(0, elapsedMs - tick.round_grace_time_ms);
+  const teamAAtStart = tick.team_a_reserve_ms ?? 0;
+  const teamBAtStart = tick.team_b_reserve_ms ?? 0;
+  const teamAReserveMs =
+    tick.team_a_id === tick.active_team_id
+      ? Math.max(0, teamAAtStart - reserveConsumedMs)
+      : teamAAtStart;
+  const teamBReserveMs =
+    tick.team_b_id === tick.active_team_id
+      ? Math.max(0, teamBAtStart - reserveConsumedMs)
+      : teamBAtStart;
+
+  return { graceRemainingMs, teamAReserveMs, teamBReserveMs };
 }
 
 /**

--- a/frontend/app/components/herodraft/useDraftCountdown.ts
+++ b/frontend/app/components/herodraft/useDraftCountdown.ts
@@ -95,18 +95,25 @@ function deriveCountdown(
  */
 export function useDraftCountdown(tick: HeroDraftTick | null): DraftCountdown {
   const serverClockOffsetMs = useHeroDraftStore((s) => s.serverClockOffsetMs);
+  // Server stops broadcasting ticks during pause; the cached tick stays
+  // `drafting` with a stale `round_started_at`. Consult live `draft.state`.
+  const isPaused = useHeroDraftStore((s) => s.draft?.state === "paused");
   const [countdown, setCountdown] = useState<DraftCountdown>(() =>
     deriveCountdown(tick, serverClockOffsetMs),
   );
   const tickRef = useRef(tick);
   const offsetRef = useRef(serverClockOffsetMs);
+  const isPausedRef = useRef(isPaused);
   tickRef.current = tick;
   offsetRef.current = serverClockOffsetMs;
+  isPausedRef.current = isPaused;
 
   useEffect(() => {
     let rafId = 0;
     const frame = () => {
-      setCountdown(deriveCountdown(tickRef.current, offsetRef.current));
+      if (!isPausedRef.current) {
+        setCountdown(deriveCountdown(tickRef.current, offsetRef.current));
+      }
       rafId = requestAnimationFrame(frame);
     };
     rafId = requestAnimationFrame(frame);

--- a/frontend/app/components/herodraft/useDraftCountdown.ts
+++ b/frontend/app/components/herodraft/useDraftCountdown.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+import type { HeroDraftTick } from "./types";
+
+/**
+ * Derived countdown values reconstructed client-side from server anchors.
+ *
+ * `tick.server_time` defines our clock offset; everything else flows from
+ * that + `Date.now()` evaluated on each requestAnimationFrame.
+ */
+export interface DraftCountdown {
+  /** ms remaining in the current round's grace window. 0 once expired. */
+  graceRemainingMs: number;
+  /** Reserve time remaining for team A right now. */
+  teamAReserveMs: number;
+  /** Reserve time remaining for team B right now. */
+  teamBReserveMs: number;
+  /** ms remaining until the RESUMING countdown ends. 0 outside RESUMING. */
+  resumingRemainingMs: number;
+}
+
+const ZERO: DraftCountdown = {
+  graceRemainingMs: 0,
+  teamAReserveMs: 0,
+  teamBReserveMs: 0,
+  resumingRemainingMs: 0,
+};
+
+function computeServerNowMs(tick: HeroDraftTick): number {
+  // Offset between server clock and ours. Server time was the moment the
+  // broadcast was assembled; our Date.now() at receive includes network
+  // latency, so offset absorbs both clock skew and one-way latency.
+  const serverTimeMs = new Date(tick.server_time).getTime();
+  const receivedAtMs = Date.now();
+  const offset = serverTimeMs - receivedAtMs;
+  return Date.now() + offset;
+}
+
+function deriveCountdown(tick: HeroDraftTick | null): DraftCountdown {
+  if (!tick) return ZERO;
+
+  const serverNowMs = computeServerNowMs(tick);
+
+  // RESUMING — single countdown to draft.resuming_until
+  if (tick.draft_state === "resuming" && tick.resuming_until) {
+    const target = new Date(tick.resuming_until).getTime();
+    return {
+      ...ZERO,
+      resumingRemainingMs: Math.max(0, target - serverNowMs),
+    };
+  }
+
+  // DRAFTING — compute grace + per-team reserve from anchors
+  if (
+    tick.draft_state === "drafting" &&
+    tick.round_started_at &&
+    typeof tick.round_grace_time_ms === "number"
+  ) {
+    const startedAtMs = new Date(tick.round_started_at).getTime();
+    const elapsedMs = Math.max(0, serverNowMs - startedAtMs);
+    const graceRemainingMs = Math.max(0, tick.round_grace_time_ms - elapsedMs);
+
+    // Active team's reserve burns down once elapsed exceeds grace.
+    // Non-active team's reserve stays at its round-start value.
+    const reserveConsumedMs = Math.max(0, elapsedMs - tick.round_grace_time_ms);
+    const teamAAtStart = tick.team_a_reserve_ms ?? 0;
+    const teamBAtStart = tick.team_b_reserve_ms ?? 0;
+    const teamAReserveMs =
+      tick.team_a_id === tick.active_team_id
+        ? Math.max(0, teamAAtStart - reserveConsumedMs)
+        : teamAAtStart;
+    const teamBReserveMs =
+      tick.team_b_id === tick.active_team_id
+        ? Math.max(0, teamBAtStart - reserveConsumedMs)
+        : teamBAtStart;
+
+    return {
+      graceRemainingMs,
+      teamAReserveMs,
+      teamBReserveMs,
+      resumingRemainingMs: 0,
+    };
+  }
+
+  return ZERO;
+}
+
+/**
+ * Render-time countdown driven by requestAnimationFrame.
+ *
+ * Each frame recomputes remaining values from `tick`'s anchors using the
+ * client's current `Date.now()`. Result: 60fps smooth UI that keeps
+ * counting down even when ticks are delayed or dropped — eliminates the
+ * "everyone's timer froze for a few seconds" symptom by design.
+ *
+ * Re-anchors implicitly on every new tick (the closure captures the new
+ * tick reference, so offset re-computation happens on next frame).
+ */
+export function useDraftCountdown(tick: HeroDraftTick | null): DraftCountdown {
+  const [countdown, setCountdown] = useState<DraftCountdown>(() =>
+    deriveCountdown(tick),
+  );
+  const tickRef = useRef(tick);
+  tickRef.current = tick;
+
+  useEffect(() => {
+    let rafId = 0;
+    const frame = () => {
+      setCountdown(deriveCountdown(tickRef.current));
+      rafId = requestAnimationFrame(frame);
+    };
+    rafId = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  return countdown;
+}

--- a/frontend/app/components/herodraft/useDraftCountdown.ts
+++ b/frontend/app/components/herodraft/useDraftCountdown.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useHeroDraftStore } from "~/store/heroDraftStore";
 import type { HeroDraftTick } from "./types";
 
 /**
@@ -25,20 +26,17 @@ const ZERO: DraftCountdown = {
   resumingRemainingMs: 0,
 };
 
-function computeServerNowMs(tick: HeroDraftTick): number {
-  // Offset between server clock and ours. Server time was the moment the
-  // broadcast was assembled; our Date.now() at receive includes network
-  // latency, so offset absorbs both clock skew and one-way latency.
-  const serverTimeMs = new Date(tick.server_time).getTime();
-  const receivedAtMs = Date.now();
-  const offset = serverTimeMs - receivedAtMs;
-  return Date.now() + offset;
-}
-
-function deriveCountdown(tick: HeroDraftTick | null): DraftCountdown {
+function deriveCountdown(
+  tick: HeroDraftTick | null,
+  serverClockOffsetMs: number,
+): DraftCountdown {
   if (!tick) return ZERO;
 
-  const serverNowMs = computeServerNowMs(tick);
+  // Offset was captured ONCE at tick-receive time by the store.
+  // Computing it again per frame (Date.now() + (server_time - Date.now()))
+  // collapses to `server_time` exactly — the clock would only advance
+  // when a new tick arrived (1Hz), not the 60fps we want.
+  const serverNowMs = Date.now() + serverClockOffsetMs;
 
   // RESUMING — single countdown to draft.resuming_until
   if (tick.draft_state === "resuming" && tick.resuming_until) {
@@ -96,16 +94,19 @@ function deriveCountdown(tick: HeroDraftTick | null): DraftCountdown {
  * tick reference, so offset re-computation happens on next frame).
  */
 export function useDraftCountdown(tick: HeroDraftTick | null): DraftCountdown {
+  const serverClockOffsetMs = useHeroDraftStore((s) => s.serverClockOffsetMs);
   const [countdown, setCountdown] = useState<DraftCountdown>(() =>
-    deriveCountdown(tick),
+    deriveCountdown(tick, serverClockOffsetMs),
   );
   const tickRef = useRef(tick);
+  const offsetRef = useRef(serverClockOffsetMs);
   tickRef.current = tick;
+  offsetRef.current = serverClockOffsetMs;
 
   useEffect(() => {
     let rafId = 0;
     const frame = () => {
-      setCountdown(deriveCountdown(tickRef.current));
+      setCountdown(deriveCountdown(tickRef.current, offsetRef.current));
       rafId = requestAnimationFrame(frame);
     };
     rafId = requestAnimationFrame(frame);

--- a/frontend/app/components/herodraft/useDraftCountdown.ts
+++ b/frontend/app/components/herodraft/useDraftCountdown.ts
@@ -85,28 +85,38 @@ function deriveCountdown(
 /**
  * Render-time countdown driven by requestAnimationFrame.
  *
- * Each frame recomputes remaining values from `tick`'s anchors using the
- * client's current `Date.now()`. Result: 60fps smooth UI that keeps
- * counting down even when ticks are delayed or dropped — eliminates the
- * "everyone's timer froze for a few seconds" symptom by design.
+ * Reads `tick`, `serverClockOffsetMs`, and `draft.state` from the store.
+ * Each frame recomputes remaining values from the tick's anchors using
+ * `Date.now() + offset` — smooth 60fps even when 1Hz ticks are delayed
+ * or dropped, eliminating the "everyone's timer froze" symptom.
  *
- * Re-anchors implicitly on every new tick (the closure captures the new
- * tick reference, so offset re-computation happens on next frame).
+ * During pause the server stops broadcasting ticks; the cached tick
+ * keeps reading `drafting` with a stale `round_started_at`. We skip the
+ * setState call while `draft.state === "paused"` so values freeze at
+ * whatever they were the moment pause was entered.
  */
-export function useDraftCountdown(tick: HeroDraftTick | null): DraftCountdown {
+export function useDraftCountdown(): DraftCountdown {
+  const tick = useHeroDraftStore((s) => s.tick);
   const serverClockOffsetMs = useHeroDraftStore((s) => s.serverClockOffsetMs);
-  // Server stops broadcasting ticks during pause; the cached tick stays
-  // `drafting` with a stale `round_started_at`. Consult live `draft.state`.
   const isPaused = useHeroDraftStore((s) => s.draft?.state === "paused");
+
   const [countdown, setCountdown] = useState<DraftCountdown>(() =>
     deriveCountdown(tick, serverClockOffsetMs),
   );
+
   const tickRef = useRef(tick);
   const offsetRef = useRef(serverClockOffsetMs);
   const isPausedRef = useRef(isPaused);
   tickRef.current = tick;
   offsetRef.current = serverClockOffsetMs;
   isPausedRef.current = isPaused;
+
+  // Re-derive once on every new tick even while paused, so a tick that
+  // lands DURING pause (e.g. a final RESUMING anchor) still propagates
+  // its values into the display before the frame loop freezes.
+  useEffect(() => {
+    setCountdown(deriveCountdown(tick, serverClockOffsetMs));
+  }, [tick, serverClockOffsetMs]);
 
   useEffect(() => {
     let rafId = 0;
@@ -122,3 +132,7 @@ export function useDraftCountdown(tick: HeroDraftTick | null): DraftCountdown {
 
   return countdown;
 }
+
+// Exported for unit-test access to the pure derivation logic.
+export { deriveCountdown as _deriveCountdown };
+export type { HeroDraftTick };

--- a/frontend/app/store/heroDraftStore.ts
+++ b/frontend/app/store/heroDraftStore.ts
@@ -268,7 +268,7 @@ export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
             _unsubscribe: null,
             wasKicked: true,
             error: 'Connection replaced by new tab',
-            isConnected: false,
+            status: 'disconnected',
           });
           break;
         }

--- a/frontend/app/store/heroDraftStore.ts
+++ b/frontend/app/store/heroDraftStore.ts
@@ -32,6 +32,10 @@ interface HeroDraftState {
   // Domain state
   draft: HeroDraft | null;
   tick: HeroDraftTick | null;
+  // Computed from `tick.server_time - Date.now()` at receive — lets
+  // outbound calls (e.g. submitPick) send timestamps in server-clock
+  // reference. Defaults to 0 until the first tick arrives.
+  serverClockOffsetMs: number;
   selectedHeroId: number | null;
   searchQuery: string;
   lastEvent: HeroDraftEvent | null;
@@ -66,6 +70,7 @@ const initialState = {
   wasKicked: false,
   draft: null,
   tick: null,
+  serverClockOffsetMs: 0,
   selectedHeroId: null,
   searchQuery: '',
   lastEvent: null,
@@ -179,22 +184,35 @@ export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
             draft_state: message.draft_state,
             current_round: message.current_round,
             active_team_id: message.active_team_id,
-            grace_time_remaining_ms: message.grace_time_remaining_ms,
-            countdown_remaining_ms: message.countdown_remaining_ms,
+            server_time: message.server_time,
+            round_started_at: message.round_started_at,
           });
 
+          // Re-anchor clock offset on every tick. Includes one-way
+          // network latency in the offset, which means submitPick's
+          // outbound timestamp will be ~RTT/2 in the past relative to
+          // server-receive — that's the desired behaviour (the server's
+          // 2s sanity window absorbs it cleanly).
+          const serverTimeMs = new Date(message.server_time).getTime();
+          const serverClockOffsetMs = Number.isFinite(serverTimeMs)
+            ? serverTimeMs - Date.now()
+            : 0;
+
           set({
+            serverClockOffsetMs,
             tick: {
               type: 'herodraft_tick',
               draft_state: message.draft_state,
+              server_time: message.server_time,
               current_round: message.current_round,
               active_team_id: message.active_team_id,
-              grace_time_remaining_ms: message.grace_time_remaining_ms,
+              round_started_at: message.round_started_at,
+              round_grace_time_ms: message.round_grace_time_ms,
               team_a_id: message.team_a_id,
               team_a_reserve_ms: message.team_a_reserve_ms,
               team_b_id: message.team_b_id,
               team_b_reserve_ms: message.team_b_reserve_ms,
-              countdown_remaining_ms: message.countdown_remaining_ms,
+              resuming_until: message.resuming_until,
             },
           });
           break;
@@ -396,3 +414,16 @@ export const heroDraftSelectors = {
     return s.draft.rounds[s.draft.current_round]?.action_type ?? null;
   },
 };
+
+/**
+ * Returns the current server time as an ISO string, derived from the
+ * latest tick's server_time plus elapsed local time. Use this instead of
+ * `new Date().toISOString()` for any timestamp the server will compare
+ * against its own clock (e.g. `client_picked_at` on pick submission).
+ * Falls back to local clock when no tick has arrived yet — the server's
+ * 2s sanity window then degrades cleanly to receive-time.
+ */
+export function getServerNowISO(): string {
+  const { serverClockOffsetMs } = useHeroDraftStore.getState();
+  return new Date(Date.now() + serverClockOffsetMs).toISOString();
+}

--- a/frontend/app/store/heroDraftStore.ts
+++ b/frontend/app/store/heroDraftStore.ts
@@ -175,20 +175,54 @@ export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
             set({ draft: message.draft_state });
           }
 
-          // Clear selected hero when a pick/ban is made (including random picks due to timeout)
-          // This fixes the bug where the selection overlay persists after a random pick
+          // On hero_selected, patch the tick with the NEW round's anchors
+          // immediately. The next 1Hz server tick would otherwise arrive up
+          // to a second later, so without this patch the grace timer keeps
+          // running against the previous round's `round_started_at` until
+          // the new tick lands — the user sees the timer linger on the
+          // previous team.
           if (message.event_type === 'hero_selected') {
-            debugLog('Clearing selectedHeroId after hero_selected event');
-            // Also null out tick.active_team_id so useDraftCountdown stops
-            // burning the previous active team's reserve in the ~1s window
-            // before the next tick broadcast arrives with the new round.
             const prevTick = get().tick;
-            set({
-              selectedHeroId: null,
-              tick: prevTick
-                ? { ...prevTick, active_team_id: null }
-                : prevTick,
-            });
+            const newDraft = message.draft_state;
+            const newRoundIdx = newDraft?.current_round ?? null;
+            const newRound =
+              newRoundIdx !== null && newDraft?.rounds
+                ? newDraft.rounds[newRoundIdx] ?? null
+                : null;
+
+            if (prevTick && newRound && newDraft) {
+              // Match teams by ID order (matches server-side tick ordering).
+              const teamsById = [...newDraft.draft_teams].sort(
+                (a, b) => a.id - b.id,
+              );
+              const teamA = teamsById[0] ?? null;
+              const teamB = teamsById[1] ?? null;
+              set({
+                selectedHeroId: null,
+                tick: {
+                  ...prevTick,
+                  current_round: newRoundIdx,
+                  active_team_id: newRound.draft_team,
+                  round_started_at: newRound.started_at,
+                  round_grace_time_ms: newRound.grace_time_ms,
+                  team_a_id: teamA?.id ?? prevTick.team_a_id,
+                  team_a_reserve_ms:
+                    teamA?.reserve_time_remaining ?? prevTick.team_a_reserve_ms,
+                  team_b_id: teamB?.id ?? prevTick.team_b_id,
+                  team_b_reserve_ms:
+                    teamB?.reserve_time_remaining ?? prevTick.team_b_reserve_ms,
+                },
+              });
+            } else {
+              // No new round (draft complete) — clear active team so the
+              // previous picker's reserve stops burning.
+              set({
+                selectedHeroId: null,
+                tick: prevTick
+                  ? { ...prevTick, active_team_id: null }
+                  : prevTick,
+              });
+            }
           }
 
           set({ lastEvent: message as HeroDraftEvent });

--- a/frontend/app/store/heroDraftStore.ts
+++ b/frontend/app/store/heroDraftStore.ts
@@ -45,6 +45,11 @@ interface HeroDraftState {
   _unsubscribe: Unsubscribe | null;
   _currentDraftId: number | null;
   _heartbeatInterval: ReturnType<typeof setInterval> | null;
+  // Receive-side tick gap detection. Server logs `tick_loop_stalled`
+  // when the broadcaster itself stalls; this catches the COMPLEMENTARY
+  // case where the broadcast happened but didn't reach this client
+  // (WS hiccup, browser tab throttled, channel-layer queue saturated).
+  _lastTickReceivedAtMs: number | null;
 
   // Actions
   connect: (draftId: number) => void;
@@ -78,6 +83,7 @@ const initialState = {
   _unsubscribe: null,
   _currentDraftId: null,
   _heartbeatInterval: null,
+  _lastTickReceivedAtMs: null,
 };
 
 export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
@@ -173,7 +179,16 @@ export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
           // This fixes the bug where the selection overlay persists after a random pick
           if (message.event_type === 'hero_selected') {
             debugLog('Clearing selectedHeroId after hero_selected event');
-            set({ selectedHeroId: null });
+            // Also null out tick.active_team_id so useDraftCountdown stops
+            // burning the previous active team's reserve in the ~1s window
+            // before the next tick broadcast arrives with the new round.
+            const prevTick = get().tick;
+            set({
+              selectedHeroId: null,
+              tick: prevTick
+                ? { ...prevTick, active_team_id: null }
+                : prevTick,
+            });
           }
 
           set({ lastEvent: message as HeroDraftEvent });
@@ -193,12 +208,31 @@ export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
           // outbound timestamp will be ~RTT/2 in the past relative to
           // server-receive — that's the desired behaviour (the server's
           // 2s sanity window absorbs it cleanly).
+          const tickReceivedAtMs = Date.now();
           const serverTimeMs = new Date(message.server_time).getTime();
           const serverClockOffsetMs = Number.isFinite(serverTimeMs)
-            ? serverTimeMs - Date.now()
+            ? serverTimeMs - tickReceivedAtMs
             : 0;
 
+          // Gap detection — expected cadence is 1Hz. If we go >2s without
+          // a tick, log it. This catches client-side delivery problems
+          // the server can't see (WS hiccup, throttled tab, queue
+          // saturation) and complements server's `tick_loop_stalled`.
+          const lastTickAt = get()._lastTickReceivedAtMs;
+          if (lastTickAt !== null) {
+            const gapMs = tickReceivedAtMs - lastTickAt;
+            if (gapMs > 2000) {
+              log.warn('client_tick_gap', {
+                draft_id: get()._currentDraftId,
+                expected_gap_ms: 1000,
+                actual_gap_ms: gapMs,
+                stall_ms: gapMs - 1000,
+              });
+            }
+          }
+
           set({
+            _lastTickReceivedAtMs: tickReceivedAtMs,
             serverClockOffsetMs,
             tick: {
               type: 'herodraft_tick',

--- a/frontend/tests/playwright/demo/herodraft-bracket.demo.ts
+++ b/frontend/tests/playwright/demo/herodraft-bracket.demo.ts
@@ -717,8 +717,43 @@ test.describe('HeroDraft with Bracket Demo', () => {
         await expect(pausedOverlayB).toBeVisible({ timeout: 10000 });
         console.log('Draft paused - overlay visible on both pages');
 
+        // Topbar countdown must freeze while paused. ±1s tolerance for the
+        // second-precision display flipping at the capture boundary.
+        const graceBeforeA = await captainA.draftPage.getGraceTimeSeconds();
+        const teamABeforeA = await captainA.draftPage.getTeamAReserveTimeSeconds();
+        const teamBBeforeA = await captainA.draftPage.getTeamBReserveTimeSeconds();
+        const graceBeforeB = await captainB.draftPage.getGraceTimeSeconds();
+        console.log(
+          `Paused timers (A view): grace=${graceBeforeA}s, A=${teamABeforeA}s, B=${teamBBeforeA}s; (B view): grace=${graceBeforeB}s`,
+        );
+
         // Show the paused state for video
         await captainA.page.waitForTimeout(3000);
+
+        const graceAfterA = await captainA.draftPage.getGraceTimeSeconds();
+        const teamAAfterA = await captainA.draftPage.getTeamAReserveTimeSeconds();
+        const teamBAfterA = await captainA.draftPage.getTeamBReserveTimeSeconds();
+        const graceAfterB = await captainB.draftPage.getGraceTimeSeconds();
+        console.log(
+          `After 3s pause (A view): grace=${graceAfterA}s, A=${teamAAfterA}s, B=${teamBAfterA}s; (B view): grace=${graceAfterB}s`,
+        );
+
+        expect(
+          Math.abs(graceBeforeA - graceAfterA),
+          'grace timer must not advance during pause (A view)',
+        ).toBeLessThanOrEqual(1);
+        expect(
+          Math.abs(teamABeforeA - teamAAfterA),
+          'team A reserve must not advance during pause',
+        ).toBeLessThanOrEqual(1);
+        expect(
+          Math.abs(teamBBeforeA - teamBAfterA),
+          'team B reserve must not advance during pause',
+        ).toBeLessThanOrEqual(1);
+        expect(
+          Math.abs(graceBeforeB - graceAfterB),
+          'grace timer must not advance during pause (B view)',
+        ).toBeLessThanOrEqual(1);
 
         // Captain A clicks resume button
         const resumeButton = captainA.page.locator('[data-testid="herodraft-resume-btn"]');

--- a/frontend/tests/playwright/e2e/07-draft/04-websocket-lifecycle.spec.ts
+++ b/frontend/tests/playwright/e2e/07-draft/04-websocket-lifecycle.spec.ts
@@ -36,6 +36,18 @@ test.describe('WebSocket Connection Lifecycle', () => {
     await context.close();
   });
 
+  // Force navigation off the draft route so any lingering WS from the
+  // previous test is closed before the next one starts measuring. Playwright
+  // closes the page between tests on its own, but the close handler
+  // back-pressures on the server's group_discard + redis cleanup, which
+  // gets slow late in the suite. Navigating away first lets useEffect
+  // cleanup run synchronously while the page is still alive.
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await page.goto('about:blank').catch(() => {});
+    }
+  });
+
   test('connects on modal open', async ({ page, loginAdmin }) => {
     await loginAdmin();
 

--- a/frontend/tests/playwright/e2e/herodraft/grace-and-reserve-urgency.spec.ts
+++ b/frontend/tests/playwright/e2e/herodraft/grace-and-reserve-urgency.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Grace + reserve urgency animation classes.
+ *
+ * Two thresholds drive distinct CSS animations in DraftTopBar:
+ *   - graceRemaining < 10s            → .animate-grace-urgent  (red ↔ yellow)
+ *   - graceRemaining === 0 AND
+ *     active team's reserve < 30s    → .animate-reserve-critical (red ↔ white)
+ *
+ * Driven by /api/tests/herodraft/<pk>/warp/ to skip the 25-90s of real-time
+ * waiting needed to reach each threshold organically.
+ */
+import { test, expect, chromium, type Page } from '@playwright/test';
+import { loginAsDiscordId, waitForHydration } from '../../fixtures/auth';
+import { HeroDraftPage } from '../../helpers/HeroDraftPage';
+
+const API_URL = 'https://localhost/api';
+const BASE_URL = 'https://localhost';
+
+test.describe('HeroDraft Timer Urgency Animations', () => {
+  test('grace<10s pulses grace-urgent; grace=0 + reserve<30s pulses reserve-critical', async () => {
+    test.setTimeout(180000);
+
+    const browser = await chromium.launch({
+      headless: true,
+      args: [
+        '--disable-web-security',
+        '--ignore-certificate-errors',
+        '--no-sandbox',
+      ],
+    });
+
+    const contextA = await browser.newContext({ ignoreHTTPSErrors: true });
+    const contextB = await browser.newContext({ ignoreHTTPSErrors: true });
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const response = await contextA.request.get(
+        `${API_URL}/tests/herodraft-by-key/two_captain_test/`,
+        { failOnStatusCode: false, timeout: 10000 },
+      );
+      if (!response.ok()) {
+        throw new Error(`Failed to get test data: ${response.status()}`);
+      }
+      const testInfo = await response.json();
+      const draftPk = testInfo.pk;
+      const teams = testInfo.draft_teams;
+
+      await contextA.request.post(
+        `${API_URL}/tests/herodraft/${draftPk}/reset/`,
+        { failOnStatusCode: false },
+      );
+
+      await loginAsDiscordId(contextA, teams[0].captain.discordId);
+      await loginAsDiscordId(contextB, teams[1].captain.discordId);
+
+      const tournamentPk = testInfo.game.tournament_pk;
+      const gamePk = testInfo.game.pk;
+      const matchUrl = `${BASE_URL}/tournament/${tournamentPk}/bracket/match/${gamePk}`;
+
+      await Promise.all([pageA.goto(matchUrl), pageB.goto(matchUrl)]);
+      await Promise.all([waitForHydration(pageA), waitForHydration(pageB)]);
+
+      const startBtn = (page: Page) => page.getByTestId('view-draft-btn');
+      await Promise.all([startBtn(pageA).click(), startBtn(pageB).click()]);
+
+      const draftPageA = new HeroDraftPage(pageA);
+      const draftPageB = new HeroDraftPage(pageB);
+
+      await Promise.all([draftPageA.waitForModal(), draftPageB.waitForModal()]);
+      await Promise.all([
+        draftPageA.waitForConnection(),
+        draftPageB.waitForConnection(),
+      ]);
+
+      await draftPageA.clickReady();
+      await draftPageB.clickReady();
+
+      await Promise.all([
+        draftPageA.waitForPhaseTransition('rolling', 15000),
+        draftPageB.waitForPhaseTransition('rolling', 15000),
+      ]);
+
+      await draftPageA.flipCoinButton.waitFor({ state: 'visible', timeout: 15000 });
+      await draftPageA.clickFlipCoin();
+
+      await Promise.all([
+        draftPageA.waitForPhaseTransition('choosing', 15000),
+        draftPageB.waitForPhaseTransition('choosing', 15000),
+      ]);
+
+      const winnerChoices = pageA.locator('[data-testid="herodraft-winner-choices"]');
+      const isAWinner = await winnerChoices.isVisible().catch(() => false);
+      if (isAWinner) {
+        await draftPageA.selectWinnerChoice('first_pick');
+        const loserChoices = pageB.locator('[data-testid="herodraft-loser-choices"]');
+        await loserChoices.waitFor({ state: 'visible', timeout: 10000 });
+        await draftPageB.selectLoserChoice('radiant');
+      } else {
+        await draftPageB.selectWinnerChoice('first_pick');
+        const loserChoices = pageA.locator('[data-testid="herodraft-loser-choices"]');
+        await loserChoices.waitFor({ state: 'visible', timeout: 10000 });
+        await draftPageA.selectLoserChoice('radiant');
+      }
+
+      await Promise.all([
+        draftPageA.waitForPhaseTransition('drafting', 15000),
+        draftPageB.waitForPhaseTransition('drafting', 15000),
+      ]);
+
+      // ── Scenario 1: grace-urgent (under 10s remaining, reserve untouched) ──
+      // Default grace = 30s. Warp elapsed to 22s → graceRemaining = 8s.
+      await contextA.request.post(
+        `${API_URL}/tests/herodraft/${draftPk}/warp/`,
+        { data: { elapsed_ms: 22000 }, failOnStatusCode: false },
+      );
+
+      const graceTimeA = pageA.locator('[data-testid="herodraft-grace-time"]');
+      const graceTimeB = pageB.locator('[data-testid="herodraft-grace-time"]');
+
+      // Wait for the next 1Hz tick to land + rAF to repaint.
+      await expect
+        .poll(
+          async () => {
+            const cls = await graceTimeA.getAttribute('class');
+            return cls?.includes('animate-grace-urgent') ?? false;
+          },
+          {
+            timeout: 5000,
+            message: 'grace-urgent class did not appear after warp to <10s',
+          },
+        )
+        .toBe(true);
+
+      const graceTextA = (await graceTimeA.textContent()) ?? '';
+      const [m, s] = graceTextA.split(':').map(Number);
+      expect(m * 60 + s).toBeLessThan(10);
+
+      // Captain B sees it too — class applied client-side from the same anchors.
+      await expect(graceTimeB).toHaveClass(/animate-grace-urgent/);
+
+      // ── Scenario 2: reserve-critical (grace=0, active team's reserve <30s) ──
+      // elapsed=32000 → grace exhausted by 2s. active_reserve_ms=25000 →
+      // displayed reserve = 25000 - 2000 = 23000 (<30s). Safe from auto-pick
+      // (total = grace 30 + reserve 25 = 55s; we're at 32s).
+      await contextA.request.post(
+        `${API_URL}/tests/herodraft/${draftPk}/warp/`,
+        {
+          data: { elapsed_ms: 32000, active_reserve_ms: 25000 },
+          failOnStatusCode: false,
+        },
+      );
+
+      // The active team's reserve span carries the critical class. Find
+      // whichever side (A or B) is the active picker — the topbar
+      // applies the class only there.
+      const reserveASpan = pageA.locator('[data-testid="herodraft-team-a-reserve-time"]');
+      const reserveBSpan = pageA.locator('[data-testid="herodraft-team-b-reserve-time"]');
+
+      await expect
+        .poll(
+          async () => {
+            const aCls = (await reserveASpan.getAttribute('class')) ?? '';
+            const bCls = (await reserveBSpan.getAttribute('class')) ?? '';
+            return (
+              aCls.includes('animate-reserve-critical') ||
+              bCls.includes('animate-reserve-critical')
+            );
+          },
+          {
+            timeout: 5000,
+            message:
+              'reserve-critical class did not appear on either team reserve after warp',
+          },
+        )
+        .toBe(true);
+
+      // Grace must read 0:00 in this state.
+      await expect(graceTimeA).toHaveText('0:00');
+
+      // Sanity: only the ACTIVE team's reserve carries the class.
+      const aHas = ((await reserveASpan.getAttribute('class')) ?? '').includes(
+        'animate-reserve-critical',
+      );
+      const bHas = ((await reserveBSpan.getAttribute('class')) ?? '').includes(
+        'animate-reserve-critical',
+      );
+      expect(aHas === bHas).toBe(false);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/frontend/tests/playwright/helpers/DraftWebSocketHelper.ts
+++ b/frontend/tests/playwright/helpers/DraftWebSocketHelper.ts
@@ -108,8 +108,14 @@ export class DraftWebSocketHelper {
 
   /**
    * Wait for all active connections to close.
+   *
+   * Default 20s tolerates accumulated load late in the full suite; in
+   * isolation a clean disconnect completes in well under 5s. The flake
+   * we're guarding against is a long-tail timing when the test runner
+   * has been going for >15 minutes and React's useEffect cleanup races
+   * other queued work — not a regression in the disconnect logic.
    */
-  async waitForDisconnect(timeout = 10000): Promise<void> {
+  async waitForDisconnect(timeout = 20000): Promise<void> {
     if (this.activeConnectionCount === 0) return;
 
     const active = this.activeConnections;


### PR DESCRIPTION
## Summary

Two related changes that together eliminate the "every captain's timer freezes for a few seconds then resumes" bug and instrument the entire draft path for diagnostic replay.

### 1. OTel spans on WebSocket lifecycle

`BaseDraftConsumer` wraps `connect`, `disconnect`, `heartbeat`, captain register/unregister in OTel spans. Each operation is its own short trace (correlation via shared `ws.conn_id` attribute, not a single long-lived parent — long sessions would never export). Logs inside spans auto-tag with `trace_id` via the existing structlog correlation processor; the Loki `traceID` derived field already routes to Tempo, so click-from-log-to-Tempo works end-to-end.

`HeroDraftConsumer.receive()` adopts the new `traced_message` helper so per-message dispatch spans nest under handler spans (e.g. heartbeat receive → heartbeat handler).

### 2. Client-side countdown architecture

The "everyone freezes for a few seconds" bug is structural in the old design: server computed `grace_time_remaining_ms` per tick, broadcast it, client rendered it. If the broadcaster fell behind, every client's timer froze.

Refactored to **anchor + offset**:
- `broadcast_tick` now sends `server_time`, `round_started_at`, `round_grace_time_ms`, raw team reserves, `resuming_until`. No computed remainders.
- Frontend `useDraftCountdown` hook computes display values per requestAnimationFrame (60fps) using `Date.now() + serverClockOffset`.
- A delayed/dropped tick no longer freezes the UI — client keeps counting from last anchor. When the late tick lands, offset silently re-anchors.
- Server-side timeout / reserve-debit logic untouched. Server stays authoritative on all the values that matter; only the per-frame display moves client-side.

Also:
- **Pick payload includes `client_picked_at`** in server-clock reference (via the offset learned from `tick.server_time`). Server trusts it if within 2s of now, credits network latency back to the captain. Out-of-window values fall back to server-receive time with `pick_time_too_old` / `pick_time_in_future` warnings.
- **Reserve consumption floored to whole seconds** — sub-second over-grace doesn't nibble the team's reserve.

### 3. Wall-to-wall telemetry

Every anomaly path in the pick + state-transition flow now has a structured event in Loki, and `submit_pick` is wrapped in an OTel span. New events:

| Severity | Event | When |
|---|---|---|
| info | `pick_submitted` | every successful pick — full timing context for replay |
| info | `round_started` | next round activated |
| info | `draft_paused` / `draft_resumed` | state transitions with `from_state`, who, when |
| info | `round_started_at_adjusted` | resume pushes round.started_at forward |
| info | `draft_completed` | final round |
| warn | `pick_time_in_future` | client clock ahead of server |
| warn | `pick_time_too_old` | pick payload >2s old when received |
| warn | `pick_reserve_exhausted` | reserve drained, auto-pick didn't fire |
| warn | `pick_time_naive_datetime` | malformed timestamp made it past view layer |
| error | `pick_elapsed_negative` | round.started_at in the future |

Frontend gains `pick_submit_started/succeeded/failed` with `duration_ms`, and `client_tick_gap` (>2s between tick receives) — catches WS delivery problems the server can't see.

### 4. Cheap fix for post-pick display blip

`hero_selected` event now clears `tick.active_team_id` in the store. The ~1s window where reserve appeared to keep draining after a pick (before the next tick arrived with new anchors) is gone.

## Test results

### Backend (Django unit tests via Docker)

`app.tests.test_herodraft_integration` + `test_herodraft_functions` + `test_herodraft_tick` + `test_consumers_base`: **46/46 pass** in 26.7s.

Includes:
- 5 new `TestSpanInstrumentation` cases asserting span attributes (`ws.conn_id` on every span, parent-child relationship for nested message spans, exception recording, defensive missing-conn_id path)
- Verified the existing 24-round-draft integration test still completes cleanly with the new tick payload + per-pick telemetry

### Playwright E2E (local headless, 1 worker)

**Herodraft specs alone**: 16 passed, 2 skipped (intentional `test.skip`), 0 failed — 5.5 minutes. Full 24-round draft from tournament bracket completes successfully including pick submission via new `client_picked_at` path.

**Full Playwright suite (258 tests)**: 203 passed, 1 failed, 37 intentional skips, 17 did-not-run due to the one failure halting the queue — 15.8 minutes.

The single failure was `tests/playwright/e2e/07-draft/04-websocket-lifecycle.spec.ts:54 — disconnects on modal close`, which:
- Tests `DraftConsumer` (snake draft), NOT `HeroDraftConsumer`. The diff of this PR doesn't touch any file under `frontend/app/components/draft/`, `frontend/app/components/tournament/`, or the `DraftConsumer` class.
- Passes 5/5 in isolation in ~30s when the file is run alone.
- Was a pre-existing load-sensitive flake: under full-suite load (16 min in, 1 worker), the 10s `waitForDisconnect` timeout was too tight when React's useEffect cleanup races other queued work.

Commit `ad3e9732` hardens the test against this load profile: bumps `waitForDisconnect` default to 20s and adds an `afterEach` that navigates the page to `about:blank` before the next test, letting useEffect cleanup run synchronously while the page is still alive. Both defensive changes; the disconnect logic itself was never broken.

## Test plan

- [x] Backend unit tests pass (46/46)
- [x] Herodraft Playwright specs pass (16/16)
- [x] WS lifecycle Playwright suite passes in isolation (5/5)
- [ ] Full Playwright suite passes (will re-run after merge of `ad3e9732` flake fix to confirm)
- [ ] In a live draft, captain timers update smoothly even if the network is briefly throttled (DevTools throttling test — manual)
- [ ] After a pick is submitted, the next round's grace countdown starts at the correct value without a visible reserve drain blip (manual)
- [ ] `client_picked_at` arriving within 2s gets credited (verify in `pick_submitted` log: `pick_time_source=client`)
- [ ] `client_picked_at` arriving >2s old falls back cleanly (verify warn log + `pick_time_source=server_now`)
- [ ] Pause/resume preserves the round timer correctly (verify `round_started_at_adjusted` log fires with the right `total_adjustment_s`)
- [ ] Tempo shows `herodraft.submit_pick` spans for picks, `ws.connect`/`ws.heartbeat`/etc. for WS lifecycle

## Copilot review (addressed in `9c9a6fc6`)

| # | Severity | Issue | Fix |
|---|---|---|---|
| 1 | **Critical** | `useDraftCountdown` clock stuck at tick boundaries — countdown only advanced 1Hz instead of 60fps | Read offset from store (captured once at tick-receive) instead of recomputing per frame |
| 2 | **Critical** | `HeroDraftConsumer.herodraft_tick` channel-layer forwarder still emitting old field names — frontend zod would reject | Updated forwarder to pass through new anchor fields (`server_time`, `round_started_at`, `round_grace_time_ms`, `resuming_until`) |
| 3 | Real | `parse_datetime` returns None on invalid input + can return naive datetimes — both would either bypass the try/except or TypeError downstream | Reject None + naive datetimes up front in the view |
| 4 | Real | `tick_loop_stalled` over-reported because expected gap was actually `1s + work_duration`, not `1s` | Sleep `max(0, 1 - tick_duration)` to maintain 1Hz cadence |
| 5 | Defensive | Naive datetime defense at `_evaluate_client_pick_time` | Reject naive + emit `pick_time_naive_datetime` warn log |

Both critical fixes would have made the feature silently broken in production (#1 the countdown wouldn't be smooth, #2 the WS payload wouldn't reach the frontend at all). Tests passed in spite of these because (a) the 1Hz step still looks like "countdown working" in coarse Playwright assertions and (b) the channel-layer forwarder only runs in live websocket sessions, not unit tests.

## Out of scope (deliberately left for follow-up)

- Long-lived "session" parent span tying every WS operation together — current short-span-per-operation design is correct for OTel (exports immediately, survives crashes); cross-operation correlation already works via `ws.conn_id` attribute.
- Subclass adoption of `traced_message` in `DraftConsumer` / `TournamentConsumer` — both have read-only `receive()` methods. No work to wrap.
- Removing the existing `tick_loop_healthy` 30-second positive heartbeat log — moot under the new architecture but noisy; can drop in a separate cleanup PR.