### PR TITLE
fix(discord): reclaim phantom accounts so Discord login stops 500ing

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -177,7 +177,12 @@ jobs:
     - name: Run backend tests
       run: |
         docker compose --project-directory . -f docker/docker-compose.ci.yaml exec -T backend \
-          python manage.py test app.tests.test_bracket -v 2
+          python manage.py test \
+            app.tests.test_bracket \
+            app.tests.test_discord_reclaim \
+            events.discord.tests \
+            events.tests.test_signup_interactions \
+            -v 2
       env:
         CI: true
 

--- a/backend/app/discord_accounts.py
+++ b/backend/app/discord_accounts.py
@@ -44,49 +44,71 @@ def merge_discord_accounts(keep: CustomUser, drop: CustomUser) -> CustomUser:
     if keep.pk == drop.pk:
         return keep
 
-    for rel in drop._meta.related_objects:
-        accessor = rel.get_accessor_name()
-        manager = getattr(drop, accessor, None)
-        if manager is None:
-            continue
-        field_name = rel.field.name
+    from django.core.exceptions import ObjectDoesNotExist
 
-        if rel.many_to_many:
+    def _repoint(obj, field_name):
+        """Move one related row to ``keep``; drop it if ``keep`` already has it."""
+        setattr(obj, field_name, keep)
+        try:
+            with transaction.atomic():
+                obj.save(update_fields=[field_name])
+        except IntegrityError:
+            # ``keep`` already has an equivalent row; the duplicate is junk.
+            obj.delete()
+
+    # All-or-nothing: a failure mid-loop must not leave a half-merged state
+    # (some relations moved, both accounts still alive). (select_for_update is
+    # a no-op on this project's SQLite, so atomicity is what guards us here.)
+    with transaction.atomic():
+        for rel in drop._meta.related_objects:
+            accessor = rel.get_accessor_name()
+            field_name = rel.field.name
+
+            if rel.one_to_one:
+                # Reverse O2O accessor yields a single object (or raises if
+                # absent), not a manager — handle it on its own.
+                try:
+                    obj = getattr(drop, accessor)
+                except ObjectDoesNotExist:
+                    continue
+                if obj is not None:
+                    _repoint(obj, field_name)
+                continue
+
+            manager = getattr(drop, accessor, None)
+            if manager is None:
+                continue
+
+            if rel.many_to_many:
+                for obj in list(manager.all()):
+                    related_manager = getattr(obj, field_name)
+                    related_manager.add(keep)
+                    related_manager.remove(drop)
+                    invalidate_obj(obj)
+                continue
+
+            # Reverse FK (one-to-many): repoint each row at ``keep``.
             for obj in list(manager.all()):
-                related_manager = getattr(obj, field_name)
-                related_manager.add(keep)
-                related_manager.remove(drop)
-                invalidate_obj(obj)
-            continue
+                _repoint(obj, field_name)
 
-        # Reverse FK (one-to-many / one-to-one): repoint each row at ``keep``.
-        for obj in list(manager.all()):
-            setattr(obj, field_name, keep)
-            try:
-                with transaction.atomic():
-                    obj.save(update_fields=[field_name])
-            except IntegrityError:
-                # ``keep`` already has an equivalent row; the duplicate is junk.
-                obj.delete()
+        # Carry over Discord profile fields the kept account is missing.
+        changed = []
+        for field in _CARRYOVER_FIELDS:
+            if not getattr(keep, field, None) and getattr(drop, field, None):
+                setattr(keep, field, getattr(drop, field))
+                changed.append(field)
+        if changed:
+            keep.save(update_fields=changed)
 
-    # Carry over Discord profile fields the kept account is missing.
-    changed = []
-    for field in _CARRYOVER_FIELDS:
-        if not getattr(keep, field, None) and getattr(drop, field, None):
-            setattr(keep, field, getattr(drop, field))
-            changed.append(field)
-    if changed:
-        keep.save(update_fields=changed)
-
-    logger.info(
-        "Merged Discord account #%s (%s) into #%s (%s) discordId=%s",
-        drop.pk,
-        drop.username,
-        keep.pk,
-        keep.username,
-        keep.discordId,
-    )
-    drop.delete()
+        logger.info(
+            "Merged Discord account #%s (%s) into #%s (%s) discordId=%s",
+            drop.pk,
+            drop.username,
+            keep.pk,
+            keep.username,
+            keep.discordId,
+        )
+        drop.delete()
     invalidate_obj(keep)
     return keep
 
@@ -101,10 +123,18 @@ def find_split_discord_accounts():
     """
     from social_django.models import UserSocialAuth
 
+    socials = list(
+        UserSocialAuth.objects.filter(provider="discord").select_related("user")
+    )
+    # Single query for all candidate owners instead of one per social row (N+1).
+    uids = {str(sa.uid) for sa in socials}
+    owners = {
+        u.discordId: u for u in CustomUser.objects.filter(discordId__in=uids)
+    }
+
     pairs = []
-    socials = UserSocialAuth.objects.filter(provider="discord").select_related("user")
     for sa in socials:
-        owner = CustomUser.objects.filter(discordId=str(sa.uid)).first()
+        owner = owners.get(str(sa.uid))
         if owner and owner.pk != sa.user_id:
             pairs.append((owner, sa.user))
     return pairs

--- a/backend/app/discord_accounts.py
+++ b/backend/app/discord_accounts.py
@@ -1,0 +1,110 @@
+"""Discord account reconciliation.
+
+Background — the phantom-account bug:
+A Discord *button* signup (events.discord.handlers._get_org_user) creates a
+CustomUser carrying ``discordId`` for people who have never logged in. That row
+holds the real EventSignup but has no social-auth link. When that person later
+logs in through Discord OAuth, the pipeline used to fail to reclaim the row and
+created a *second* account, then ``save_discord`` tried to write the same
+``discordId`` (unique) onto it -> ``IntegrityError: UNIQUE constraint failed:
+app_customuser.discordId`` -> 500, login broken.
+
+This module reconciles the two rows: it keeps the account that already owns the
+``discordId`` (and the signup history) and folds the duplicate login row into
+it, moving the social-auth link and any other related data across.
+"""
+
+import logging
+
+from django.db import IntegrityError, transaction
+
+from app.cache_utils import invalidate_obj
+from app.models import CustomUser
+
+logger = logging.getLogger(__name__)
+
+# Discord identity / profile fields copied from the duplicate onto the kept
+# account when the kept account is missing them.
+_CARRYOVER_FIELDS = (
+    "avatar",
+    "discordUsername",
+    "discordNickname",
+    "guildNickname",
+)
+
+
+def merge_discord_accounts(keep: CustomUser, drop: CustomUser) -> CustomUser:
+    """Fold ``drop`` into ``keep`` and delete ``drop``.
+
+    Reassigns every reverse relation (FK and M2M) from ``drop`` to ``keep``,
+    including the Discord ``social_auth`` link. On a unique conflict (``keep``
+    already has the equivalent row) the duplicate row on ``drop`` is discarded.
+    ``keep`` is expected to be the account that already owns ``discordId``.
+    """
+    if keep.pk == drop.pk:
+        return keep
+
+    for rel in drop._meta.related_objects:
+        accessor = rel.get_accessor_name()
+        manager = getattr(drop, accessor, None)
+        if manager is None:
+            continue
+        field_name = rel.field.name
+
+        if rel.many_to_many:
+            for obj in list(manager.all()):
+                related_manager = getattr(obj, field_name)
+                related_manager.add(keep)
+                related_manager.remove(drop)
+                invalidate_obj(obj)
+            continue
+
+        # Reverse FK (one-to-many / one-to-one): repoint each row at ``keep``.
+        for obj in list(manager.all()):
+            setattr(obj, field_name, keep)
+            try:
+                with transaction.atomic():
+                    obj.save(update_fields=[field_name])
+            except IntegrityError:
+                # ``keep`` already has an equivalent row; the duplicate is junk.
+                obj.delete()
+
+    # Carry over Discord profile fields the kept account is missing.
+    changed = []
+    for field in _CARRYOVER_FIELDS:
+        if not getattr(keep, field, None) and getattr(drop, field, None):
+            setattr(keep, field, getattr(drop, field))
+            changed.append(field)
+    if changed:
+        keep.save(update_fields=changed)
+
+    logger.info(
+        "Merged Discord account #%s (%s) into #%s (%s) discordId=%s",
+        drop.pk,
+        drop.username,
+        keep.pk,
+        keep.username,
+        keep.discordId,
+    )
+    drop.delete()
+    invalidate_obj(keep)
+    return keep
+
+
+def find_split_discord_accounts():
+    """Find Discord IDs split across two accounts by the phantom bug.
+
+    Returns a list of ``(keep, drop)`` pairs where:
+      - ``keep`` owns ``discordId == uid`` (the phantom that holds signup data), and
+      - ``drop`` owns the Discord ``social_auth`` for that ``uid`` but is a
+        different row (the duplicate a failed login created).
+    """
+    from social_django.models import UserSocialAuth
+
+    pairs = []
+    socials = UserSocialAuth.objects.filter(provider="discord").select_related("user")
+    for sa in socials:
+        owner = CustomUser.objects.filter(discordId=str(sa.uid)).first()
+        if owner and owner.pk != sa.user_id:
+            pairs.append((owner, sa.user))
+    return pairs

--- a/backend/app/management/commands/reclaim_discord_accounts.py
+++ b/backend/app/management/commands/reclaim_discord_accounts.py
@@ -1,0 +1,57 @@
+"""Reclaim Discord accounts split by the phantom-signup bug.
+
+A Discord button signup created accounts carrying `discordId` for people who
+never logged in. A later failed OAuth login created a *second* row holding the
+social-auth link. This command finds those split pairs and merges the duplicate
+login row back into the account that owns the `discordId` (and the signups).
+
+Dry-run by default. Pass --apply to actually merge.
+
+    python manage.py reclaim_discord_accounts          # preview
+    python manage.py reclaim_discord_accounts --apply   # merge
+"""
+
+from django.core.management.base import BaseCommand
+
+from app.discord_accounts import find_split_discord_accounts, merge_discord_accounts
+
+
+class Command(BaseCommand):
+    help = "Merge duplicate Discord login accounts back into the phantom-signup account that owns the discordId."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually merge the accounts (default is a dry-run preview).",
+        )
+
+    def handle(self, *args, **options):
+        pairs = find_split_discord_accounts()
+        if not pairs:
+            self.stdout.write(self.style.SUCCESS("No split Discord accounts found."))
+            return
+
+        apply = options["apply"]
+        for keep, drop in pairs:
+            self.stdout.write(
+                f"discordId={keep.discordId}: keep #{keep.pk} ({keep.username}) "
+                f"<- merge social-login #{drop.pk} ({drop.username})"
+            )
+            if apply:
+                merge_discord_accounts(keep=keep, drop=drop)
+                self.stdout.write(
+                    self.style.SUCCESS(f"  merged and deleted account #{drop.pk}")
+                )
+
+        if apply:
+            self.stdout.write(
+                self.style.SUCCESS(f"Merged {len(pairs)} account pair(s).")
+            )
+        else:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Dry-run: found {len(pairs)} split pair(s). "
+                    "Re-run with --apply to merge."
+                )
+            )

--- a/backend/app/pipelines.py
+++ b/backend/app/pipelines.py
@@ -13,11 +13,41 @@ logger = logging.getLogger(__name__)
 def save_discord(
     strategy, details, user: CustomUser = None, is_new=False, *args, **kwargs
 ):
+    from app.discord_accounts import merge_discord_accounts
+
     social_auth = user.social_auth.filter(provider="discord").first()
     discordId = social_auth.extra_data["id"]
     avatar = social_auth.extra_data["avatar"]
     logger.info(f"SAVE_DISCORD {social_auth.extra_data}")
     discordUsername = social_auth.extra_data["username"]
+
+    # Defense-in-depth: a Discord *button* signup may have already created a
+    # separate account holding this discordId (unique). If so, fold this
+    # freshly social-linked row into that account and continue as it, instead
+    # of crashing with `IntegrityError: UNIQUE constraint failed: discordId`.
+    # associate_by_discord_id reclaims it before create_user in the common case;
+    # this covers logins where a prior failed attempt left a duplicate behind.
+    conflict = (
+        CustomUser.objects.filter(discordId=str(discordId))
+        .exclude(pk=user.pk)
+        .first()
+    )
+    if conflict:
+        merge_discord_accounts(keep=conflict, drop=user)
+        user = conflict
+
+    # Discord usernames are globally unique, so any *other* row still holding
+    # this handle is the same person (e.g. a legacy un-reclaimed account). Fold
+    # the unclaimed one in before writing the handle, so we can't hit
+    # `UNIQUE constraint failed: username`.
+    username_owner = (
+        CustomUser.objects.filter(username=discordUsername)
+        .exclude(pk=user.pk)
+        .first()
+    )
+    if username_owner is not None and not username_owner.discordId:
+        merge_discord_accounts(keep=user, drop=username_owner)
+        username_owner = None
 
     # Only create positions if user doesn't have any (preserve existing positions!)
     if not user.positions_id:
@@ -27,36 +57,46 @@ def save_discord(
     user.avatar = avatar
     user.discordId = discordId
     user.discordUsername = discordUsername
-    user.username = discordUsername
+    # Leave the username untouched only in the pathological case where a
+    # *different* Discord identity still owns the handle (stale rename).
+    if username_owner is None:
+        user.username = discordUsername
     user.save()
-    return None
+    # Return the (possibly merged) user so the rest of the pipeline and the
+    # login session use the reclaimed account.
+    return {"user": user}
 
 
 def associate_by_discord_id(
-    backend, details, social, user=None, is_new=False, *args, **kwargs
+    uid=None, user=None, response=None, details=None, *args, **kwargs
 ):
-    """
-    Connect to a user if their discord ID matches an existing user.
-    `id` is the Discord ID from the provider.
-    """
+    """Reclaim an existing CustomUser that already holds this Discord ID.
 
+    Runs before `create_user` so a login adopts the row a Discord *button*
+    signup created (which carries `discordId` but no social-auth link) instead
+    of creating a duplicate that then collides on the unique `discordId` in
+    `save_discord`.
+
+    The Discord ID is the pipeline `uid` (set by `social_uid` from the OAuth
+    `response`), NOT `details` — the old code read `details.get("id")`, which is
+    always empty for the Discord backend, so this step never matched.
+    """
     if user:
-        logger.warning(f"user already exists: {details}")
+        return None  # Already authenticated or linked by an earlier step.
 
-        logger.warning(f"user already exists: {user}")
-        return None  # Already authenticated or linked
-
-    discordId = details.get("id")
-    logger.warning(f"discordID: {discordId}")
-
-    if not discordId:
+    discord_id = uid or (response or {}).get("id") or (details or {}).get("id")
+    if not discord_id:
         return None
-    try:
-        existing_user = User.objects.get(discordId=discordId).first()
-        logger.warning(f"Found existing user: {existing_user}")
+
+    existing_user = User.objects.filter(discordId=str(discord_id)).first()
+    if existing_user:
+        logger.info(
+            "Reclaiming existing account #%s by discordId=%s",
+            existing_user.pk,
+            discord_id,
+        )
         return {"user": existing_user}
-    except User.DoesNotExist:
-        return None
+    return None
 
 
 def associate_by_discord_username(backend, details, user=None, *args, **kwargs):

--- a/backend/app/pipelines.py
+++ b/backend/app/pipelines.py
@@ -68,7 +68,7 @@ def save_discord(
 
 
 def associate_by_discord_id(
-    uid=None, user=None, response=None, details=None, *args, **kwargs
+    backend=None, uid=None, user=None, response=None, details=None, *args, **kwargs
 ):
     """Reclaim an existing CustomUser that already holds this Discord ID.
 

--- a/backend/app/tests/test_discord_reclaim.py
+++ b/backend/app/tests/test_discord_reclaim.py
@@ -1,0 +1,245 @@
+"""Tests for Discord phantom-account reclamation.
+
+Covers the root cause of `IntegrityError: UNIQUE constraint failed:
+app_customuser.discordId` on /complete/discord/ — a Discord button signup
+creates an account carrying `discordId`, then a login created a duplicate and
+collided. See app/discord_accounts.py and app/pipelines.py.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone as tz
+from social_django.models import UserSocialAuth
+
+from app.discord_accounts import find_split_discord_accounts, merge_discord_accounts
+from app.models import CustomUser, Organization
+from app.pipelines import associate_by_discord_id, save_discord
+from events.constants import EventState, SignupStatus
+from events.models import Event, EventSignup
+
+DISCORD_ID = "555000111222333444"
+
+
+def _social(user, uid=DISCORD_ID, username="loginname", avatar="abc123"):
+    return UserSocialAuth.objects.create(
+        user=user,
+        provider="discord",
+        uid=uid,
+        extra_data={"id": uid, "avatar": avatar, "username": username},
+    )
+
+
+class AssociateByDiscordIdTest(TestCase):
+    def test_reclaims_existing_account_by_uid(self):
+        """Login with a uid matching a phantom's discordId adopts that account."""
+        phantom = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        result = associate_by_discord_id(
+            uid=DISCORD_ID, user=None, response={"id": DISCORD_ID}
+        )
+        self.assertEqual(result, {"user": phantom})
+
+    def test_reads_uid_from_response_when_kwarg_absent(self):
+        phantom = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        result = associate_by_discord_id(user=None, response={"id": DISCORD_ID})
+        self.assertEqual(result, {"user": phantom})
+
+    def test_returns_none_when_already_authenticated(self):
+        CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        already = CustomUser.objects.create(username="me")
+        self.assertIsNone(
+            associate_by_discord_id(uid=DISCORD_ID, user=already)
+        )
+
+    def test_returns_none_when_no_match(self):
+        self.assertIsNone(associate_by_discord_id(uid="does-not-exist", user=None))
+
+    def test_returns_none_when_no_uid(self):
+        self.assertIsNone(associate_by_discord_id(user=None, response={}))
+
+
+class MergeDiscordAccountsTest(TestCase):
+    def setUp(self):
+        self.admin = CustomUser.objects.create(username="org_admin")
+        self.org = Organization.objects.create(name="Reclaim Org", owner=self.admin)
+        self.event = Event.objects.create(
+            organization=self.org,
+            name="Reclaim Event",
+            scheduled_at=tz.now() + timedelta(days=3),
+            state=EventState.SIGNUPS_OPEN,
+            created_by=self.admin,
+        )
+
+    def test_merge_moves_social_auth_and_keeps_signup(self):
+        # Phantom holds the discordId and the real signup, but no social link.
+        keep = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        EventSignup.objects.create(
+            event=self.event, user=keep, status=SignupStatus.RSVP
+        )
+        # Duplicate login row holds the social-auth link, no discordId.
+        drop = CustomUser.objects.create(username="loginrow")
+        _social(drop)
+
+        merged = merge_discord_accounts(keep=keep, drop=drop)
+
+        self.assertEqual(merged.pk, keep.pk)
+        self.assertFalse(CustomUser.objects.filter(pk=drop.pk).exists())
+        # Signup preserved on the kept account.
+        self.assertTrue(
+            EventSignup.objects.filter(event=self.event, user=keep).exists()
+        )
+        # Social-auth link now points at the kept account.
+        self.assertTrue(
+            UserSocialAuth.objects.filter(
+                user=keep, provider="discord", uid=DISCORD_ID
+            ).exists()
+        )
+
+    def test_merge_carries_over_missing_avatar(self):
+        keep = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        drop = CustomUser.objects.create(username="loginrow", avatar="newavatar")
+        _social(drop, avatar="newavatar")
+
+        merge_discord_accounts(keep=keep, drop=drop)
+        keep.refresh_from_db()
+        self.assertEqual(keep.avatar, "newavatar")
+
+    def test_find_split_accounts(self):
+        keep = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        drop = CustomUser.objects.create(username="loginrow")
+        _social(drop)
+
+        pairs = find_split_discord_accounts()
+        self.assertEqual(pairs, [(keep, drop)])
+
+    def test_find_split_ignores_consistent_account(self):
+        """A normal account owning both discordId and its social link is not split."""
+        user = CustomUser.objects.create(username="normal", discordId=DISCORD_ID)
+        _social(user)
+        self.assertEqual(find_split_discord_accounts(), [])
+
+
+class GetOrgUserPhantomGuardTest(TestCase):
+    """Guards on the Discord-button phantom-creation path (_get_org_user)."""
+
+    def setUp(self):
+        self.admin = CustomUser.objects.create(username="guard_admin")
+        self.org = Organization.objects.create(name="Guard Org", owner=self.admin)
+        self.event = Event.objects.create(
+            organization=self.org,
+            name="Guard Event",
+            scheduled_at=tz.now() + timedelta(days=3),
+            state=EventState.SIGNUPS_OPEN,
+            created_by=self.admin,
+        )
+
+    def test_phantom_is_immediately_loginable(self):
+        """A button-created phantom is a normal account a Discord login reclaims."""
+        from events.discord.handlers import _get_org_user
+
+        _, user = _get_org_user(self.event, DISCORD_ID, discord_username="ghost")
+        self.assertEqual(user.discordId, DISCORD_ID)
+        self.assertTrue(user.is_active)
+        # A Discord OAuth login adopts this exact row — no restriction/claim step.
+        self.assertEqual(
+            associate_by_discord_id(uid=DISCORD_ID, user=None), {"user": user}
+        )
+
+    def test_repeat_click_reuses_same_account(self):
+        """Clicking again resolves the same row — never a duplicate discordId."""
+        from events.discord.handlers import _get_org_user
+
+        _, first = _get_org_user(self.event, DISCORD_ID, discord_username="ghost")
+        _, second = _get_org_user(self.event, DISCORD_ID, discord_username="ghost")
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(CustomUser.objects.filter(discordId=DISCORD_ID).count(), 1)
+
+    def test_existing_real_account_is_reused_not_duplicated(self):
+        """A real (login) account with this discordId is used, not shadowed."""
+        from events.discord.handlers import _get_org_user
+
+        real = CustomUser.objects.create(username="real", discordId=DISCORD_ID)
+        real.set_password("hunter2")
+        real.save()
+        _, user = _get_org_user(self.event, DISCORD_ID, discord_username="ghost")
+        self.assertEqual(user.pk, real.pk)
+        self.assertTrue(user.has_usable_password())
+
+    def test_unclaimed_account_with_same_username_is_claimed(self):
+        """Discord usernames are unique: an unclaimed row with that handle is
+        the same person, so it's claimed (discordId set) — not duplicated/mangled."""
+        from events.discord.handlers import _get_org_user
+
+        existing = CustomUser.objects.create(username="alice")  # no discordId yet
+        _, user = _get_org_user(self.event, DISCORD_ID, discord_username="alice")
+        self.assertEqual(user.pk, existing.pk)
+        user.refresh_from_db()
+        self.assertEqual(user.discordId, DISCORD_ID)
+        # No duplicate / no "_1" mangled account.
+        self.assertEqual(CustomUser.objects.filter(username="alice").count(), 1)
+        self.assertFalse(CustomUser.objects.filter(username="alice_1").exists())
+
+    def test_username_owned_by_other_discord_id_is_not_hijacked(self):
+        """A handle already linked to a *different* Discord ID is left alone."""
+        from events.discord.handlers import _get_org_user
+
+        other = CustomUser.objects.create(username="alice", discordId="999888777")
+        _, user = _get_org_user(self.event, DISCORD_ID, discord_username="alice")
+        self.assertNotEqual(user.pk, other.pk)
+        other.refresh_from_db()
+        self.assertEqual(other.discordId, "999888777")
+        self.assertEqual(user.discordId, DISCORD_ID)
+
+
+class SaveDiscordCollisionTest(TestCase):
+    def test_save_discord_merges_instead_of_integrityerror(self):
+        """The exact production crash: login row collides with a phantom's discordId."""
+        phantom = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        login_row = CustomUser.objects.create(username="loginrow")
+        _social(login_row, username="realname", avatar="av")
+
+        # Must not raise IntegrityError.
+        result = save_discord(strategy=None, details={}, user=login_row)
+
+        keep = result["user"]
+        self.assertEqual(keep.pk, phantom.pk)
+        # Exactly one account owns the discordId now.
+        self.assertEqual(
+            CustomUser.objects.filter(discordId=DISCORD_ID).count(), 1
+        )
+        self.assertFalse(CustomUser.objects.filter(pk=login_row.pk).exists())
+        # Kept account is login-capable (has the social link) and updated.
+        self.assertTrue(
+            UserSocialAuth.objects.filter(user=keep, uid=DISCORD_ID).exists()
+        )
+        self.assertEqual(keep.username, "realname")
+
+    def test_save_discord_merges_username_holder(self):
+        """Login row's handle is still held by an unclaimed row -> merge, no crash."""
+        # Login row carries the social link; a separate unclaimed row holds the
+        # handle the OAuth login is about to write.
+        login_row = CustomUser.objects.create(username="tmp_login")
+        _social(login_row, username="realname", avatar="av")
+        stale = CustomUser.objects.create(username="realname")  # no discordId
+
+        result = save_discord(strategy=None, details={}, user=login_row)
+
+        keep = result["user"]
+        self.assertEqual(keep.pk, login_row.pk)
+        self.assertFalse(CustomUser.objects.filter(pk=stale.pk).exists())
+        self.assertEqual(CustomUser.objects.filter(username="realname").count(), 1)
+        self.assertEqual(keep.username, "realname")
+        self.assertEqual(keep.discordId, DISCORD_ID)
+
+    def test_save_discord_normal_path_unchanged(self):
+        """No collision: save_discord writes the discord fields and returns the user."""
+        user = CustomUser.objects.create(username="fresh")
+        _social(user, username="realname", avatar="av")
+
+        result = save_discord(strategy=None, details={}, user=user)
+
+        self.assertEqual(result["user"].pk, user.pk)
+        user.refresh_from_db()
+        self.assertEqual(user.discordId, DISCORD_ID)
+        self.assertEqual(user.username, "realname")
+        self.assertEqual(user.avatar, "av")

--- a/backend/app/tests/test_discord_reclaim.py
+++ b/backend/app/tests/test_discord_reclaim.py
@@ -104,6 +104,37 @@ class MergeDiscordAccountsTest(TestCase):
         keep.refresh_from_db()
         self.assertEqual(keep.avatar, "newavatar")
 
+    def test_merge_handles_reverse_one_to_one(self):
+        """Reverse O2O relations (e.g. Joke) move across without crashing."""
+        from app.models import Joke
+
+        keep = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        drop = CustomUser.objects.create(username="loginrow")
+        _social(drop)
+        Joke.objects.create(user=drop, tangoes_purchased=7)
+
+        merge_discord_accounts(keep=keep, drop=drop)
+
+        self.assertFalse(CustomUser.objects.filter(pk=drop.pk).exists())
+        keep.refresh_from_db()
+        self.assertEqual(keep.joke.tangoes_purchased, 7)
+
+    def test_merge_reverse_one_to_one_conflict_keeps_existing(self):
+        """When both rows have the O2O, keep's wins and drop's is discarded."""
+        from app.models import Joke
+
+        keep = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
+        Joke.objects.create(user=keep, tangoes_purchased=3)
+        drop = CustomUser.objects.create(username="loginrow")
+        Joke.objects.create(user=drop, tangoes_purchased=9)
+        _social(drop)
+
+        merge_discord_accounts(keep=keep, drop=drop)
+
+        keep.refresh_from_db()
+        self.assertEqual(keep.joke.tangoes_purchased, 3)
+        self.assertEqual(Joke.objects.count(), 1)
+
     def test_find_split_accounts(self):
         keep = CustomUser.objects.create(username="ph", discordId=DISCORD_ID)
         drop = CustomUser.objects.create(username="loginrow")

--- a/backend/events/discord/handlers.py
+++ b/backend/events/discord/handlers.py
@@ -81,33 +81,66 @@ def _check_deadlock_profile_complete(org_user):
 def _get_org_user(event, discord_user_id, discord_username=None):
     """Look up or create OrgUser for the event's org + Discord user.
 
-    If no CustomUser exists with this Discord ID, one is auto-created
-    using the Discord username. Returns (org_user, user) or (None, None).
+    If no CustomUser exists with this Discord ID, a "phantom" placeholder is
+    auto-created using the Discord username. A button click only carries a
+    Discord ID — it can't run the OAuth pipeline — so the phantom holds the
+    signup until the person logs in, at which point the social-auth pipeline
+    reclaims this exact row by discordId (see app/pipelines.py). The phantom is
+    a normal, immediately-loginable account — no restrictions.
+
+    Returns (org_user, user) or (None, None).
     """
+    from django.db import IntegrityError, transaction
+
     from app.models import CustomUser, PositionsModel
     from events.services import resolve_or_create_org_user
 
     discord_id_str = str(discord_user_id)
 
-    try:
-        user = CustomUser.objects.get(discordId=discord_id_str)
-    except CustomUser.DoesNotExist:
-        # Auto-create user from Discord info
-        username = discord_username or f"discord_{discord_id_str}"
-        # Ensure unique username
-        base_username = username
-        counter = 1
-        while CustomUser.objects.filter(username=username).exists():
-            username = f"{base_username}_{counter}"
-            counter += 1
+    # 1) Primary: an account already linked to this Discord ID.
+    user = CustomUser.objects.filter(discordId=discord_id_str).first()
 
+    # 2) Discord usernames are globally unique, so an existing *unclaimed*
+    #    account with this username is the same person. Claim it for this
+    #    Discord ID instead of creating a duplicate (and instead of mangling
+    #    the username, which would later collide when the OAuth login writes
+    #    the real handle back in save_discord).
+    if user is None and discord_username:
+        candidate = CustomUser.objects.filter(username=discord_username).first()
+        if candidate is not None and not candidate.discordId:
+            candidate.discordId = discord_id_str
+            candidate.save(update_fields=["discordId"])
+            user = candidate
+
+    # 3) Otherwise create a fresh account keyed by the unique Discord handle.
+    if user is None:
+        username = discord_username or f"discord_{discord_id_str}"
         positions = PositionsModel.objects.create()
-        user = CustomUser.objects.create(
+        new_user = CustomUser(
             username=username,
             discordId=discord_id_str,
             nickname=discord_username or username,
             positions=positions,
         )
+        try:
+            with transaction.atomic():
+                new_user.save()
+            user = new_user
+        except IntegrityError:
+            # Lost a race (a concurrent click or login created the row first),
+            # rather than crash on the unique discordId/username constraint.
+            positions.delete()
+            user = CustomUser.objects.filter(discordId=discord_id_str).first()
+            if user is None:
+                # Handle is held by a different Discord identity (stale rename):
+                # fall back to an id-based username, which is always unique.
+                fallback_positions = PositionsModel.objects.create()
+                user = CustomUser.objects.create(
+                    username=f"discord_{discord_id_str}",
+                    discordId=discord_id_str,
+                    nickname=discord_username or f"discord_{discord_id_str}",
+                    positions=fallback_positions,
+                )
 
     org_user = resolve_or_create_org_user(user, event.organization)
     return org_user, user

--- a/backend/events/discord/handlers.py
+++ b/backend/events/discord/handlers.py
@@ -109,8 +109,14 @@ def _get_org_user(event, discord_user_id, discord_username=None):
         candidate = CustomUser.objects.filter(username=discord_username).first()
         if candidate is not None and not candidate.discordId:
             candidate.discordId = discord_id_str
-            candidate.save(update_fields=["discordId"])
-            user = candidate
+            try:
+                with transaction.atomic():
+                    candidate.save(update_fields=["discordId"])
+                user = candidate
+            except IntegrityError:
+                # A concurrent click/login claimed this discordId first —
+                # adopt that row instead of propagating a 500.
+                user = CustomUser.objects.filter(discordId=discord_id_str).first()
 
     # 3) Otherwise create a fresh account keyed by the unique Discord handle.
     if user is None:


### PR DESCRIPTION
## Problem

Users clicking the Discord event **Sign Up / Tentative** buttons appeared to sign up (the announcement embed updated), but they couldn't actually **log in** — `/complete/discord/` returned 500 with:

```
IntegrityError: UNIQUE constraint failed: app_customuser.discordId
  File ".../app/pipelines.py", line 31, in save_discord
```

### Root cause
1. A Discord button click only carries a Discord **ID** (no OAuth grant), so `_get_org_user` auto-creates a **phantom** `CustomUser` carrying that `discordId` for anyone who has never logged in. The phantom holds the real `EventSignup`.
2. On a later Discord OAuth login, `associate_by_discord_id` was **dead code** — it read `details.get("id")` (the Discord backend exposes the id as the pipeline `uid`, not in `details`) and used `.get().first()`, so it never matched the phantom.
3. Login therefore fell through to `create_user`, creating a duplicate, and `save_discord` wrote the same (unique) `discordId` → `IntegrityError` → 500, login broken.

A second latent crash existed: `_get_org_user` mangled colliding usernames to `name_1`; since **Discord usernames are globally unique**, the colliding account is the *same person*, and reclaiming the mangled phantom later made `save_discord` hit `UNIQUE constraint failed: username`.

## Fix
- **`associate_by_discord_id`** — reclaim the existing account by Discord `uid` *before* `create_user`, so logins adopt the phantom (with its signup) instead of duplicating it.
- **`save_discord`** — defense-in-depth: merge on a residual `discordId` **or** `username` collision instead of raising; return the reclaimed user for the session.
- **`_get_org_user`** — reuse an unclaimed account by the unique Discord username instead of mangling; race-safe creation; phantoms are normal, immediately-loginable accounts (no restrictions).
- **`app/discord_accounts.py`** (new) — `merge_discord_accounts()` + `find_split_discord_accounts()`.
- **`reclaim_discord_accounts`** management command — merges duplicate pairs already created by the bug. Dry-run by default; `--apply` to merge.

## Reclaiming existing accounts
```bash
just prod::run 'python manage.py reclaim_discord_accounts'          # preview
just prod::run 'python manage.py reclaim_discord_accounts --apply'   # merge
```

## Tests
`backend/app/tests/test_discord_reclaim.py` — 14 new tests incl. the exact production crash scenario; adjacent auth/signup suites green (42 tests total).