### PR TITLE
test(15-edit-user): per-spec isolated user + serial mark for sequential

### DIFF
--- a/.claude/skills/testing/references/feature-isolation.md
+++ b/.claude/skills/testing/references/feature-isolation.md
@@ -121,7 +121,7 @@ await visitAndWait(page, '/organizations/3/');  // Fragile!
 | League | 6 (steam=17934) | Shuffle Tie |
 | League | 7 (steam=17935) | Events |
 | Users | 1000-1099 | Site-level + roles (admin, staff, regular, claim, org roles, league roles) |
-| Users | 2000-2099 | CSV Import (2000-2004) + User Edit (2050-2052) |
+| Users | 2000-2099 | CSV Import (2000-2004) + User Edit (2050-2058) |
 | Users | 3000-3019 | Tournament 38 real users |
 | Users | 4000-4019 | Shuffle Tie (4 captains + 16 players) |
 | Users | 5000-5020 | Events (admin + 20 players) |

--- a/backend/tests/data/users.py
+++ b/backend/tests/data/users.py
@@ -464,9 +464,24 @@ CSV_IMPORT_USERS: list[TestUser] = [
 ]
 
 # =============================================================================
-# User Edit Test Users (pk=2050-2052)
-# These users are members of the User Edit Org/League/Tournament.
-# User edit E2E tests modify their fields (MMR, nickname, etc.)
+# User Edit Test Users (pk=2050-2058)
+# Members of the User Edit Org / League / Tournament.
+#
+# Independent specs each own a dedicated user (so they can run in parallel
+# without read-modify-write races on the same record). Sequential specs
+# share alpha/bravo/charlie.
+#
+# pk   | username                  | owner
+# -----|---------------------------|-----------------------------------
+# 2050 | edit_user_alpha           | sequential specs (05, 07)
+# 2051 | edit_user_bravo           | sequential specs (07 needs A+B)
+# 2052 | edit_user_charlie         | sequential reserve
+# 2053 | edit_user_org             | 01-org-edit
+# 2054 | edit_user_tournament      | 02-tournament-edit
+# 2055 | edit_user_league          | 03-league-edit
+# 2056 | edit_user_mmr             | 04-org-mmr-edit
+# 2057 | edit_user_positions       | 08-position-persistence
+# 2058 | edit_user_cache           | 10-cache-merge
 # =============================================================================
 
 USER_EDIT_USERS: list[TestUser] = [
@@ -493,6 +508,54 @@ USER_EDIT_USERS: list[TestUser] = [
         discord_id="400000000000000003",
         steam_id_64=76561198900000003,
         mmr=5200,
+    ),
+    TestUser(
+        pk=2053,
+        username="edit_user_org",
+        nickname="Edit Org",
+        discord_id="400000000000000004",
+        steam_id_64=76561198900000004,
+        mmr=3100,
+    ),
+    TestUser(
+        pk=2054,
+        username="edit_user_tournament",
+        nickname="Edit Tournament",
+        discord_id="400000000000000005",
+        steam_id_64=76561198900000005,
+        mmr=3200,
+    ),
+    TestUser(
+        pk=2055,
+        username="edit_user_league",
+        nickname="Edit League",
+        discord_id="400000000000000006",
+        steam_id_64=76561198900000006,
+        mmr=3300,
+    ),
+    TestUser(
+        pk=2056,
+        username="edit_user_mmr",
+        nickname="Edit MMR",
+        discord_id="400000000000000007",
+        steam_id_64=76561198900000007,
+        mmr=3400,
+    ),
+    TestUser(
+        pk=2057,
+        username="edit_user_positions",
+        nickname="Edit Positions",
+        discord_id="400000000000000008",
+        steam_id_64=76561198900000008,
+        mmr=3500,
+    ),
+    TestUser(
+        pk=2058,
+        username="edit_user_cache",
+        nickname="Edit Cache",
+        discord_id="400000000000000009",
+        steam_id_64=76561198900000009,
+        mmr=3600,
     ),
 ]
 

--- a/frontend/tests/playwright/e2e/15-edit-user/01-org-edit.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/01-org-edit.spec.ts
@@ -42,6 +42,10 @@ test.describe('Edit User on Organization Page (@cicd)', () => {
     await loginAdmin();
   });
 
+  // Dedicated user for this spec — never use `.first()` on usercard, that
+  // races with every other 15-edit-user spec that also picks index 0.
+  const TARGET_USERNAME = 'edit_user_org';
+
   test('@cicd smoke: edit user nickname via org user card', async ({ page }) => {
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await expect(page.locator('h1')).toBeVisible({ timeout: 15000 });
@@ -51,24 +55,18 @@ test.describe('Edit User on Organization Page (@cicd)', () => {
     await expect(usersTab).toBeVisible({ timeout: 5000 });
     await usersTab.click();
 
-    // Wait for user cards to load
-    const firstUserCard = page.locator('[data-testid^="usercard-"]').first();
-    await expect(firstUserCard).toBeVisible({ timeout: 10000 });
+    const targetCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
+    await expect(targetCard).toBeVisible({ timeout: 10000 });
 
-    // Open edit modal and read original nickname
-    await openEditModal(page, firstUserCard);
+    await openEditModal(page, targetCard);
     const originalNickname = await readEditField(page, 'nickname');
     const newNickname = originalNickname === 'TestNick' ? 'TestNickAlt' : 'TestNick';
 
     await fillEditField(page, 'nickname', newNickname);
-    // saveEditModal waits for PATCH 200 and closes the dialog
     await saveEditModal(page);
 
-    // Verify the nickname updated in the UI
-    await expect(page.getByText(newNickname).first()).toBeVisible({ timeout: 5000 });
+    await expect(targetCard.getByText(newNickname).first()).toBeVisible({ timeout: 5000 });
 
-    // Restore original value
-    const userCardAfter = page.locator('[data-testid^="usercard-"]').first();
-    await restoreUserField(page, userCardAfter, 'nickname', originalNickname);
+    await restoreUserField(page, targetCard, 'nickname', originalNickname);
   });
 });

--- a/frontend/tests/playwright/e2e/15-edit-user/02-tournament-edit.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/02-tournament-edit.spec.ts
@@ -53,25 +53,23 @@ test.describe('Edit User on Tournament Page (@cicd)', () => {
     await loginAdmin();
   });
 
+  // Dedicated user — see USER_EDIT_USERS in backend/tests/data/users.py.
+  const TARGET_USERNAME = 'edit_user_tournament';
+
   test('@cicd smoke: edit user nickname via tournament player card', async ({ page }) => {
     await visitAndWaitForHydration(page, `/tournament/${tournamentPk}`);
     await expect(page.locator('[data-testid="tournamentDetailPage"]')).toBeVisible({ timeout: 15000 });
 
-    // Players tab is the default — wait for user cards
-    const firstUserCard = page.locator('[data-testid^="usercard-"]').first();
-    await expect(firstUserCard).toBeVisible({ timeout: 10000 });
+    const targetCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
+    await expect(targetCard).toBeVisible({ timeout: 10000 });
 
-    // Open edit modal and read original nickname
-    await openEditModal(page, firstUserCard);
+    await openEditModal(page, targetCard);
     const originalNickname = await readEditField(page, 'nickname');
     const newNickname = originalNickname === 'TestNick' ? 'TestNickAlt' : 'TestNick';
 
     await fillEditField(page, 'nickname', newNickname);
-    // saveEditModal waits for PATCH 200 and closes the dialog
     await saveEditModal(page);
 
-    // Restore original value
-    const userCardAfter = page.locator('[data-testid^="usercard-"]').first();
-    await restoreUserField(page, userCardAfter, 'nickname', originalNickname);
+    await restoreUserField(page, targetCard, 'nickname', originalNickname);
   });
 });

--- a/frontend/tests/playwright/e2e/15-edit-user/03-league-edit.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/03-league-edit.spec.ts
@@ -42,33 +42,29 @@ test.describe('Edit User on League Page (@cicd)', () => {
     await loginAdmin();
   });
 
+  // Dedicated user — see USER_EDIT_USERS in backend/tests/data/users.py.
+  const TARGET_USERNAME = 'edit_user_league';
+
   test('@cicd smoke: edit user nickname via league user card', async ({ page }) => {
     await visitAndWaitForHydration(page, `/leagues/${leaguePk}`);
     await expect(page.locator('h1')).toBeVisible({ timeout: 15000 });
 
-    // Switch to Users tab
     const usersTab = page.locator('[data-testid="league-tab-users"]');
     await expect(usersTab).toBeVisible({ timeout: 5000 });
     await usersTab.click();
 
-    // Wait for user cards to load
-    const firstUserCard = page.locator('[data-testid^="usercard-"]').first();
-    await expect(firstUserCard).toBeVisible({ timeout: 10000 });
+    const targetCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
+    await expect(targetCard).toBeVisible({ timeout: 10000 });
 
-    // Open edit modal and read original nickname
-    await openEditModal(page, firstUserCard);
+    await openEditModal(page, targetCard);
     const originalNickname = await readEditField(page, 'nickname');
     const newNickname = originalNickname === 'TestNick' ? 'TestNickAlt' : 'TestNick';
 
     await fillEditField(page, 'nickname', newNickname);
-    // saveEditModal waits for PATCH 200 and closes the dialog
     await saveEditModal(page);
 
-    // Verify the nickname updated in the UI
-    await expect(page.getByText(newNickname).first()).toBeVisible({ timeout: 5000 });
+    await expect(targetCard.getByText(newNickname).first()).toBeVisible({ timeout: 5000 });
 
-    // Restore original value
-    const userCardAfter = page.locator('[data-testid^="usercard-"]').first();
-    await restoreUserField(page, userCardAfter, 'nickname', originalNickname);
+    await restoreUserField(page, targetCard, 'nickname', originalNickname);
   });
 });

--- a/frontend/tests/playwright/e2e/15-edit-user/04-org-mmr-edit.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/04-org-mmr-edit.spec.ts
@@ -42,32 +42,30 @@ test.describe('Edit User MMR on Organization Page (@cicd)', () => {
     await loginAdmin();
   });
 
+  // Dedicated user — see USER_EDIT_USERS in backend/tests/data/users.py.
+  const TARGET_USERNAME = 'edit_user_mmr';
+
   test('@cicd smoke: edit user MMR via org user card', async ({ page }) => {
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await expect(page.locator('h1')).toBeVisible({ timeout: 15000 });
 
-    // Switch to Users tab
     const usersTab = page.locator('[data-testid="org-tab-users"]');
     await expect(usersTab).toBeVisible({ timeout: 5000 });
     await usersTab.click();
 
-    // Wait for user cards to load
-    const firstUserCard = page.locator('[data-testid^="usercard-"]').first();
-    await expect(firstUserCard).toBeVisible({ timeout: 10000 });
+    const targetCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
+    await expect(targetCard).toBeVisible({ timeout: 10000 });
 
-    // Open edit modal and read original MMR
-    await openEditModal(page, firstUserCard);
+    await openEditModal(page, targetCard);
     const originalMmr = await readEditField(page, 'mmr');
     const newMmr = originalMmr === '9999' ? '8888' : '9999';
 
     await fillEditField(page, 'mmr', newMmr);
     await saveEditModal(page);
 
-    // Verify the MMR value updated in the UI (allow time for store refresh + cache invalidation)
-    await expect(page.getByText(newMmr).first()).toBeVisible({ timeout: 10000 });
+    // Allow store refresh + cache invalidation
+    await expect(targetCard.getByText(newMmr).first()).toBeVisible({ timeout: 10000 });
 
-    // Restore original value
-    const userCardAfter = page.locator('[data-testid^="usercard-"]').first();
-    await restoreUserField(page, userCardAfter, 'mmr', originalMmr);
+    await restoreUserField(page, targetCard, 'mmr', originalMmr);
   });
 });

--- a/frontend/tests/playwright/e2e/15-edit-user/05-sequential-cross-context.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/05-sequential-cross-context.spec.ts
@@ -27,7 +27,14 @@ const USER_EDIT_LEAGUE_NAME = 'User Edit League';
 let orgPk: number;
 let leaguePk: number;
 
-test.describe('Cross-Context Cache Invalidation (@cicd)', () => {
+// Sequential: this spec edits a user on the league page and then asserts
+// the new value is visible on the org page. Any parallel write on the
+// same user would invalidate the read. `.serial` forces tests within this
+// file to run in order; we also share `edit_user_alpha` with spec
+// 07-sequential-multi-user (which is also `.serial`) — see USER_EDIT_USERS.
+const TARGET_USERNAME = 'edit_user_alpha';
+
+test.describe.serial('Cross-Context Cache Invalidation (@cicd)', () => {
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext({ ignoreHTTPSErrors: true });
 
@@ -63,10 +70,10 @@ test.describe('Cross-Context Cache Invalidation (@cicd)', () => {
     await expect(usersTab).toBeVisible({ timeout: 5000 });
     await usersTab.click();
 
-    const firstUserCard = page.locator('[data-testid^="usercard-"]').first();
-    await expect(firstUserCard).toBeVisible({ timeout: 10000 });
+    const leagueCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
+    await expect(leagueCard).toBeVisible({ timeout: 10000 });
 
-    await openEditModal(page, firstUserCard);
+    await openEditModal(page, leagueCard);
     const originalNickname = await readEditField(page, 'nickname');
     const crossContextNick = originalNickname === 'CrossCtx' ? 'CrossCtxAlt' : 'CrossCtx';
 
@@ -81,11 +88,11 @@ test.describe('Cross-Context Cache Invalidation (@cicd)', () => {
     await expect(orgUsersTab).toBeVisible({ timeout: 5000 });
     await orgUsersTab.click();
 
-    const orgUserCard = page.locator('[data-testid^="usercard-"]').first();
+    const orgUserCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
     await expect(orgUserCard).toBeVisible({ timeout: 10000 });
 
     // The new nickname should be visible on the org page (cacheops invalidated)
-    await expect(page.getByText(crossContextNick).first()).toBeVisible({ timeout: 10000 });
+    await expect(orgUserCard.getByText(crossContextNick).first()).toBeVisible({ timeout: 10000 });
 
     // 3. Restore original value from the org page
     await restoreUserField(page, orgUserCard, 'nickname', originalNickname);

--- a/frontend/tests/playwright/e2e/15-edit-user/07-sequential-multi-user.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/07-sequential-multi-user.spec.ts
@@ -20,7 +20,15 @@ const USER_EDIT_ORG_NAME = 'User Edit Org';
 
 let orgPk: number;
 
-test.describe('Sequential multi-user edits (@cicd)', () => {
+// Sequential: each test in this file edits one or both shared users
+// (alpha + bravo) and the order matters (an earlier nickname change is
+// asserted against by a later test via getByText). `.serial` keeps these
+// tests in declaration order; using dedicated usernames keeps them from
+// racing with parallel specs in this directory.
+const USER_A_USERNAME = 'edit_user_alpha';
+const USER_B_USERNAME = 'edit_user_bravo';
+
+test.describe.serial('Sequential multi-user edits (@cicd)', () => {
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext({ ignoreHTTPSErrors: true });
     const orgsResp = await context.request.get(`${API_URL}/organizations/`);
@@ -40,11 +48,12 @@ test.describe('Sequential multi-user edits (@cicd)', () => {
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await page.locator('[data-testid="org-tab-users"]').click();
 
-    const userCards = page.locator('[data-testid^="usercard-"]');
-    await expect(userCards.first()).toBeVisible({ timeout: 10000 });
+    const cardA = page.locator(`[data-testid="usercard-${USER_A_USERNAME}"]`);
+    const cardB = page.locator(`[data-testid="usercard-${USER_B_USERNAME}"]`);
+    await expect(cardA).toBeVisible({ timeout: 10000 });
+    await expect(cardB).toBeVisible({ timeout: 10000 });
 
     // Edit user A: nickname + MMR
-    const cardA = userCards.nth(0);
     await openEditModal(page, cardA);
     const newNickA = `SeqA-${Date.now()}`;
     await fillEditField(page, 'nickname', newNickA);
@@ -52,7 +61,6 @@ test.describe('Sequential multi-user edits (@cicd)', () => {
     await saveEditModal(page);
 
     // Edit user B: nickname only
-    const cardB = userCards.nth(1);
     await openEditModal(page, cardB);
     const newNickB = `SeqB-${Date.now()}`;
     await fillEditField(page, 'nickname', newNickB);
@@ -61,17 +69,16 @@ test.describe('Sequential multi-user edits (@cicd)', () => {
     // Reload and verify both persist
     await page.reload();
     await page.locator('[data-testid="org-tab-users"]').click();
-    await expect(page.getByText(newNickA).first()).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText(newNickB).first()).toBeVisible({ timeout: 5000 });
+    await expect(cardA.getByText(newNickA).first()).toBeVisible({ timeout: 5000 });
+    await expect(cardB.getByText(newNickB).first()).toBeVisible({ timeout: 5000 });
   });
 
   test('@cicd PATCH body contains only dirty fields', async ({ page }) => {
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await page.locator('[data-testid="org-tab-users"]').click();
-    const userCards = page.locator('[data-testid^="usercard-"]');
-    await expect(userCards.first()).toBeVisible({ timeout: 10000 });
+    const card = page.locator(`[data-testid="usercard-${USER_A_USERNAME}"]`);
+    await expect(card).toBeVisible({ timeout: 10000 });
 
-    const card = userCards.first();
     await openEditModal(page, card);
 
     const patchPromise = page.waitForRequest(
@@ -92,7 +99,7 @@ test.describe('Sequential multi-user edits (@cicd)', () => {
   test('@cicd save with no changes does not fire a PATCH', async ({ page }) => {
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await page.locator('[data-testid="org-tab-users"]').click();
-    const card = page.locator('[data-testid^="usercard-"]').first();
+    const card = page.locator(`[data-testid="usercard-${USER_A_USERNAME}"]`);
     await expect(card).toBeVisible({ timeout: 10000 });
 
     await openEditModal(page, card);

--- a/frontend/tests/playwright/e2e/15-edit-user/08-position-persistence.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/08-position-persistence.spec.ts
@@ -35,6 +35,9 @@ test.describe('Position dropdown persistence (@cicd)', () => {
     await loginAdmin();
   });
 
+  // Dedicated user — see USER_EDIT_USERS in backend/tests/data/users.py.
+  const TARGET_USERNAME = 'edit_user_positions';
+
   test('@cicd position changes persist in PATCH and re-render correctly', async ({ page }) => {
     // Use a wider viewport so the 5-column position grid (xl:grid-cols-5
     // ≥ 1280px) renders without the SelectTrigger buttons visually overlapping
@@ -43,13 +46,13 @@ test.describe('Position dropdown persistence (@cicd)', () => {
     await page.setViewportSize({ width: 1600, height: 900 });
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await page.locator('[data-testid="org-tab-users"]').click();
-    const card = page.locator('[data-testid^="usercard-"]').first();
-    await expect(card).toBeVisible({ timeout: 10000 });
+    const targetCard = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
+    await expect(targetCard).toBeVisible({ timeout: 10000 });
 
     // Step 1: reset carry+hard_support to 0 so the next set is guaranteed to
     // make `formState.isDirty` true (the modal short-circuits and skips PATCH
     // when no fields changed; previous runs may have left non-zero values).
-    await openEditModal(page, card);
+    await openEditModal(page, targetCard);
     await setPositionField(page, 'carry', 0);
     await setPositionField(page, 'hard_support', 0);
     // Best-effort reset: if both were already 0, the modal closes without a
@@ -61,8 +64,7 @@ test.describe('Position dropdown persistence (@cicd)', () => {
     });
 
     // Step 2: now apply the real target values and assert the PATCH body.
-    const cardAfterReset = page.locator('[data-testid^="usercard-"]').first();
-    await openEditModal(page, cardAfterReset);
+    await openEditModal(page, targetCard);
     await setPositionField(page, 'carry', 1);
     await setPositionField(page, 'hard_support', 5);
 
@@ -80,7 +82,7 @@ test.describe('Position dropdown persistence (@cicd)', () => {
     expect(body.positions.hard_support).toBe(5);
 
     // Re-open and confirm the trigger displays the new selection (not placeholder)
-    await openEditModal(page, page.locator('[data-testid^="usercard-"]').first());
+    await openEditModal(page, targetCard);
     const carryDisplay = await readPositionField(page, 'carry');
     expect(carryDisplay).toContain('Favorite');
     const supportDisplay = await readPositionField(page, 'hard_support');

--- a/frontend/tests/playwright/e2e/15-edit-user/10-cache-merge.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/10-cache-merge.spec.ts
@@ -28,9 +28,12 @@ import {
 
 const API_URL = 'https://localhost/api';
 const USER_EDIT_ORG_NAME = 'User Edit Org';
+// Dedicated user for this spec — see USER_EDIT_USERS in
+// backend/tests/data/users.py. Looked up by username so parallel specs
+// in 15-edit-user/ don't race on the same record.
+const TARGET_USERNAME = 'edit_user_cache';
 let orgPk: number;
 let targetUserPk: number;
-let targetUsername: string;
 
 test.describe('User cache merge after org PATCH (@cicd)', () => {
   test.beforeAll(async ({ browser }) => {
@@ -38,18 +41,17 @@ test.describe('User cache merge after org PATCH (@cicd)', () => {
     const orgs = await (await context.request.get(`${API_URL}/organizations/`)).json();
     const orgList = Array.isArray(orgs) ? orgs : orgs.results ?? [];
     const editOrg = orgList.find((o: { name: string }) => o.name === USER_EDIT_ORG_NAME);
+    if (!editOrg) throw new Error(`Org "${USER_EDIT_ORG_NAME}" not found.`);
     orgPk = editOrg.pk;
     const usersResp = await context.request.get(`${API_URL}/organizations/${orgPk}/users/`);
     const users = await usersResp.json();
-    // Skip the global superuser (pk=1) and the org-admin actor (pk=1020) —
-    // see 09-scope-permissions.spec.ts for the same filter pattern.
     const target = users.find(
-      (u: { pk: number; username?: string }) =>
-        u.pk !== 1 && u.pk !== 1020 && u.username && u.username !== 'org_admin_tester',
+      (u: { username?: string }) => u.username === TARGET_USERNAME,
     );
-    if (!target) throw new Error('No suitable target user in User Edit Org');
+    if (!target) {
+      throw new Error(`Target user "${TARGET_USERNAME}" not in User Edit Org. Run just db::populate::all`);
+    }
     targetUserPk = target.pk;
-    targetUsername = target.username;
     await context.close();
   });
 
@@ -64,7 +66,7 @@ test.describe('User cache merge after org PATCH (@cicd)', () => {
     //    still has the username field.
     await visitAndWaitForHydration(page, `/user/${targetUserPk}`);
     await expect(
-      page.getByText(targetUsername, { exact: true }).first(),
+      page.getByText(TARGET_USERNAME, { exact: true }).first(),
     ).toBeVisible({ timeout: 10000 });
 
     // 2. Switch to the org page and edit the user. The org PATCH endpoint
@@ -73,7 +75,7 @@ test.describe('User cache merge after org PATCH (@cicd)', () => {
     //    those fields.
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await page.locator('[data-testid="org-tab-users"]').click();
-    const card = page.locator(`[data-testid="usercard-${targetUsername}"]`);
+    const card = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
     await expect(card).toBeVisible({ timeout: 10000 });
     await openEditModal(page, card);
     await fillEditField(page, 'nickname', `MergeTest-${Date.now()}`);
@@ -84,7 +86,7 @@ test.describe('User cache merge after org PATCH (@cicd)', () => {
     //    rather than replacing it.
     await visitAndWaitForHydration(page, `/user/${targetUserPk}`);
     await expect(
-      page.getByText(targetUsername, { exact: true }).first(),
+      page.getByText(TARGET_USERNAME, { exact: true }).first(),
     ).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary

The recurring \"chromium shard 3/4\" flake on the 15-edit-user suite was a shared-state race: every spec selected \`[data-testid^=\"usercard-\"]\`.first()\` and edited whoever was at index 0 (always \`edit_user_alpha\`). Two specs running concurrently across shard workers raced read-modify-write on the same record — one verifies its own write, sees the OTHER spec's value first → \`element-not-found\`.

Per the project's \`testing\` skill: **each spec must own its data**.

## What changed

### Backend — extend `USER_EDIT_USERS` from 3 to 9
\`backend/tests/data/users.py\`: pk 2050-2058. Existing alpha/bravo/charlie kept for the sequential specs; pk=2053-2058 are dedicated, one per parallel spec.

### Frontend — per-spec dedicated user + scoped assertions
Each independent spec now uses \`[data-testid=\"usercard-<dedicated>\"]\` and scopes its \`getByText()\` assertions to that card so a parallel spec's nickname can't accidentally satisfy this spec's expectation.

| Spec | Dedicated user |
|---|---|
| 01 org-edit | edit_user_org |
| 02 tournament-edit | edit_user_tournament |
| 03 league-edit | edit_user_league |
| 04 org-mmr-edit | edit_user_mmr |
| 08 position-persistence | edit_user_positions |
| 10 cache-merge | edit_user_cache |

### Sequential specs renamed + marked
- \`05-cross-context.spec.ts\` → \`05-sequential-cross-context.spec.ts\`. Tests the cache-invalidation-across-pages flow which inherently depends on write→read order. Added \`test.describe.serial\` and uses \`edit_user_alpha\`.
- \`07-sequential-multi-user.spec.ts\` already named sequential — \`test.describe.serial\` added explicitly. Uses dedicated \`edit_user_alpha\` + \`edit_user_bravo\` instead of \`nth(0)\`/\`nth(1)\`.

### Skill memory
\`feature-isolation.md\`: PK note updated to 2050-2058.

## Test plan
- [x] \`just test::pw::spec 15-edit-user\` → 14/14 passed in 1.6m locally
- [ ] CI: chromium shard 3/4 passes consistently across runs