### PR TITLE
test/components: per-row data-testid for signup + rollcall + rank-status

### DIFF
--- a/frontend/app/components/events/EventSignupModal/RankStatusRadioGroup.tsx
+++ b/frontend/app/components/events/EventSignupModal/RankStatusRadioGroup.tsx
@@ -46,6 +46,7 @@ export function RankStatusRadioGroup({
                 return (
                   <label
                     key={o.value}
+                    data-testid={`signup-rank-status-${o.value}`}
                     className={cn(
                       // ring-inset keeps the highlight inside the card's box —
                       // the modal body scrolls (overflow-y-auto) and an outside

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -841,6 +841,7 @@ function SignupsTab({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <SecondaryButton color="green" size="sm"
+                      data-testid={`approve-signup-${signup.id}`}
                       onClick={() => setApprovalSignup(signup)}
                       disabled={signupActions.approve.isPending}
                     >
@@ -852,7 +853,9 @@ function SignupsTab({
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <DestructiveButton size="sm" onClick={() => signupActions.demote.mutate(signup.id)} loading={signupActions.demote.isPending} depth={false}>
+                    <DestructiveButton size="sm"
+                      data-testid={`waitlist-signup-${signup.id}`}
+                      onClick={() => signupActions.demote.mutate(signup.id)} loading={signupActions.demote.isPending} depth={false}>
                       <ArrowDownToLine className="h-3.5 w-3.5" />
                       <span className="hidden lg:inline ml-1">Waitlist</span>
                     </DestructiveButton>
@@ -898,6 +901,7 @@ function SignupsTab({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <SecondaryButton color="green" size="sm"
+                    data-testid={`approve-signup-${signup.id}`}
                     onClick={() => setApprovalSignup(signup)}
                     disabled={signupActions.approve.isPending}
                   >
@@ -975,6 +979,7 @@ function SignupsTab({
           return (
             <UserEventStrip
               key={signup.id}
+              data-testid={`event-signup-row-${signup.id}`}
               user={user}
               dotaProfile={stripProfile}
               contextSlot={statusSlot}

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -833,6 +833,11 @@ function SignupsTab({
       {signups.map((signup, index) => {
         const user = userMap.get(signup.user);
         const position = signup.waitlist_position ?? index + 1;
+        // "Waitlist" in the UI fires the `demote` mutation on the server —
+        // moving an approved/rsvp signup down to waitlisted is conceptually
+        // a demotion. Named handler so the JSX stays readable and the
+        // semantic gap between button label and mutation name is documented.
+        const handleWaitlist = () => signupActions.demote.mutate(signup.id);
 
         const adminActions = isAdmin ? (
           <div className="flex gap-1">
@@ -855,7 +860,7 @@ function SignupsTab({
                   <TooltipTrigger asChild>
                     <DestructiveButton size="sm"
                       data-testid={`waitlist-signup-${signup.id}`}
-                      onClick={() => signupActions.demote.mutate(signup.id)} loading={signupActions.demote.isPending} depth={false}>
+                      onClick={handleWaitlist} loading={signupActions.demote.isPending} depth={false}>
                       <ArrowDownToLine className="h-3.5 w-3.5" />
                       <span className="hidden lg:inline ml-1">Waitlist</span>
                     </DestructiveButton>
@@ -877,7 +882,7 @@ function SignupsTab({
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <DestructiveButton size="sm" onClick={() => signupActions.demote.mutate(signup.id)} loading={signupActions.demote.isPending} depth={false}>
+                    <DestructiveButton size="sm" onClick={handleWaitlist} loading={signupActions.demote.isPending} depth={false}>
                       <ArrowDownToLine className="h-3.5 w-3.5" />
                       <span className="hidden lg:inline ml-1">Waitlist</span>
                     </DestructiveButton>

--- a/frontend/app/routes/rollcall.tsx
+++ b/frontend/app/routes/rollcall.tsx
@@ -547,7 +547,7 @@ function SignupStrip({
       {signup.status === 'confirmed' && (
         <DestructiveButton
           size="sm"
-          data-testid="rollcall-cancel-btn"
+          data-testid={`rollcall-cancel-btn-${signup.id}`}
           onClick={() => onRequestCancel(signup)}
           disabled={signupActions.cancel.isPending}
         >

--- a/frontend/tests/playwright/e2e/15-edit-user/09-scope-permissions.spec.ts
+++ b/frontend/tests/playwright/e2e/15-edit-user/09-scope-permissions.spec.ts
@@ -15,6 +15,11 @@ import {
 
 const API_URL = 'https://localhost/api';
 const USER_EDIT_ORG_NAME = 'User Edit Org';
+// Pin to a specific dedicated user so the test is deterministic instead of
+// depending on whatever happens to be at index 0 in the org's users list.
+// edit_user_alpha is a non-staff member of User Edit Org — perfect target
+// for "non-superuser, non-actor" visibility assertions.
+const TARGET_USERNAME = 'edit_user_alpha';
 let orgPk: number;
 let targetUserPk: number;
 
@@ -24,16 +29,13 @@ test.describe('Scope permissions (@cicd)', () => {
     const orgs = await (await context.request.get(`${API_URL}/organizations/`)).json();
     const orgList = Array.isArray(orgs) ? orgs : orgs.results ?? [];
     const editOrg = orgList.find((o: { name: string }) => o.name === USER_EDIT_ORG_NAME);
+    if (!editOrg) throw new Error(`Org "${USER_EDIT_ORG_NAME}" not found. Run just db::populate::all`);
     orgPk = editOrg.pk;
     const usersResp = await context.request.get(`${API_URL}/organizations/${orgPk}/users/`);
     const users = await usersResp.json();
-    // Pick a target user that is neither the test actor (pk=1020 / org_admin_tester)
-    // nor the global admin (pk=1, who has is_superuser=true and would render the
-    // edit button regardless of scope, defeating the assertion).
-    targetUserPk = users.find(
-      (u: any) =>
-        u.pk !== 1020 && u.pk !== 1 && u.username !== 'org_admin_tester'
-    ).pk;
+    const target = users.find((u: { username?: string }) => u.username === TARGET_USERNAME);
+    if (!target) throw new Error(`Target user "${TARGET_USERNAME}" not in User Edit Org`);
+    targetUserPk = target.pk;
     await context.close();
   });
 
@@ -44,7 +46,7 @@ test.describe('Scope permissions (@cicd)', () => {
     await loginOrgAdmin();
     await visitAndWaitForHydration(page, `/organizations/${orgPk}`);
     await page.locator('[data-testid="org-tab-users"]').click();
-    const card = page.locator('[data-testid^="usercard-"]').first();
+    const card = page.locator(`[data-testid="usercard-${TARGET_USERNAME}"]`);
     await expect(card).toBeVisible({ timeout: 10000 });
     await expect(card.locator('[data-testid="edit-user-btn"]')).toBeVisible();
   });

--- a/frontend/tests/playwright/e2e/16-events/03-roll-call.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/03-roll-call.spec.ts
@@ -114,7 +114,7 @@ test.describe.serial('Roll Call Flow (@cicd)', () => {
     await page.waitForURL(/\/rollcall\//);
 
     // Confirmed player has the new Remove (cancel) button — verify dialog opens.
-    const removeBtn = page.getByTestId('rollcall-cancel-btn').first();
+    const removeBtn = page.getByTestId(`rollcall-cancel-btn-${signup.id}`);
     await expect(removeBtn).toBeVisible();
     await removeBtn.click();
     await expect(page.getByTestId('rollcall-cancel-summary')).toBeVisible();
@@ -122,7 +122,7 @@ test.describe.serial('Roll Call Flow (@cicd)', () => {
     // Cancel preserves the confirmed state — no API call should fire.
     await page.getByTestId('rollcall-cancel-dialog-cancel').click();
     await expect(page.getByTestId('rollcall-cancel-summary')).toHaveCount(0);
-    await expect(page.getByTestId('rollcall-cancel-btn').first()).toBeVisible();
+    await expect(page.getByTestId(`rollcall-cancel-btn-${signup.id}`)).toBeVisible();
   });
 
   test('roll call page shows correct state for non-roll-call events', async ({

--- a/frontend/tests/playwright/e2e/16-events/04-discord-integration.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/04-discord-integration.spec.ts
@@ -278,6 +278,7 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventPlayer(context);
     const rsvpResp = await postWithCsrf(context, `${API_URL}/events/${event.id}/signup/`, { intent: 'rsvp' });
     expect(rsvpResp.ok()).toBeTruthy();
+    const signup = await rsvpResp.json();
 
     // Clear event_player_1's prior approved MMR so the test exercises the
     // self-report → range fallback (populate seeds an org-user MMR of 3500
@@ -293,11 +294,10 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await page.getByTestId('event-tab-signups').click();
 
     // 5. Verify player is in the signups list
-    await expect(page.getByText('EventPlayer1')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId(`event-signup-row-${signup.id}`)).toBeVisible({ timeout: 10000 });
 
     // 6. Click the Approve button — opens MMR approval modal (Dota 2 event)
-    const approveBtn = page.getByRole('button', { name: 'Approve' }).first();
-    await approveBtn.click();
+    await page.getByTestId(`approve-signup-${signup.id}`).click();
 
     // 7. Verify modal opened with player name in the dialog title
     const dialog = page.locator('[role="dialog"]');
@@ -383,6 +383,7 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventPlayer(context);
     const rsvpResp = await postWithCsrf(context, `${API_URL}/events/${event.id}/signup/`, { intent: "rsvp" });
     expect(rsvpResp.ok()).toBeTruthy();
+    const signup = await rsvpResp.json();
 
     // Set prior approved MMR before opening modal
     await setApprovedMmr(context, eventInfo.orgPk, 5001, 2400);
@@ -390,8 +391,8 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventAdmin(context);
     await visitAndWaitForHydration(page, `/events/${event.id}`);
     await page.getByTestId('event-tab-signups').click();
-    await expect(page.getByText('EventPlayer1')).toBeVisible({ timeout: 10000 });
-    await page.getByRole('button', { name: 'Approve' }).first().click();
+    await expect(page.getByTestId(`event-signup-row-${signup.id}`)).toBeVisible({ timeout: 10000 });
+    await page.getByTestId(`approve-signup-${signup.id}`).click();
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
@@ -431,6 +432,7 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventPlayer4(context);
     const rsvpResp = await postWithCsrf(context, `${API_URL}/events/${event.id}/signup/`, { intent: "rsvp" });
     expect(rsvpResp.ok()).toBeTruthy();
+    const signup = await rsvpResp.json();
 
     // Clear event_player_4's prior approved MMR so the test exercises the
     // battle-cup midpoint fallback rather than the populate-seeded prior.
@@ -439,8 +441,8 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventAdmin(context);
     await visitAndWaitForHydration(page, `/events/${event.id}`);
     await page.getByTestId('event-tab-signups').click();
-    await expect(page.getByText('EventPlayer4')).toBeVisible({ timeout: 10000 });
-    await page.getByRole('button', { name: 'Approve' }).first().click();
+    await expect(page.getByTestId(`event-signup-row-${signup.id}`)).toBeVisible({ timeout: 10000 });
+    await page.getByTestId(`approve-signup-${signup.id}`).click();
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
@@ -489,6 +491,7 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventPlayer(context);
     const rsvpResp = await postWithCsrf(context, `${API_URL}/events/${event.id}/signup/`, { intent: "rsvp" });
     expect(rsvpResp.ok()).toBeTruthy();
+    const signup = await rsvpResp.json();
 
     // 33% delta scenario: prior 2,400 vs autofill 3,200 (self-report).
     await setApprovedMmr(context, eventInfo.orgPk, 5001, 2400);
@@ -496,8 +499,8 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventAdmin(context);
     await visitAndWaitForHydration(page, `/events/${event.id}`);
     await page.getByTestId('event-tab-signups').click();
-    await expect(page.getByText('EventPlayer1')).toBeVisible({ timeout: 10000 });
-    await page.getByRole('button', { name: 'Approve' }).first().click();
+    await expect(page.getByTestId(`event-signup-row-${signup.id}`)).toBeVisible({ timeout: 10000 });
+    await page.getByTestId(`approve-signup-${signup.id}`).click();
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
@@ -570,6 +573,7 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await loginEventPlayer(context);
     const rsvpResp = await postWithCsrf(context, `${API_URL}/events/${event.id}/signup/`, { intent: "rsvp" });
     expect(rsvpResp.ok()).toBeTruthy();
+    const signup = await rsvpResp.json();
 
     // Login as the site superuser (is_superuser=True) so PlayerModal shows
     // the edit button (canEdit = is_staff || is_superuser).
@@ -589,10 +593,11 @@ test.describe('Events - Discord Integration (@cicd)', () => {
     await orgUsersLoaded;
 
     await page.getByTestId('event-tab-signups').click();
-    await expect(page.getByText('EventPlayer1')).toBeVisible({ timeout: 10000 });
+    const signupRow = page.getByTestId(`event-signup-row-${signup.id}`);
+    await expect(signupRow).toBeVisible({ timeout: 10000 });
 
     // Open the PlayerModal by clicking the user name in the signup row.
-    await page.getByText('EventPlayer1').first().click();
+    await signupRow.getByText('EventPlayer1').click();
 
     // Click the edit-user pencil button inside PlayerModal.
     await page.getByTestId('edit-user-btn').click();

--- a/frontend/tests/playwright/e2e/16-events/12-event-signup-form.spec.ts
+++ b/frontend/tests/playwright/e2e/16-events/12-event-signup-form.spec.ts
@@ -97,7 +97,7 @@ test.describe('Event Signup Form (@cicd)', () => {
     await page.getByTestId('event-signup-btn').click();
     const modal = page.getByTestId('event-signup-modal');
     await expect(modal).toBeVisible();
-    await modal.getByText("I've never had an MMR").click();
+    await modal.getByTestId('signup-rank-status-never').click();
     await expect(modal.getByTestId('signup-battlecup-tier')).toBeVisible();
     await expect(modal.getByTestId('signup-rank-medal')).toHaveCount(0);
     await expect(modal.getByTestId('signup-rank-star')).toHaveCount(0);
@@ -110,7 +110,7 @@ test.describe('Event Signup Form (@cicd)', () => {
     await page.getByTestId('event-signup-btn').click();
     const modal = page.getByTestId('event-signup-modal');
     await expect(modal).toBeVisible();
-    await modal.getByText('I have an active MMR').click();
+    await modal.getByTestId('signup-rank-status-active').click();
     await modal.getByTestId('signup-rank-medal').click();
     await page.getByRole('option', { name: 'Legend', exact: true }).click();
     await modal.getByTestId('signup-rank-star').click();


### PR DESCRIPTION
## Summary

Audit findings from the `/playwright` + `/testing` skill rules applied across the e2e suite. Three component files needed per-row testids; four spec files were violating "always use \`data-testid\`" and/or "no \`.first()\` on mutable selectors". This is the follow-up to PR #262 (15-edit-user user-card races) — same shape, different components.

## Component changes

| File | What |
|---|---|
| \`app/routes/event.tsx\` | \`UserEventStrip\` now receives \`data-testid="event-signup-row-\${signup.id}"\`; Approve buttons get \`approve-signup-\${signup.id}\` (both rsvp/pending_approval and waitlisted branches); Waitlist demote gets \`waitlist-signup-\${signup.id}\`. |
| \`app/routes/rollcall.tsx\` | Shared \`rollcall-cancel-btn\` → per-signup \`rollcall-cancel-btn-\${signup.id}\`. |
| \`app/components/events/EventSignupModal/RankStatusRadioGroup.tsx\` | Each radio label gets \`signup-rank-status-\${o.value}\` (\`active\`, \`previous\`, \`never\`). |

## Spec changes

| File | What |
|---|---|
| \`16-events/04-discord-integration.spec.ts\` | 4× \`getByRole('button', { name: 'Approve' }).first()\` → \`getByTestId(\`approve-signup-\${signup.id}\`)\`; each test now captures \`const signup = await rsvpResp.json()\` from its own RSVP setup. PlayerModal-edit test's \`getByText('EventPlayer1').first().click()\` → \`signupRow.getByText('EventPlayer1').click()\`. |
| \`16-events/03-roll-call.spec.ts\` | \`getByTestId('rollcall-cancel-btn').first()\` → \`getByTestId(\`rollcall-cancel-btn-\${signup.id}\`)\`. |
| \`16-events/12-event-signup-form.spec.ts\` | \`getByText("I've never had an MMR")\` → \`getByTestId('signup-rank-status-never')\` (and \`-active\`). |
| \`15-edit-user/09-scope-permissions.spec.ts\` | "find any non-admin non-actor user" + \`.first()\` usercard → stable \`edit_user_alpha\` lookup by username. Read-only test, but \`.first()\` would silently start checking the wrong user once PR #262 adds more users to the same org. |

## Verified locally

After \`just db::populate::all\`:

| Spec | Result |
|---|---|
| \`16-events/03-roll-call\` | 6/6 passed (22.1s) |
| \`16-events/04-discord-integration\` | 10/10 passed (58.2s) |
| \`16-events/12-event-signup-form\` | 8/8 passed (24.3s) |
| \`15-edit-user/09-scope-permissions\` | 3/3 passed (11.4s) |

## Not fixed (Low — wouldn't break under data isolation)

- Tab navigation \`getByRole('tab', { name: /…/i })\` in 05-match-stats, 16-events/09 (only one tab matches)
- \`getByText('Drop a CSV file here')\` in 14-csv-import (single dropzone label)
- \`getByText('E2E Signup Event')\` in 16-events/01 (single navigation link)
- \`matchNodes.nth(2)\` in 09-bracket (depends on stable bracket layout — separate concern)