### PR TITLE
fix(types): align useForm generics + fix 3 surfaced bugs

### DIFF
--- a/frontend/app/components/events/ApprovalConfigSection.tsx
+++ b/frontend/app/components/events/ApprovalConfigSection.tsx
@@ -1,9 +1,18 @@
 /**
  * Approval Requirements config section for event create/edit modals.
  * Controls which rank types are allowed, screenshot requirements, and min MMR.
+ *
+ * Shared across CreateEventModal, EditEventModal, EditOrgDefaultsModal, and
+ * EditRepeaterModal — all four schemas `.merge(discordConfigSchema)`, so any
+ * generic T extending z.input<typeof discordConfigSchema> is accepted.
+ *
+ * One narrowing cast at the top (`as unknown as Control<ApprovalFields>`) lets
+ * the body reference `name="allow_active_mmr"` etc. with full type checking —
+ * a typo'd name is a compile error rather than silent dead UI.
  */
 
-import type { Control, UseFormWatch } from 'react-hook-form';
+import type { Control, FieldValues, UseFormWatch } from 'react-hook-form';
+import type { z } from 'zod';
 import {
   FormControl,
   FormDescription,
@@ -12,16 +21,24 @@ import {
   FormLabel,
 } from '~/components/ui/form';
 import { Input } from '~/components/ui/input';
+import type { discordConfigSchema } from './schemas';
 
-interface ApprovalConfigSectionProps {
-  control: Control<any>;
-  watch: UseFormWatch<any>;
+type ApprovalFields = z.input<typeof discordConfigSchema>;
+
+interface ApprovalConfigSectionProps<T extends FieldValues & ApprovalFields> {
+  control: Control<T>;
+  watch: UseFormWatch<T>;
 }
 
-/** Reusable checkbox field matching DiscordConfigSection pattern */
-function CheckboxField({ control, name, label, description }: {
-  control: Control<any>;
-  name: string;
+/** Reusable checkbox field bound to a known approval field name. */
+function CheckboxField({
+  control,
+  name,
+  label,
+  description,
+}: {
+  control: Control<ApprovalFields>;
+  name: Extract<keyof ApprovalFields, string>;
   label: string;
   description: string;
 }) {
@@ -34,7 +51,7 @@ function CheckboxField({ control, name, label, description }: {
           <FormControl>
             <input
               type="checkbox"
-              checked={field.value}
+              checked={!!field.value}
               onChange={field.onChange}
               className="h-4 w-4 rounded border-border accent-primary"
             />
@@ -49,7 +66,16 @@ function CheckboxField({ control, name, label, description }: {
   );
 }
 
-export function ApprovalConfigSection({ control, watch }: ApprovalConfigSectionProps) {
+export function ApprovalConfigSection<T extends FieldValues & ApprovalFields>({
+  control: parentControl,
+  watch: parentWatch,
+}: ApprovalConfigSectionProps<T>) {
+  // T extends ApprovalFields by the generic constraint, so narrowing to
+  // Control<ApprovalFields> is sound: we touch only the discord-config slice
+  // of the parent form, never the parent's extra keys.
+  const control = parentControl as unknown as Control<ApprovalFields>;
+  const watch = parentWatch as unknown as UseFormWatch<ApprovalFields>;
+
   const allowActiveMmr = watch('allow_active_mmr');
   const allowPreviousRank = watch('allow_previous_rank');
   const allowBattlecupRating = watch('allow_battlecup_rating');

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -67,7 +67,7 @@ export function CreateEventModal({
   // TTransformedValues = z.output<S> (what onSubmit receives after parse)
   // For schemas without transforms these are structurally identical but
   // TypeScript still treats them as distinct due to zod 4 type branding.
-  const form = useForm<z.input<typeof createEventInputSchema>, undefined, CreateEventInput>({
+  const form = useForm<z.input<typeof createEventInputSchema>, unknown, CreateEventInput>({
     resolver: zodResolver(createEventInputSchema),
     defaultValues: {
       name: '',

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -140,6 +140,13 @@ export function CreateEventModal({
         allow_active_mmr: orgDefaults.allow_active_mmr ?? true,
         allow_previous_rank: orgDefaults.allow_previous_rank ?? true,
         allow_battlecup_rating: orgDefaults.allow_battlecup_rating ?? true,
+        // Approval rule flags added to discordConfigSchema in 46de0503. Without
+        // these in the reset payload, form state would be `undefined` after
+        // orgDefaults loads and zod's z.boolean() would silently fail validation
+        // on submit — the modal would stay open with no visible error.
+        require_steam_id: orgDefaults.require_steam_id ?? false,
+        require_mmr_verified: orgDefaults.require_mmr_verified ?? false,
+        require_profile_complete: orgDefaults.require_profile_complete ?? false,
         is_recurring: false,
         frequency: Frequency.WEEKLY,
         generate_days_ahead: 7,

--- a/frontend/app/components/events/CreateEventModal.tsx
+++ b/frontend/app/components/events/CreateEventModal.tsx
@@ -28,6 +28,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { ApprovalConfigSection } from './ApprovalConfigSection';
 import { DiscordConfigSection, DiscordIcon } from './DiscordConfigSection';
 import { LobbyConfigSection } from './LobbyConfigSection';
+import { z } from 'zod';
 import { createEventInputSchema, GameMode, Frequency, FREQUENCY_LABELS, DAY_LABELS, DISCORD_CONFIG_DEFAULTS, COMMON_TIMEZONES, localToUTC, type CreateEventInput } from './schemas';
 import { GAME_TYPE } from '~/components/game/constants';
 import { LeagueCombobox } from '~/components/league/LeagueCombobox';
@@ -59,7 +60,14 @@ export function CreateEventModal({
   // hardcoded useForm values and we show the form anyway after isLoading clears.
   const formReady = !orgDefaultsLoading && (orgDefaults == null || defaultsApplied);
 
-  const form = useForm<CreateEventInput>({
+  // RHF 7.55+ split the form's internal field-values type from the
+  // transformed-on-submit type. @hookform/resolvers v5 + zod 4 always returns
+  // Resolver<z.input<T>, _, z.output<T>>, so we need both generics aligned:
+  // TFieldValues = z.input<S> (matches resolver's first arg)
+  // TTransformedValues = z.output<S> (what onSubmit receives after parse)
+  // For schemas without transforms these are structurally identical but
+  // TypeScript still treats them as distinct due to zod 4 type branding.
+  const form = useForm<z.input<typeof createEventInputSchema>, undefined, CreateEventInput>({
     resolver: zodResolver(createEventInputSchema),
     defaultValues: {
       name: '',

--- a/frontend/app/components/events/DiscordConfigSection.tsx
+++ b/frontend/app/components/events/DiscordConfigSection.tsx
@@ -1,4 +1,5 @@
-import type { Control, UseFormWatch } from 'react-hook-form';
+import type { Control, FieldValues, UseFormWatch } from 'react-hook-form';
+import type { z } from 'zod';
 import {
   FormControl,
   FormDescription,
@@ -16,8 +17,19 @@ import {
   SelectValue,
 } from '~/components/ui/select';
 import { Textarea } from '~/components/ui/textarea';
+import type { discordConfigSchema } from './schemas';
 import { DiscordChannelPicker } from './DiscordChannelPicker';
 import { DiscordRolePicker } from './DiscordRolePicker';
+
+/** Field set covered by this section. Includes discordConfigSchema's input
+ *  plus the repeater-only `discord_notify_new_events` flag — that field lives
+ *  on createEventInputSchema + editRepeaterSchema directly (not in the shared
+ *  sub-schema) because non-repeater forms don't expose it, but the JSX still
+ *  references it under the `isRepeater` guard. */
+type DiscordFields = z.input<typeof discordConfigSchema> & {
+  discord_notify_new_events?: boolean;
+};
+type DiscordFieldName = Extract<keyof DiscordFields, string>;
 
 const REMINDER_HOURS_OPTIONS = [
   { value: 1, label: '1 hour before' },
@@ -35,11 +47,11 @@ export const DiscordIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-/** Reusable checkbox field for Discord config options */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/** Reusable checkbox field for Discord config options. The `name` prop is
+ *  constrained to known DiscordFields keys — a typo'd literal is a TS error. */
 function CheckboxField({ control, name, label, description }: {
-  control: Control<any>;
-  name: string;
+  control: Control<DiscordFields>;
+  name: DiscordFieldName;
   label: string;
   description: string;
 }) {
@@ -53,7 +65,7 @@ function CheckboxField({ control, name, label, description }: {
             <input
               type="checkbox"
               data-testid={`discord-${name}`}
-              checked={field.value}
+              checked={!!field.value}
               onChange={field.onChange}
               className="h-4 w-4 rounded border-border accent-primary"
             />
@@ -69,10 +81,9 @@ function CheckboxField({ control, name, label, description }: {
 }
 
 /** Reusable hours dropdown for reminder timing */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function HoursSelect({ control, name, label }: {
-  control: Control<any>;
-  name: string;
+  control: Control<DiscordFields>;
+  name: DiscordFieldName;
   label?: string;
 }) {
   return (
@@ -108,16 +119,24 @@ function HoursSelect({ control, name, label }: {
   );
 }
 
-interface DiscordConfigSectionProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  control: Control<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  watch: UseFormWatch<any>;
+interface DiscordConfigSectionProps<T extends FieldValues & DiscordFields> {
+  control: Control<T>;
+  watch: UseFormWatch<T>;
   isRepeater: boolean;
   organizationId: number;
 }
 
-export function DiscordConfigSection({ control, watch, isRepeater, organizationId }: DiscordConfigSectionProps) {
+export function DiscordConfigSection<T extends FieldValues & DiscordFields>({
+  control: parentControl,
+  watch: parentWatch,
+  isRepeater,
+  organizationId,
+}: DiscordConfigSectionProps<T>) {
+  // T extends DiscordFields by the generic constraint, so narrowing to
+  // Control<DiscordFields> is sound: we touch only the discord-config slice.
+  const control = parentControl as unknown as Control<DiscordFields>;
+  const watch = parentWatch as unknown as UseFormWatch<DiscordFields>;
+
   const [createEvent, signupReminder, profileReminder, confirmAttendance, postSignups, announcement] = watch([
     'discord_create_event',
     'discord_signup_reminder',

--- a/frontend/app/components/events/EditEventModal.tsx
+++ b/frontend/app/components/events/EditEventModal.tsx
@@ -69,7 +69,10 @@ export function EditEventModal({ event, open, onOpenChange }: EditEventModalProp
   const [isSubmitting, setIsSubmitting] = useState(false);
   const mutation = useUpdateEventMutation(event?.id ?? 0);
 
-  const form = useForm<EditEventInput>({
+  // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
+  // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
+  // See https://github.com/react-hook-form/resolvers/issues/792.
+  const form = useForm<z.input<typeof editEventSchema>, undefined, EditEventInput>({
     resolver: zodResolver(editEventSchema),
     defaultValues: {
       name: '',

--- a/frontend/app/components/events/EditEventModal.tsx
+++ b/frontend/app/components/events/EditEventModal.tsx
@@ -72,7 +72,7 @@ export function EditEventModal({ event, open, onOpenChange }: EditEventModalProp
   // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
   // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
   // See https://github.com/react-hook-form/resolvers/issues/792.
-  const form = useForm<z.input<typeof editEventSchema>, undefined, EditEventInput>({
+  const form = useForm<z.input<typeof editEventSchema>, unknown, EditEventInput>({
     resolver: zodResolver(editEventSchema),
     defaultValues: {
       name: '',

--- a/frontend/app/components/events/EditEventModal.tsx
+++ b/frontend/app/components/events/EditEventModal.tsx
@@ -143,6 +143,10 @@ export function EditEventModal({ event, open, onOpenChange }: EditEventModalProp
         allow_active_mmr: event.allow_active_mmr,
         allow_previous_rank: event.allow_previous_rank,
         allow_battlecup_rating: event.allow_battlecup_rating,
+        // Approval rule flags — see CreateEventModal for the regression note.
+        require_steam_id: event.require_steam_id ?? false,
+        require_mmr_verified: event.require_mmr_verified ?? false,
+        require_profile_complete: event.require_profile_complete ?? false,
       });
     }
   }, [event, open]);

--- a/frontend/app/components/events/EditOrgDefaultsModal.tsx
+++ b/frontend/app/components/events/EditOrgDefaultsModal.tsx
@@ -66,7 +66,10 @@ export function EditOrgDefaultsModal({
     enabled: open && !!organizationId,
   });
 
-  const form = useForm<OrgDefaultsInput>({
+  // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
+  // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
+  // See https://github.com/react-hook-form/resolvers/issues/792.
+  const form = useForm<z.input<typeof orgDefaultsSchema>, undefined, OrgDefaultsInput>({
     resolver: zodResolver(orgDefaultsSchema),
     defaultValues: {
       tournament_name: '',

--- a/frontend/app/components/events/EditOrgDefaultsModal.tsx
+++ b/frontend/app/components/events/EditOrgDefaultsModal.tsx
@@ -69,7 +69,7 @@ export function EditOrgDefaultsModal({
   // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
   // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
   // See https://github.com/react-hook-form/resolvers/issues/792.
-  const form = useForm<z.input<typeof orgDefaultsSchema>, undefined, OrgDefaultsInput>({
+  const form = useForm<z.input<typeof orgDefaultsSchema>, unknown, OrgDefaultsInput>({
     resolver: zodResolver(orgDefaultsSchema),
     defaultValues: {
       tournament_name: '',

--- a/frontend/app/components/events/EditOrgDefaultsModal.tsx
+++ b/frontend/app/components/events/EditOrgDefaultsModal.tsx
@@ -124,6 +124,10 @@ export function EditOrgDefaultsModal({
         allow_active_mmr: defaults.allow_active_mmr ?? true,
         allow_previous_rank: defaults.allow_previous_rank ?? true,
         allow_battlecup_rating: defaults.allow_battlecup_rating ?? true,
+        // Approval rule flags — see CreateEventModal for the regression note.
+        require_steam_id: defaults.require_steam_id ?? false,
+        require_mmr_verified: defaults.require_mmr_verified ?? false,
+        require_profile_complete: defaults.require_profile_complete ?? false,
       });
     }
   }, [defaults, open]);

--- a/frontend/app/components/events/EditRepeaterModal.tsx
+++ b/frontend/app/components/events/EditRepeaterModal.tsx
@@ -138,6 +138,10 @@ export function EditRepeaterModal({ repeater, open, onOpenChange }: EditRepeater
         allow_active_mmr: repeater.allow_active_mmr ?? true,
         allow_previous_rank: repeater.allow_previous_rank ?? true,
         allow_battlecup_rating: repeater.allow_battlecup_rating ?? true,
+        // Approval rule flags — see CreateEventModal for the regression note.
+        require_steam_id: repeater.require_steam_id ?? false,
+        require_mmr_verified: repeater.require_mmr_verified ?? false,
+        require_profile_complete: repeater.require_profile_complete ?? false,
       });
     }
   }, [repeater, open]);

--- a/frontend/app/components/events/EditRepeaterModal.tsx
+++ b/frontend/app/components/events/EditRepeaterModal.tsx
@@ -67,7 +67,7 @@ export function EditRepeaterModal({ repeater, open, onOpenChange }: EditRepeater
   // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
   // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
   // See https://github.com/react-hook-form/resolvers/issues/792.
-  const form = useForm<z.input<typeof editRepeaterSchema>, undefined, EditRepeaterInput>({
+  const form = useForm<z.input<typeof editRepeaterSchema>, unknown, EditRepeaterInput>({
     resolver: zodResolver(editRepeaterSchema),
     defaultValues: {
       name: '',

--- a/frontend/app/components/events/EditRepeaterModal.tsx
+++ b/frontend/app/components/events/EditRepeaterModal.tsx
@@ -64,7 +64,10 @@ export function EditRepeaterModal({ repeater, open, onOpenChange }: EditRepeater
   const [isSubmitting, setIsSubmitting] = useState(false);
   const mutation = useUpdateEventRepeaterMutation(repeater?.id ?? 0);
 
-  const form = useForm<EditRepeaterInput>({
+  // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
+  // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
+  // See https://github.com/react-hook-form/resolvers/issues/792.
+  const form = useForm<z.input<typeof editRepeaterSchema>, undefined, EditRepeaterInput>({
     resolver: zodResolver(editRepeaterSchema),
     defaultValues: {
       name: '',

--- a/frontend/app/components/events/LobbyConfigSection.tsx
+++ b/frontend/app/components/events/LobbyConfigSection.tsx
@@ -1,4 +1,4 @@
-import type { Control, UseFormWatch } from 'react-hook-form';
+import type { Control, FieldValues, UseFormWatch } from 'react-hook-form';
 import {
   FormControl,
   FormField,
@@ -17,11 +17,21 @@ import {
 import { GameMode } from './schemas';
 import { GAME_TYPE } from '~/components/game/constants';
 
-interface LobbyConfigSectionProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  control: Control<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  watch: UseFormWatch<any>;
+/** Field set this section renders. Not extracted as a zod sub-schema (yet) —
+ *  these keys are inline on createEventInputSchema, editEventSchema,
+ *  editRepeaterSchema. The constraint catches field-name typos in this file
+ *  without forcing a schema refactor across all four parent forms. */
+interface LobbyFields {
+  game_type: number;
+  game_mode: string;
+  lobby_steam_league_id: number | null;
+  captains_draft_time: number;
+  custom_game_name: string;
+}
+
+interface LobbyConfigSectionProps<T extends FieldValues & LobbyFields> {
+  control: Control<T>;
+  watch: UseFormWatch<T>;
 }
 
 const GAME_MODE_LABELS: Record<string, string> = {
@@ -33,7 +43,15 @@ const GAME_MODE_LABELS: Record<string, string> = {
 
 const DOTA_ONLY_MODES: Set<string> = new Set([GameMode.CAPTAINS_MODE, GameMode.TURBO]);
 
-export function LobbyConfigSection({ control, watch }: LobbyConfigSectionProps) {
+export function LobbyConfigSection<T extends FieldValues & LobbyFields>({
+  control: parentControl,
+  watch: parentWatch,
+}: LobbyConfigSectionProps<T>) {
+  // Narrow once: T extends LobbyFields, so all this section's field references
+  // are sound. Catches typo'd `name=`s in the JSX below.
+  const control = parentControl as unknown as Control<LobbyFields>;
+  const watch = parentWatch as unknown as UseFormWatch<LobbyFields>;
+
   const gameType = watch('game_type');
   const gameMode = watch('game_mode');
   const isDota = gameType === GAME_TYPE.DOTA2;

--- a/frontend/app/components/events/MmrApprovalModal.tsx
+++ b/frontend/app/components/events/MmrApprovalModal.tsx
@@ -42,7 +42,9 @@ import type { UserType } from '~/components/user/types';
 const LARGE_CHANGE_THRESHOLD = 0.2;
 
 const mmrSchema = z.object({
-  mmr: z.number({ coerce: true }).int().min(0, 'MMR must be positive').max(20000, 'MMR too high'),
+  // zod 4 dropped the `{ coerce: true }` option on z.number; use z.coerce.number()
+  // so the resolver still parses string inputs from the <Input> element.
+  mmr: z.coerce.number().int().min(0, 'MMR must be positive').max(20000, 'MMR too high'),
 });
 type MmrFormValues = z.infer<typeof mmrSchema>;
 
@@ -67,7 +69,10 @@ export function MmrApprovalModal({
 }: MmrApprovalModalProps) {
   const gameType = useGameType();
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const form = useForm<MmrFormValues>({
+  // 3-generic useForm because z.coerce.number() genuinely splits input/output:
+  // input is `unknown` (coerce accepts anything), output is `number`.
+  // See https://github.com/react-hook-form/resolvers/issues/792.
+  const form = useForm<z.input<typeof mmrSchema>, unknown, MmrFormValues>({
     resolver: zodResolver(mmrSchema),
     defaultValues: { mmr: 0 },
   });
@@ -81,7 +86,10 @@ export function MmrApprovalModal({
     }
   }, [signup, open]);
 
-  const watchedMmr = form.watch('mmr');
+  // form.watch returns z.input shape, which for z.coerce.number() is `unknown`
+  // (the resolver coerces at parse time). At runtime the Input's onChange
+  // already calls valueAsNumber, so Number(...)||0 is a safe narrowing.
+  const watchedMmr = Number(form.watch('mmr')) || 0;
   const priorMmr = signup?.org_user_mmr ?? null;
   const hasDelta =
     priorMmr != null && Number.isFinite(watchedMmr) && watchedMmr !== priorMmr;
@@ -128,7 +136,9 @@ export function MmrApprovalModal({
   };
 
   const handleConfirmApproval = () => {
-    onApprove(signup.id, form.getValues('mmr'));
+    // form.getValues returns z.input shape (unknown for coerce fields).
+    // Narrow with Number() — matches onChange's valueAsNumber behavior.
+    onApprove(signup.id, Number(form.getValues('mmr')) || 0);
     setConfirmOpen(false);
   };
 
@@ -223,6 +233,9 @@ export function MmrApprovalModal({
                         placeholder="e.g. 3000"
                         data-testid="mmr-input"
                         {...field}
+                        // field.value is `unknown` (coerce input). Narrow to
+                        // number|'' so the <input> value prop typechecks.
+                        value={typeof field.value === 'number' ? field.value : ''}
                         onChange={(e) => field.onChange(e.target.valueAsNumber || 0)}
                       />
                     </FormControl>

--- a/frontend/app/components/events/schemas.ts
+++ b/frontend/app/components/events/schemas.ts
@@ -280,6 +280,14 @@ export const discordConfigSchema = z.object({
   allow_active_mmr: z.boolean(),
   allow_previous_rank: z.boolean(),
   allow_battlecup_rating: z.boolean(),
+  // Generic approval requirements rendered by ApprovalConfigSection. These
+  // were referenced by name in the UI but missing from the input schema, so
+  // checkbox state was silently dropped from create/edit submissions. The
+  // backend already accepts these fields (see eventsAPI.ts EventType:168-170
+  // and the `evaluateSignupGap` consumers).
+  require_steam_id: z.boolean(),
+  require_mmr_verified: z.boolean(),
+  require_profile_complete: z.boolean(),
 });
 
 export const DISCORD_CONFIG_DEFAULTS = {
@@ -308,6 +316,11 @@ export const DISCORD_CONFIG_DEFAULTS = {
   allow_active_mmr: true,
   allow_previous_rank: true,
   allow_battlecup_rating: true,
+  // See discordConfigSchema for why these moved into the canonical config —
+  // the UI used them before they were schema-tracked.
+  require_steam_id: false,
+  require_mmr_verified: false,
+  require_profile_complete: false,
 } as const;
 
 export const createEventInputSchema = z.object({

--- a/frontend/app/components/organization/forms/EditOrganizationModal.tsx
+++ b/frontend/app/components/organization/forms/EditOrganizationModal.tsx
@@ -52,7 +52,7 @@ export function EditOrganizationModal({
   // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
   // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
   // See https://github.com/react-hook-form/resolvers/issues/792.
-  const form = useForm<z.input<typeof EditOrganizationSchema>, undefined, EditOrganizationInput>({
+  const form = useForm<z.input<typeof EditOrganizationSchema>, unknown, EditOrganizationInput>({
     resolver: zodResolver(EditOrganizationSchema),
     defaultValues: {
       name: organization.name || '',

--- a/frontend/app/components/organization/forms/EditOrganizationModal.tsx
+++ b/frontend/app/components/organization/forms/EditOrganizationModal.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { z } from 'zod';
 
 import { AdminTeamSection } from '~/components/admin-team';
 import { updateOrganization } from '~/components/api/api';
@@ -48,7 +49,10 @@ export function EditOrganizationModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isOrgAdmin = useIsOrganizationAdmin(organization);
 
-  const form = useForm<EditOrganizationInput>({
+  // 3-generic useForm to align TFieldValues=z.input and TTransformedValues=z.output
+  // — zodResolver returns Resolver<z.input<S>, _, z.output<S>> under zod 4.
+  // See https://github.com/react-hook-form/resolvers/issues/792.
+  const form = useForm<z.input<typeof EditOrganizationSchema>, undefined, EditOrganizationInput>({
     resolver: zodResolver(EditOrganizationSchema),
     defaultValues: {
       name: organization.name || '',

--- a/frontend/app/routes/organization.tsx
+++ b/frontend/app/routes/organization.tsx
@@ -470,7 +470,7 @@ export default function OrganizationDetailPage() {
           {/* Events Tab */}
           <TabsContent value="events">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-xl font-semibold">Events</h2>
+              <h2 className="text-xl font-semibold" data-testid="org-events-heading">Events</h2>
               <div className="flex items-center gap-2">
                 {canEditEvents && (
                   <Tooltip>

--- a/frontend/app/store/heroDraftStore.ts
+++ b/frontend/app/store/heroDraftStore.ts
@@ -210,13 +210,15 @@ export const useHeroDraftStore = create<HeroDraftState>((set, get) => ({
           if (kickedConnId) {
             manager.disconnect(kickedConnId, 'Kicked by server');
           }
-          // Clear connection state but preserve wasKicked flag
+          // Clear connection state but preserve wasKicked flag.
+          // `isConnected` is a derived selector (line 353), not state — the
+          // canonical disconnected signal is `status: 'disconnected'`.
           set({
             _connectionId: null,
             _unsubscribe: null,
             wasKicked: true,
             error: 'Connection replaced by new tab',
-            isConnected: false,
+            status: 'disconnected',
           });
           break;
         }

--- a/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
@@ -40,8 +40,10 @@ test.describe('Events - Create Event (@cicd)', () => {
     // Click the Events tab
     await page.getByTestId('org-tab-events').click();
 
-    // Should see Events heading and Create Event button
-    await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible();
+    // Should see Events heading and Create Event button. Use exact:true —
+    // the org page already contains "Events Test Org" (h1), "Events (N)" (h3)
+    // and "Repeating Events (N)" (h3), all of which substring-match "Events".
+    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
     await expect(page.getByTestId('create-event-btn')).toBeVisible();
   });
 
@@ -51,7 +53,7 @@ test.describe('Events - Create Event (@cicd)', () => {
 
     await page.getByTestId('org-tab-events').click();
 
-    await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
     await expect(page.getByTestId('create-event-btn')).not.toBeVisible();
   });
 

--- a/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/02-create-event.spec.ts
@@ -40,10 +40,11 @@ test.describe('Events - Create Event (@cicd)', () => {
     // Click the Events tab
     await page.getByTestId('org-tab-events').click();
 
-    // Should see Events heading and Create Event button. Use exact:true —
-    // the org page already contains "Events Test Org" (h1), "Events (N)" (h3)
-    // and "Repeating Events (N)" (h3), all of which substring-match "Events".
-    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+    // Use data-testid per the project's testing skill: getByRole with text
+    // matching is fragile on the org page where "Events" is a substring of
+    // multiple headings (h1 "Events Test Org", h3 "Events (N)", h3 "Repeating
+    // Events (N)").
+    await expect(page.getByTestId('org-events-heading')).toBeVisible();
     await expect(page.getByTestId('create-event-btn')).toBeVisible();
   });
 
@@ -53,7 +54,7 @@ test.describe('Events - Create Event (@cicd)', () => {
 
     await page.getByTestId('org-tab-events').click();
 
-    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+    await expect(page.getByTestId('org-events-heading')).toBeVisible();
     await expect(page.getByTestId('create-event-btn')).not.toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

What started as the `useForm`/`zodResolver` generic alignment expanded as the review process surfaced three real bugs that the typing fixes uncovered. All six commits are reviewable independently.

## Commits

| Commit | What | Errors fixed |
|---|---|---|
| `e3f23530` | Apply 3-generic `useForm<z.input<S>, _, z.output<S>>` across 5 event/org modals — RHF resolvers [#792](https://github.com/react-hook-form/resolvers/issues/792) | 73 |
| `cf91e415` | Switch second generic from `undefined` to `unknown` (code-reviewer nit; matches canonical examples) | 0 (pure style) |
| `1fe8acca` | Port `MmrApprovalModal` to zod 4 `z.coerce.number()` syntax + 3-generic + downstream narrowing | 1 |
| `ca5353b0` | `heroDraftStore` herodraft_kicked handler was setting `isConnected: false` on a state that has no such field (derived selector only). Replace with `status: 'disconnected'` | 1 |
| `46de0503` | **Active bug fix**: 3 admin checkboxes (`require_steam_id`, `require_mmr_verified`, `require_profile_complete`) rendered in `ApprovalConfigSection` were dead UI — values were silently dropped because the input schemas didn't include them. Added to `discordConfigSchema` + `DISCORD_CONFIG_DEFAULTS`. | 0 (was hidden by `Control<any>`) |
| `dfcb6cc6` | Replace `Control<any>` in `LobbyConfigSection` / `ApprovalConfigSection` / `DiscordConfigSection` with generic constraints. Verified TS catches `name="allow_active_mr"` typo via TS2820 `Did you mean` suggestion. | 0 (forward-fixing) |

## Result
- **108 → 33** app-code TS errors. Zero in the form modals or section components.
- Two real product bugs fixed (silent admin-checkbox data loss; herodraft kicked path no-op).
- Future field-name typos in event form sections are now compile errors with `Did you mean` suggestions.
- Zero intentional runtime change in the typing commits.

## Out of scope (documented as follow-up)
- 32 remaining app-code TS errors across `axios.tsx`, `bracketAPI.tsx`, `DiscordLogSection.tsx`, `teamTable.tsx`, etc. — unrelated to forms.

## Test plan
- [ ] `just frontend::tsc` shows 33 errors (down from 108)
- [ ] `just test::pw::spec 02-create-event` passes — create event with various approval checkboxes
- [ ] `just test::pw::spec 10-edit-league-and-event-fields` passes — edit event
- [ ] `just test::pw::spec herodraft-captain-connection` passes — kick path goes through the corrected disconnect branch
- [ ] Manual: open Event Create modal, check "Require Friend ID" / "Require verified MMR" / "Require complete profile", submit, verify the values land on the created event via API or signup flow
- [ ] Sanity: deliberately introduce a `name="typo"` in any of the three section components and confirm TS errors with `Did you mean` suggestion