### PR TITLE
feat(discord): DM full tournament pool on draft start, not just captains

### DIFF
--- a/.claude/just-interceptor.json
+++ b/.claude/just-interceptor.json
@@ -13,6 +13,13 @@
       "pattern": "^docker compose.*down",
       "just_command": "just test::down",
       "reason": "project-standard compose config"
+    },
+    {
+      "category": "docker",
+      "enabled": true,
+      "pattern": "^docker compose.*run.*manage.py test",
+      "just_command": "just test::run",
+      "reason": "test::run bypasses daphne entrypoint for backend tests"
     }
   ]
 }

--- a/backend/app/tests/test_internal_endpoints.py
+++ b/backend/app/tests/test_internal_endpoints.py
@@ -388,3 +388,60 @@ class InternalClientIntegrationTest(LiveServerTestCase):
             )
         finally:
             client.INTERNAL_API_URL = old_url
+
+
+@override_settings(INTERNAL_SERVICE_TOKEN=TOKEN)
+class TournamentParticipantsEndpointTest(TestCase):
+    """get_tournament_participants returns the full Tournament.users pool."""
+
+    def setUp(self):
+        from datetime import date
+
+        from app.models import CustomUser, Team, Tournament
+
+        self.client = APIClient()
+        self.client.credentials(**HEADERS)
+
+        self.tournament = Tournament.objects.create(
+            name="Participants Tournament", date_played=date.today()
+        )
+        # Captain: in the pool and seeded onto a team roster.
+        self.captain = CustomUser.objects.create_user(
+            username="cap", password="pw", discordId="1001"
+        )
+        # Undrafted participant: in the pool, on no team yet.
+        self.participant = CustomUser.objects.create_user(
+            username="pleb", password="pw", discordId="1002"
+        )
+        # Participant without a Discord link: must be excluded.
+        self.no_discord = CustomUser.objects.create_user(
+            username="nodiscord", password="pw"
+        )
+        self.tournament.users.add(self.captain, self.participant, self.no_discord)
+
+        team = Team.objects.create(
+            name="Team A", captain=self.captain, tournament=self.tournament
+        )
+        team.members.add(self.captain)
+
+    def _get(self):
+        return self.client.get(
+            f"/api/internal/tournaments/{self.tournament.pk}/participants/"
+        )
+
+    def test_returns_full_pool_including_undrafted(self):
+        resp = self._get()
+        self.assertEqual(resp.status_code, 200)
+        discord_ids = sorted(p["discord_id"] for p in resp.json())
+        # Captain (drafted) AND undrafted participant both included.
+        self.assertEqual(discord_ids, ["1001", "1002"])
+
+    def test_excludes_users_without_discord_id(self):
+        resp = self._get()
+        returned_pks = {p["user_pk"] for p in resp.json()}
+        self.assertNotIn(self.no_discord.pk, returned_pks)
+
+    def test_no_duplicate_for_captain_in_pool_and_roster(self):
+        resp = self._get()
+        captain_rows = [p for p in resp.json() if p["discord_id"] == "1001"]
+        self.assertEqual(len(captain_rows), 1)

--- a/backend/app/views/internal.py
+++ b/backend/app/views/internal.py
@@ -859,8 +859,9 @@ def get_tournament_participants(request, tournament_id):
     """Get tournament participants with Discord IDs (for DM sending).
 
     Returns the full tournament membership pool (``Tournament.users``) —
-    captains and undrafted participants alike — not just drafted team
-    members. At draft-start time nobody is on a team roster yet.
+    captains and undrafted participants alike. A roster-based query
+    (``Team.members``) would miss the undrafted pool: at draft-start time
+    only captains have been seeded onto team rosters.
     """
     from app.models import CustomUser
 

--- a/backend/app/views/internal.py
+++ b/backend/app/views/internal.py
@@ -856,12 +856,17 @@ def get_tournament_for_task(request, tournament_id):
 @authentication_classes(_auth)
 @permission_classes(_perm)
 def get_tournament_participants(request, tournament_id):
-    """Get tournament participants with Discord IDs (for DM sending)."""
+    """Get tournament participants with Discord IDs (for DM sending).
+
+    Returns the full tournament membership pool (``Tournament.users``) —
+    captains and undrafted participants alike — not just drafted team
+    members. At draft-start time nobody is on a team roster yet.
+    """
     from app.models import CustomUser
 
     users = (
         CustomUser.objects.filter(
-            teams_as_member__tournament_id=tournament_id,
+            tournaments=tournament_id,
             discordId__isnull=False,
         )
         .exclude(discordId="")

--- a/tasks.py
+++ b/tasks.py
@@ -144,12 +144,19 @@ def docker_compose_exec(c, compose_file: Path, service: str, cmd_str: str):
         c.run(cmd, pty=True)
 
 
-def docker_compose_run(c, compose_file: Path, service: str, cmd_str: str):
-    """Run a one-off command in a new container with --rm flag."""
+def docker_compose_run(
+    c, compose_file: Path, service: str, cmd_str: str, entrypoint: str | None = None
+):
+    """Run a one-off command in a new container with --rm flag.
+
+    Pass ``entrypoint=""`` to bypass the image entrypoint (e.g. daphne) so the
+    command runs directly — required for ``python manage.py ...`` one-offs.
+    """
+    entrypoint_flag = f'--entrypoint "{entrypoint}" ' if entrypoint is not None else ""
     with c.cd(paths.PROJECT_PATH):
         cmd = (
             f"docker compose --project-directory {paths.PROJECT_PATH.resolve()} "
-            f"-f {compose_file.resolve()} run --rm {service} {cmd_str}"
+            f"-f {compose_file.resolve()} run --rm {entrypoint_flag}{service} {cmd_str}"
         )
         c.run(cmd, pty=True)
 
@@ -508,7 +515,7 @@ def test_exec(c, service, cmd):
 @task(name="test-run")
 def test_run(c, service="backend", cmd=""):
     """Run a one-off command in test environment. Example: inv test.run --cmd 'python manage.py test app.tests -v 2'"""
-    docker_compose_run(c, paths.DOCKER_COMPOSE_TEST_PATH, service, cmd)
+    docker_compose_run(c, paths.DOCKER_COMPOSE_TEST_PATH, service, cmd, entrypoint="")
 
 
 @task(name="test-upd")

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,4 @@
+import shlex
 from pathlib import Path
 
 import semver
@@ -152,7 +153,9 @@ def docker_compose_run(
     Pass ``entrypoint=""`` to bypass the image entrypoint (e.g. daphne) so the
     command runs directly — required for ``python manage.py ...`` one-offs.
     """
-    entrypoint_flag = f'--entrypoint "{entrypoint}" ' if entrypoint is not None else ""
+    entrypoint_flag = (
+        f"--entrypoint {shlex.quote(entrypoint)} " if entrypoint is not None else ""
+    )
     with c.cd(paths.PROJECT_PATH):
         cmd = (
             f"docker compose --project-directory {paths.PROJECT_PATH.resolve()} "


### PR DESCRIPTION
## Summary

When a team draft starts, DraftForge DMs the draft link to participants. The
machinery (`send_tournament_draft_links` task → `get_tournament_participants`
endpoint) was *intended* to reach all participants, but the query filtered by
`teams_as_member__tournament_id` — drafted team rosters. At draft-start time
nobody has been drafted yet (only captains are seeded onto teams), so in
practice the DM reached **captains only**.

This changes the query to the tournament membership pool (`Tournament.users`,
reverse accessor `tournaments`) so captains **and** undrafted participants both
get the DM. `.distinct()` prevents a captain (who is in both the pool and a
roster) from being DM'd twice. The task, dispatch, embed copy, and send path
are unchanged.

### Tooling (needed to run the backend tests)
- `inv test.run` now passes `--entrypoint ""` so `just test::run 'python manage.py test ...'` bypasses the daphne entrypoint instead of failing with `daphne: error: unrecognized arguments`. dev/prod `run` are untouched.
- Added a just-interceptor redirect: `^docker compose.*run.*manage.py test → just test::run`.

## Test plan
- [x] New `TournamentParticipantsEndpointTest`: full pool incl. undrafted participant, excludes Discord-less users, no duplicate row for captain-in-pool-and-roster. Written test-first (failed on the missing undrafted participant), then fixed → green.
- [x] Regression: `app.tests.test_internal_endpoints` + `discordbot.tests.test_tournament_dm` — 44 tests pass.