### PR TITLE
fix(discord): MISSING sentinel for view/embed in DM-disabled signup fallback (#268)

### DIFF
--- a/backend/discordbot/signup_responses.py
+++ b/backend/discordbot/signup_responses.py
@@ -26,6 +26,7 @@ CRITICAL — `thinking=True` on defer for component interactions:
 from enum import Enum
 
 import discord
+from discord.utils import MISSING
 
 from telemetry.logging import get_logger
 
@@ -93,8 +94,14 @@ async def respond_to_signup_user(
         if getattr(e, "code", None) == 50007:
             mention = f"<@{user_id}>"
             text = f"{mention} {content}".strip() if content else mention
+            # Webhook.send (followup) rejects a literal None view/embed — it is
+            # not MISSING and lacks __discord_ui_view__. Pass MISSING instead.
+            # (The DM path above is Messageable.send, which tolerates None.)
             await interaction.followup.send(
-                content=text, embed=embed, view=view, ephemeral=True
+                content=text,
+                embed=embed if embed is not None else MISSING,
+                view=view if view is not None else MISSING,
+                ephemeral=True,
             )
             channel = ResponseChannel.EPHEMERAL
         else:

--- a/backend/discordbot/tests/test_signup_responses.py
+++ b/backend/discordbot/tests/test_signup_responses.py
@@ -113,6 +113,41 @@ class RespondToSignupUserDMDisabledTest(SimpleTestCase):
         self.assertEqual(result, ResponseChannel.EPHEMERAL)
 
 
+class RespondToSignupUserNoViewFallbackTest(SimpleTestCase):
+    async def test_forbidden_fallback_with_no_view_does_not_raise_typeerror(self):
+        """#268 bug 1: DM-disabled + no view/embed must fall back cleanly.
+
+        discord.py's Webhook.send (the followup.send path) rejects a literal
+        None view (None is not MISSING and lacks __discord_ui_view__). The
+        fallback must pass MISSING, not None. The DM path (Messageable.send)
+        tolerates None, so only the followup is affected.
+        """
+        interaction = _make_interaction(user_id=999)
+        dm_channel = AsyncMock()
+        dm_channel.send = AsyncMock(side_effect=_make_forbidden(50007))
+        interaction.user.create_dm.return_value = dm_channel
+
+        # Mirror Webhook.send: reject a literal None view/embed.
+        def _send(*args, **kwargs):
+            if kwargs.get("view", discord.utils.MISSING) is None:
+                raise TypeError(
+                    "expected view parameter to be of type View not NoneType"
+                )
+            if kwargs.get("embed", discord.utils.MISSING) is None:
+                raise TypeError(
+                    "expected embed parameter to be of type Embed not NoneType"
+                )
+        interaction.followup.send = AsyncMock(side_effect=_send)
+
+        channel = await respond_to_signup_user(interaction, content="✅ You're signed up!")
+
+        self.assertEqual(channel, ResponseChannel.EPHEMERAL)
+        interaction.followup.send.assert_awaited_once()
+        kwargs = interaction.followup.send.await_args.kwargs
+        self.assertTrue(kwargs["ephemeral"])
+        self.assertTrue(kwargs["content"].startswith("<@999>"))
+
+
 class RespondToSignupUserOtherForbiddenTest(SimpleTestCase):
     async def test_non_50007_forbidden_reraises(self):
         interaction = _make_interaction()

--- a/docs/superpowers/plans/2026-06-01-discord-providers-pr1-signup-responses-missing.md
+++ b/docs/superpowers/plans/2026-06-01-discord-providers-pr1-signup-responses-missing.md
@@ -1,0 +1,139 @@
+# PR1 — Fix `view=None` crash in DM-disabled signup fallback (#268 bug 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `respond_to_signup_user` from raising `TypeError` when a user with DMs disabled signs up and no `view`/`embed` was passed.
+
+**Architecture:** discord.py's `Webhook.send` (the `interaction.followup.send` fallback path) rejects a literal `None` for `view`/`embed` (`None` is not `MISSING` and has no `__discord_ui_view__`). The DM path (`Messageable.send`) tolerates `None`. Fix: pass `discord.utils.MISSING` instead of `None` on both sends.
+
+**Tech Stack:** Python, discord.py, Django `SimpleTestCase`, run via `just test::run`.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-discord-game-type-providers-design.md` → "Bugs fixed in-flight (issue #268)" bug 1. This is the first PR in the 3-PR stack; it is independent of the refactor.
+
+---
+
+### Task 1: Use the MISSING sentinel for view/embed in `respond_to_signup_user`
+
+**Files:**
+- Modify: `backend/discordbot/signup_responses.py` (`respond_to_signup_user`, lines ~75-98)
+- Test: `backend/discordbot/tests/test_signup_responses.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/discordbot/tests/test_signup_responses.py` (the file already has `_make_interaction` and `_make_forbidden` helpers and imports `discord`, `ResponseChannel`, `respond_to_signup_user`):
+
+```python
+class RespondToSignupUserNoViewFallbackTest(SimpleTestCase):
+    async def test_forbidden_fallback_with_no_view_does_not_raise_typeerror(self):
+        """#268 bug 1: DM-disabled + no view/embed must fall back cleanly.
+
+        Webhook.send rejects a literal None view (None is not MISSING and lacks
+        __discord_ui_view__). The fallback must pass MISSING, not None.
+        """
+        interaction = _make_interaction(user_id=999)
+        interaction.user.create_dm.side_effect = _make_forbidden(50007)
+
+        # Make followup.send assert it never receives a literal None view/embed,
+        # mirroring discord.py's Webhook.send behavior.
+        def _send(*args, **kwargs):
+            if kwargs.get("view", discord.utils.MISSING) is None:
+                raise TypeError("expected view parameter to be of type View not NoneType")
+            if kwargs.get("embed", discord.utils.MISSING) is None:
+                raise TypeError("expected embed parameter to be of type Embed not NoneType")
+        interaction.followup.send = AsyncMock(side_effect=_send)
+
+        channel = await respond_to_signup_user(interaction, content="✅ You're signed up!")
+
+        assert channel == ResponseChannel.EPHEMERAL
+        interaction.followup.send.assert_awaited_once()
+        kwargs = interaction.followup.send.call_args.kwargs
+        assert kwargs["ephemeral"] is True
+        assert kwargs["content"].startswith("<@999>")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test::run 'python manage.py test discordbot.tests.test_signup_responses.RespondToSignupUserNoViewFallbackTest -v 2'`
+Expected: FAIL — `TypeError: expected view parameter to be of type View not NoneType` (the current code passes `view=None`).
+
+- [ ] **Step 3: Apply the MISSING-sentinel fix**
+
+In `backend/discordbot/signup_responses.py`, add the import near the top (with the other imports):
+
+```python
+from discord.utils import MISSING
+```
+
+Then in `respond_to_signup_user`, replace the two send calls. The DM send (currently `await dm_channel.send(content=content, embed=embed, view=view)`) and the fallback send become:
+
+```python
+    send_embed = embed if embed is not None else MISSING
+    send_view = view if view is not None else MISSING
+
+    try:
+        dm_channel = await interaction.user.create_dm()
+        await dm_channel.send(content=content, embed=send_embed, view=send_view)
+        try:
+            await interaction.delete_original_response()
+            log.info(
+                "signup_interaction_placeholder_deleted",
+                system="discord",
+                subsystem="interaction",
+                tags=["events", "signup"],
+                tags_csv="events,signup",
+                user_id=user_id,
+                event_id=event_id,
+            )
+        except discord.NotFound:
+            pass
+        channel = ResponseChannel.DM
+    except discord.Forbidden as e:
+        if getattr(e, "code", None) == 50007:
+            mention = f"<@{user_id}>"
+            text = f"{mention} {content}".strip() if content else mention
+            await interaction.followup.send(
+                content=text, embed=send_embed, view=send_view, ephemeral=True
+            )
+            channel = ResponseChannel.EPHEMERAL
+        else:
+            log.error(
+                "signup_response_failed",
+                system="discord",
+                subsystem="interaction",
+                tags=["events", "signup"],
+                tags_csv="events,signup",
+                user_id=user_id,
+                event_id=event_id,
+                channel_id=channel_id,
+                source_message_id=source_message_id,
+                error=str(e),
+            )
+            raise
+```
+
+(`send_embed`/`send_view` are computed once before the `try`. Leave the rest of the function — the deferral block above it and the `signup_response_sent` log below it — unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test::run 'python manage.py test discordbot.tests.test_signup_responses.RespondToSignupUserNoViewFallbackTest -v 2'`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full signup_responses suite (no regression)**
+
+Run: `just test::run 'python manage.py test discordbot.tests.test_signup_responses -v 2'`
+Expected: all PASS (including the existing DM-success placeholder-deletion regression test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/discordbot/signup_responses.py backend/discordbot/tests/test_signup_responses.py
+git commit -m "fix(discord): MISSING sentinel for view/embed in DM-disabled signup fallback (#268)"
+```
+
+---
+
+## Self-Review
+- **Spec coverage:** Implements "Bugs fixed in-flight → bug 1" and its test bullet. ✓
+- **Placeholders:** none — full test + full replacement block.
+- **Type consistency:** `send_embed`/`send_view` used in both sends; `MISSING` imported.
+- **Scope:** single file + its test; independent of the refactor; safe to ship first.

--- a/docs/superpowers/plans/2026-06-01-discord-providers-pr2-pydantic-contract.md
+++ b/docs/superpowers/plans/2026-06-01-discord-providers-pr2-pydantic-contract.md
@@ -1,0 +1,384 @@
+# PR2 — Pydantic `modal_config` contract (discriminated union) on the monolith
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the eight flat Dota config flags (and the write-only `medal`/`tier`) on `SignupActionResponse` with a single `kind`-discriminated `modal_config` sub-model, tighten the envelope to `extra:"forbid"`, and centralize the screenshot-required ternary — all in place on the current monolith, behavior-preserving.
+
+**Architecture:** With `modal_config: SignupModalConfig | None`, Pydantic v2 serializes by the declared base type and drops subclass fields on the `model_validate→model_dump` wire path (empirically verified). A `kind`-discriminated union (`DotaModalConfig | DeadlockModalConfig | SignupModalConfig`) round-trips intact. Producers in `handlers.py` nest the config; the consumer in `components.py` reads `result["modal_config"]`. No structural file moves here — that is PR3.
+
+**Tech Stack:** Pydantic v2, Django, discord.py, run via `just test::run`.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-...design.md` → "Pydantic data layer", "Per-game modal config", "Tidied response envelope", "dota_require_screenshot". Depends on nothing; PR3 stacks on this.
+
+**Deploy note:** `extra:"forbid"` turns a backend↔bot version skew into a crash. This PR's two containers MUST deploy from the same release tag (the existing release model). See spec "Deploy-skew note".
+
+---
+
+### Task 1: Add the config models + union + `dota_require_screenshot` to `events/schemas.py`
+
+**Files:**
+- Modify: `backend/events/schemas.py`
+- Test: `backend/events/tests/test_signup_schema.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/events/tests/test_signup_schema.py`:
+
+```python
+from typing import get_args
+
+from events.schemas import (
+    DeadlockModalConfig,
+    DotaModalConfig,
+    SignupModalConfig,
+    dota_require_screenshot,
+)
+
+
+def test_dota_modal_config_has_kind_dota():
+    cfg = DotaModalConfig(min_mmr=3000, allow_active_mmr=False)
+    assert cfg.kind == "dota"
+    assert cfg.min_mmr == 3000
+
+
+def test_deadlock_modal_config_kind():
+    assert DeadlockModalConfig().kind == "deadlock"
+
+
+def test_base_modal_config_kind_default():
+    assert SignupModalConfig().kind == "default"
+
+
+def test_dota_require_screenshot_truth_table():
+    cfg = DotaModalConfig(require_rank_screenshot=True, require_battlecup_screenshot=True)
+    assert dota_require_screenshot("active", cfg) is True
+    assert dota_require_screenshot("never", cfg) is True
+    assert dota_require_screenshot("previous", cfg) is False
+    cfg_off = DotaModalConfig(require_rank_screenshot=False, require_battlecup_screenshot=False)
+    assert dota_require_screenshot("active", cfg_off) is False
+    assert dota_require_screenshot("never", cfg_off) is False
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just test::run 'python -m pytest events/tests/test_signup_schema.py -k modal_config -q'`
+Expected: FAIL — `ImportError: cannot import name 'DotaModalConfig'`.
+
+- [ ] **Step 3: Add the models + function to `backend/events/schemas.py`**
+
+Near the top, ensure these imports exist (the module already imports from `pydantic`):
+
+```python
+from typing import Annotated, Literal
+from pydantic import BaseModel, Field
+```
+
+Add (place above `SignupActionResponse`):
+
+```python
+class SignupModalConfig(BaseModel):
+    """Base / default game config carried in the needs_modal response."""
+
+    kind: Literal["default"] = "default"
+    require_steam_id: bool = True
+
+
+class DotaModalConfig(SignupModalConfig):
+    kind: Literal["dota"] = "dota"
+    require_rank_screenshot: bool = False
+    require_battlecup_screenshot: bool = False
+    min_mmr: int | None = None
+    allow_active_mmr: bool = True
+    allow_previous_rank: bool = True
+    allow_battlecup_rating: bool = True
+
+
+class DeadlockModalConfig(SignupModalConfig):
+    kind: Literal["deadlock"] = "deadlock"
+
+
+# Discriminated union — required so model_validate(dict)->model_dump() keeps
+# subclass fields. A plain `SignupModalConfig` annotation drops them.
+ModalConfig = Annotated[
+    DotaModalConfig | DeadlockModalConfig | SignupModalConfig,
+    Field(discriminator="kind"),
+]
+
+
+def dota_require_screenshot(rank_status: str, cfg: DotaModalConfig) -> bool:
+    """Single home for the screenshot-required rule (was duplicated in
+    components.py and handle_get_rank_flow_state)."""
+    if rank_status == "active":
+        return cfg.require_rank_screenshot
+    if rank_status == "never":
+        return cfg.require_battlecup_screenshot
+    return False
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `just test::run 'python -m pytest events/tests/test_signup_schema.py -k modal_config -q'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/events/schemas.py backend/events/tests/test_signup_schema.py
+git commit -m "feat(schemas): add discriminated ModalConfig union + dota_require_screenshot (#268)"
+```
+
+---
+
+### Task 2: Reshape `SignupActionResponse` (nest modal_config, drop medal/tier, forbid)
+
+**Files:**
+- Modify: `backend/events/schemas.py` (`SignupActionResponse`, lines ~266-308)
+- Test: `backend/events/tests/test_signup_schema.py`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Append to `backend/events/tests/test_signup_schema.py`:
+
+```python
+from events.schemas import SignupActionResponse
+
+
+def test_modal_config_survives_validate_then_dump():
+    """The wire path is model_validate(dict).model_dump() in signup_actions.py."""
+    resp = SignupActionResponse(
+        action="needs_modal",
+        game_type=1,
+        modal_config=DotaModalConfig(min_mmr=2500, require_rank_screenshot=True),
+    )
+    wire = resp.model_dump()
+    rt = SignupActionResponse.model_validate(wire).model_dump()
+    assert rt["modal_config"]["kind"] == "dota"
+    assert rt["modal_config"]["min_mmr"] == 2500
+    assert rt["modal_config"]["require_rank_screenshot"] is True
+
+
+def test_response_forbids_legacy_flat_keys():
+    with pytest.raises(PydanticValidationError):
+        SignupActionResponse.model_validate(
+            {"action": "needs_modal", "game_type": 1, "min_mmr": 3000}
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just test::run 'python -m pytest events/tests/test_signup_schema.py -k "modal_config_survives or forbids_legacy" -q'`
+Expected: FAIL — current model has flat `min_mmr` and `extra:"ignore"`.
+
+- [ ] **Step 3: Reshape the model**
+
+Replace the field block in `SignupActionResponse` (everything from `prefill: dict | None = None` through `positions: list[int] | None = None` and `model_config`) with:
+
+```python
+    prefill: dict | None = None
+    modal_config: "ModalConfig | None" = None      # was 8 flat Dota flags
+    screenshot_type: str | None = None              # stays FLAT (views bracket-index it)
+    subscribed: bool | None = None
+    success: bool | None = None
+    signed_up: bool | None = None
+    positions: list[int] | None = None
+
+    model_config = {"extra": "forbid"}              # was "ignore"
+```
+
+(Removes `require_steam_id`, `require_rank_screenshot`, `require_battlecup_screenshot`, `min_mmr`, `allow_active_mmr`, `allow_previous_rank`, `allow_battlecup_rating`, `medal`, `tier`. `ModalConfig` is defined above in this module, so the forward-ref string resolves; if the module already calls `model_rebuild()` anywhere keep it, otherwise no rebuild is needed since `ModalConfig` is in scope.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `just test::run 'python -m pytest events/tests/test_signup_schema.py -q'`
+Expected: PASS (all schema tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/events/schemas.py backend/events/tests/test_signup_schema.py
+git commit -m "feat(schemas): nest modal_config, drop medal/tier, extra:forbid on SignupActionResponse (#268)"
+```
+
+---
+
+### Task 3: Update producers in `handlers.py` (nest config, drop medal/tier)
+
+**Files:**
+- Modify: `backend/events/discord/handlers.py` — `handle_signup_button` (~256-275), `handle_rank_medal_select` (~433-437), `handle_previous_rank_submit` (~490-494), `handle_battle_cup_submit` (~545-549), `handle_get_rank_flow_state` (~799-807)
+
+- [ ] **Step 1: Update `handle_signup_button`'s needs_modal return**
+
+Add to the imports at the top of `handlers.py` (module-level, not function-local):
+
+```python
+from events.schemas import DeadlockModalConfig, DotaModalConfig, SignupModalConfig
+```
+
+Replace the `return {"action": "needs_modal", ...}` block (the dict with the 8 flat flags) with a per-game config build, then nest its dump:
+
+```python
+    if event.game_type == GameType.DOTA2:
+        modal_config = DotaModalConfig(
+            require_steam_id=event.require_steam_id,
+            require_rank_screenshot=event.discord_require_rank_screenshot,
+            require_battlecup_screenshot=event.discord_require_battlecup_screenshot,
+            min_mmr=event.min_mmr,
+            allow_active_mmr=event.allow_active_mmr,
+            allow_previous_rank=event.allow_previous_rank,
+            allow_battlecup_rating=event.allow_battlecup_rating,
+        )
+    elif event.game_type == GameType.DEADLOCK:
+        modal_config = DeadlockModalConfig(require_steam_id=event.require_steam_id)
+    else:
+        modal_config = SignupModalConfig(require_steam_id=event.require_steam_id)
+
+    _log_interaction(event_id, "signup_modal_opened", discord_user_id, discord_username)
+    return {
+        "action": "needs_modal",
+        "game_type": event.game_type,
+        "prefill": {
+            "unverified_friend_id": getattr(
+                getattr(org_user, "dota_profile", None), "unverified_friend_id", ""
+            )
+            or getattr(
+                getattr(org_user, "deadlock_profile", None), "unverified_friend_id", ""
+            )
+            or "",
+        },
+        "modal_config": modal_config.model_dump(),
+    }
+```
+
+- [ ] **Step 2: Drop `medal`/`tier` from the three screenshot producers**
+
+In `handle_rank_medal_select` and `handle_previous_rank_submit`, the `needs_screenshot` return currently includes `"medal": medal`. Remove that key:
+
+```python
+            return {"action": "needs_screenshot", "screenshot_type": "rank"}
+```
+
+In `handle_battle_cup_submit`, remove `"tier": tier`:
+
+```python
+            return {"action": "needs_screenshot", "screenshot_type": "battlecup"}
+```
+
+(The `medal`/`tier` locals are still used elsewhere in those functions for persistence — only the returned response keys are dropped.)
+
+- [ ] **Step 3: Route `handle_get_rank_flow_state` through `dota_require_screenshot`**
+
+Replace its inline ternary (the `require_screenshot = ( ... if rank_status == "active" else ... )` block) with:
+
+```python
+    from events.schemas import DotaModalConfig, dota_require_screenshot
+
+    cfg = DotaModalConfig(
+        require_rank_screenshot=event.discord_require_rank_screenshot,
+        require_battlecup_screenshot=event.discord_require_battlecup_screenshot,
+    )
+    require_screenshot = dota_require_screenshot(rank_status, cfg)
+```
+
+- [ ] **Step 4: Run the handler interaction tests**
+
+Run: `just test::run 'python manage.py test events.tests.test_signup_interactions -v 2'`
+Expected: tests that assert the old flat keys will FAIL — fix them in Task 5. Tests not asserting on config shape PASS. Note which fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/events/discord/handlers.py
+git commit -m "feat(discord): producers emit nested modal_config, drop medal/tier (#268)"
+```
+
+---
+
+### Task 4: Update the consumer in `components.py` (read nested modal_config)
+
+**Files:**
+- Modify: `backend/discordbot/components.py` — `SignupButton.callback` (~169-188), `EventSignupModal.__init__`/`_add_dota_fields` (~307, ~367), `EventSignupModal.on_submit` (~444-457)
+
+- [ ] **Step 1: Read modal_config in `SignupButton.callback`**
+
+The `needs_modal` branch currently builds `event_config={...}` from `result.get("require_steam_id")` etc. Replace that dict construction with the nested config:
+
+```python
+            elif result["action"] == "needs_modal":
+                modal = EventSignupModal(
+                    event_id=self.event_id,
+                    game_type=result["game_type"],
+                    prefill=result.get("prefill", {}),
+                    event_config=result.get("modal_config", {}) or {},
+                )
+                await send_modal_v2(interaction, modal)
+```
+
+(`event_config` is now the `modal_config` dict, whose keys are the same names — `require_steam_id`, `min_mmr`, `require_rank_screenshot`, etc. — so the existing `self.event_config.get("...")` reads downstream keep working unchanged.)
+
+- [ ] **Step 2: Replace the inline screenshot ternary in `on_submit`**
+
+In `EventSignupModal.on_submit`, the `needs_rank_details` branch computes `require_screenshot` via a nested ternary on `self.event_config`. Replace it with the shared function:
+
+```python
+            if result["action"] == "needs_rank_details":
+                from events.schemas import DotaModalConfig, dota_require_screenshot
+
+                rank_status = values.get("rank_status", "never")
+                cfg = DotaModalConfig(**{
+                    k: v for k, v in self.event_config.items()
+                    if k in DotaModalConfig.model_fields
+                })
+                require_screenshot = dota_require_screenshot(rank_status, cfg)
+                view = PositionSelectView(
+                    self.event_id,
+                    rank_status,
+                    require_screenshot=require_screenshot,
+                    min_mmr=self.event_config.get("min_mmr"),
+                )
+                ...
+```
+
+(Keep the rest of the branch — the `send_message(..., view=view, ephemeral=True)` — unchanged.)
+
+- [ ] **Step 3: Run the component + signup-logging suites**
+
+Run: `just test::run 'python manage.py test discordbot.tests.test_components discordbot.tests.test_signup_logging -v 2'`
+Expected: PASS (these don't assert the wire config shape; verify no regression).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/discordbot/components.py
+git commit -m "feat(discord): consume nested modal_config in signup modal (#268)"
+```
+
+---
+
+### Task 5: Fix handler tests that asserted the old flat shape
+
+**Files:**
+- Modify: `backend/events/tests/test_signup_interactions.py`, `backend/tests/test_events_discord.py` (only the assertions that read flat config/`medal`/`tier`)
+
+- [ ] **Step 1: Update assertions**
+
+For any test asserting `result["min_mmr"]` / `result["require_steam_id"]` / etc. on a `needs_modal` response, change to `result["modal_config"]["min_mmr"]` etc. For tests asserting `result["medal"]`/`result["tier"]` on a `needs_screenshot` response, delete those assertions (the keys are intentionally gone; assert `result["screenshot_type"]` instead).
+
+- [ ] **Step 2: Run the full affected suite**
+
+Run: `just test::run 'python manage.py test events.tests.test_signup_interactions tests.test_events_discord events.tests.test_signup_schema -v 2'`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/events/tests/test_signup_interactions.py backend/tests/test_events_discord.py
+git commit -m "test(discord): update assertions for nested modal_config (#268)"
+```
+
+---
+
+## Self-Review
+- **Spec coverage:** config models + union (Task 1), envelope reshape + forbid (Task 2), producers (Task 3), consumer + dedup ternary (Task 4), test migration (Task 5). ✓
+- **Placeholders:** none — full code for models, function, edits, tests.
+- **Type consistency:** `DotaModalConfig`/`DeadlockModalConfig`/`SignupModalConfig`/`ModalConfig`/`dota_require_screenshot` used consistently across schemas, handlers, components.
+- **Behavior:** wire shape changes, runtime behavior preserved (same modal fields, same screenshot logic). PR3 will move this code without touching the contract again.

--- a/docs/superpowers/plans/2026-06-01-discord-providers-pr3-structural-refactor.md
+++ b/docs/superpowers/plans/2026-06-01-discord-providers-pr3-structural-refactor.md
@@ -1,0 +1,659 @@
+# PR3 — Game-type provider/registry structural refactor
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the Discord signup UI and business logic into per-game-type provider modules behind two registries, add a typed custom-id codec layer, and fold in the #268 bug-2 defer-first fix — with **no wire-contract change** (PR2 already did that).
+
+**Architecture:** Two parallel registries keyed on `GameType` (process boundary stays: `discordbot/` = bot UI, `events/discord/` = ORM logic). `discordbot/components/` owns the UI provider + views; `events/discord/providers/` owns the handler logic. `discordbot/custom_ids.py` is the bot-internal typed wire format. Each ephemeral-view callback decodes its typed `CustomId` and delegates to a bound `DotaComponents` method, forwarding View state. `bot.py` routes only the bare `pos_select_` select via the registry; all other components self-dispatch via discord.py's in-memory ephemeral view store.
+
+**Tech Stack:** Python, discord.py, Pydantic v2, Django, run via `just test::run`.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-...design.md` (whole document). Stacks on PR2. The "Adding a game type" checklist in the spec should be mirrored as a docstring on both `registry.py` files.
+
+**Ground rule for relocations:** Moving a class means copy its body **verbatim** from `components.py`/`handlers.py` into the new module, then apply only the explicitly-noted change (provider injection, callback delegation, defer-first). Do not rewrite untouched logic.
+
+---
+
+### Task 1: Typed custom-id codecs — `discordbot/custom_ids.py`
+
+**Files:**
+- Create: `backend/discordbot/custom_ids.py`
+- Test: `backend/discordbot/tests/test_custom_ids.py`
+
+- [ ] **Step 1: Write the failing round-trip + guard tests**
+
+Create `backend/discordbot/tests/test_custom_ids.py`:
+
+```python
+import pytest
+from discordbot import custom_ids as cid
+
+
+def test_event_signup_roundtrip():
+    s = cid.SignupId(event_id=42).encode()
+    assert s == "event_signup:42"
+    assert cid.SignupId.matches(s)
+    assert cid.SignupId.decode(s).event_id == 42
+
+
+def test_pos_select_slot_before_colon():
+    s = cid.PosSelectId(event_id=7, slot=2).encode()
+    assert s == "pos_select_2:7"
+    assert cid.PosSelectId.matches(s)
+    d = cid.PosSelectId.decode(s)
+    assert (d.event_id, d.slot) == (7, 2)
+
+
+def test_rank_star_carries_medal():
+    s = cid.RankStarId(event_id=5, medal="Crusader").encode()
+    assert s == "rank_star:5:Crusader"
+    assert cid.RankStarId.decode(s).medal == "Crusader"
+
+
+def test_screenshot_url_prefix_exists():
+    assert cid.ScreenshotUrlId(event_id=1, screenshot_type="rank").encode() == "screenshot_url:1:rank"
+
+
+def test_decode_malformed_raises_valueerror():
+    with pytest.raises(ValueError):
+        cid.SignupId.decode("event_signup:notanint")
+
+
+def test_missing_prefix_subclass_fails_at_definition():
+    with pytest.raises(AssertionError):
+        class Bad(cid.CustomId):  # no PREFIX
+            pass
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just test::run 'python -m pytest discordbot/tests/test_custom_ids.py -q'`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the codecs**
+
+Create `backend/discordbot/custom_ids.py`. Implement the `CustomId` base (frozen Pydantic, `__init_subclass__` PREFIX assert, `encode`/`matches`/`decode` raising `ValueError`) and one subclass per prefix in the spec's codec table. Two irregular shapes need overrides: `PosSelectId` (slot before the colon: `pos_select_{slot}:{id}`) and the three-segment ids (`RankStarId` → `rank_star:{id}:{medal}`, `ScreenshotUploadId`/`ScreenshotFileId`/`ScreenshotUrlId` → `<prefix>:{id}:{type}`).
+
+```python
+from __future__ import annotations
+from typing import ClassVar
+from pydantic import BaseModel, ValidationError
+
+
+class CustomId(BaseModel):
+    PREFIX: ClassVar[str]
+    event_id: int
+    model_config = {"frozen": True}
+
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        assert getattr(cls, "PREFIX", None), f"{cls.__name__} must set PREFIX"
+
+    def encode(self) -> str:
+        return f"{self.PREFIX}:{self.event_id}"
+
+    @classmethod
+    def matches(cls, raw: str) -> bool:
+        return raw.startswith(cls.PREFIX + ":")
+
+    @classmethod
+    def decode(cls, raw: str) -> "CustomId":
+        try:
+            _, rest = raw.split(":", 1)
+            return cls(event_id=int(rest))
+        except (ValueError, IndexError, ValidationError) as exc:
+            raise ValueError(f"bad custom_id {raw!r}") from exc
+
+
+class SignupId(CustomId):     PREFIX = "event_signup"
+class TentativeId(CustomId):  PREFIX = "event_tentative"
+class DeclineId(CustomId):    PREFIX = "event_decline"
+class NotifyId(CustomId):     PREFIX = "event_notify"
+class PosConfirmId(CustomId): PREFIX = "pos_confirm"
+class RankStatusId(CustomId): PREFIX = "rank_status"
+class RankMedalId(CustomId):  PREFIX = "rank_medal"
+class BattleCupTierId(CustomId): PREFIX = "bcup_tier"
+class SignupFriendId(CustomId):  PREFIX = "signup_friend_id"
+class SignupRankStatusId(CustomId): PREFIX = "signup_rank_status"
+class SignupDeadlockRankId(CustomId): PREFIX = "signup_deadlock_rank"
+class SignupDeadlockDateId(CustomId): PREFIX = "signup_deadlock_date"
+
+
+class PosSelectId(CustomId):
+    PREFIX = "pos_select"   # wire form: pos_select_{slot}:{event_id}
+    slot: int
+
+    def encode(self) -> str:
+        return f"{self.PREFIX}_{self.slot}:{self.event_id}"
+
+    @classmethod
+    def matches(cls, raw: str) -> bool:
+        return raw.startswith(cls.PREFIX + "_")
+
+    @classmethod
+    def decode(cls, raw: str) -> "PosSelectId":
+        try:
+            head, ev = raw.split(":", 1)
+            slot = int(head[len(cls.PREFIX) + 1:])  # after "pos_select_"
+            return cls(event_id=int(ev), slot=slot)
+        except (ValueError, IndexError, ValidationError) as exc:
+            raise ValueError(f"bad custom_id {raw!r}") from exc
+
+
+class _TypedTailId(CustomId):
+    """Base for `<prefix>:{event_id}:{value}` codecs (value stored on a named field by subclass)."""
+    pass
+
+
+class RankStarId(CustomId):
+    PREFIX = "rank_star"
+    medal: str
+
+    def encode(self) -> str:
+        return f"{self.PREFIX}:{self.event_id}:{self.medal}"
+
+    @classmethod
+    def decode(cls, raw: str) -> "RankStarId":
+        try:
+            _, ev, medal = raw.split(":", 2)
+            return cls(event_id=int(ev), medal=medal)
+        except (ValueError, IndexError, ValidationError) as exc:
+            raise ValueError(f"bad custom_id {raw!r}") from exc
+
+
+def _screenshot_codec(prefix):
+    class _Id(CustomId):
+        PREFIX = prefix
+        screenshot_type: str
+
+        def encode(self) -> str:
+            return f"{self.PREFIX}:{self.event_id}:{self.screenshot_type}"
+
+        @classmethod
+        def decode(cls, raw: str) -> "CustomId":
+            try:
+                _, ev, st = raw.split(":", 2)
+                return cls(event_id=int(ev), screenshot_type=st)
+            except (ValueError, IndexError, ValidationError) as exc:
+                raise ValueError(f"bad custom_id {raw!r}") from exc
+    _Id.__name__ = _Id.__qualname__ = {
+        "screenshot_upload": "ScreenshotUploadId",
+        "screenshot_file": "ScreenshotFileId",
+        "screenshot_url": "ScreenshotUrlId",
+    }[prefix]
+    return _Id
+
+
+ScreenshotUploadId = _screenshot_codec("screenshot_upload")
+ScreenshotFileId = _screenshot_codec("screenshot_file")
+ScreenshotUrlId = _screenshot_codec("screenshot_url")
+
+# Prefix registry used by log_context for tag derivation (Task 2).
+ALL_CODECS = [
+    SignupId, TentativeId, DeclineId, NotifyId, PosSelectId, PosConfirmId,
+    RankStatusId, RankMedalId, RankStarId, BattleCupTierId,
+    ScreenshotUploadId, ScreenshotFileId, ScreenshotUrlId,
+    SignupFriendId, SignupRankStatusId, SignupDeadlockRankId, SignupDeadlockDateId,
+]
+SIGNUP_TAG_PREFIXES = frozenset(c.PREFIX for c in ALL_CODECS)
+```
+
+(Remove the unused `_TypedTailId` stub if your linter flags it; it is illustrative only.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `just test::run 'python -m pytest discordbot/tests/test_custom_ids.py -q'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/discordbot/custom_ids.py backend/discordbot/tests/test_custom_ids.py
+git commit -m "feat(discord): typed custom-id codecs with byte-for-byte round-trip (#268)"
+```
+
+---
+
+### Task 2: Derive `log_context` prefixes from codecs (with `pos_select_` runtime guard)
+
+**Files:**
+- Modify: `backend/discordbot/log_context.py`
+- Modify: `backend/discordbot/tests/test_log_context.py`
+
+- [ ] **Step 1: Write the failing parity + runtime-membership tests**
+
+Add to `backend/discordbot/tests/test_log_context.py`:
+
+```python
+from discordbot import custom_ids as cid
+from discordbot.log_context import _SIGNUP_TAG_PREFIXES, resolve_tags
+
+
+def test_prefix_set_matches_codecs():
+    assert _SIGNUP_TAG_PREFIXES == cid.SIGNUP_TAG_PREFIXES
+
+
+def test_pos_select_runtime_tag_membership():
+    # pos_select_1:42 must still resolve to the signup tags despite the slot.
+    assert resolve_tags("pos_select_1:42") == ["events", "signup"]
+    assert resolve_tags("pos_select_3:7") == ["events", "signup"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just test::run 'python -m pytest discordbot/tests/test_log_context.py -k "prefix_set or pos_select_runtime" -q'`
+Expected: FAIL — `_SIGNUP_TAG_PREFIXES` is the hardcoded set (contains `pos_select_1/2/3`, not `pos_select`), and `_prefix("pos_select_1:42")` returns `"pos_select_1"` which won't be in the codec-derived set.
+
+- [ ] **Step 3: Rewrite the prefix source + the `pos_select_` match**
+
+In `backend/discordbot/log_context.py`:
+
+```python
+from discordbot.custom_ids import SIGNUP_TAG_PREFIXES as _SIGNUP_TAG_PREFIXES
+
+
+def _prefix(custom_id: str | None) -> str | None:
+    if not custom_id:
+        return None
+    head = custom_id.split(":", 1)[0]
+    # pos_select_{slot} normalizes to the codec prefix "pos_select"
+    if head.startswith("pos_select_"):
+        return "pos_select"
+    return head
+```
+
+Delete the old hardcoded `_SIGNUP_TAG_PREFIXES = {...}` literal. `resolve_tags`, `parse_event_id`, and `span_name` already call `_prefix`, so they inherit the normalization. (`span_name` for a pos_select now yields `discord.interaction.pos_select` — accepted granularity change.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `just test::run 'python -m pytest discordbot/tests/test_log_context.py -q'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/discordbot/log_context.py backend/discordbot/tests/test_log_context.py
+git commit -m "refactor(discord): derive log_context prefixes from codecs (#268)"
+```
+
+---
+
+### Task 3: `discordbot/components/` package — base + per-game providers
+
+**Files:**
+- Create: `backend/discordbot/components/__init__.py`, `base.py`, `dota.py`, `deadlock.py`, `default.py`, `registry.py`
+- Delete: `backend/discordbot/components.py`
+
+- [ ] **Step 1: Create `base.py` (shared, game-agnostic)**
+
+Move verbatim from `components.py`: `send_modal_v2`, `EventSignupView`, `SignupButton`, `NotifyButton`, `TentativeButton`, `DeclineButton`, the screenshot infra (`ScreenshotUploadPromptView`, `ScreenshotUploadButton`, `ScreenshotUploadModal`, `SCREENSHOT_EXAMPLE_URLS`). Add the shared friend-id helper (extracted from the current modal's friend-id block):
+
+```python
+def build_friend_id_input(event_id, prefill, required):
+    """Shared Steam Friend ID field; returns None when already known or not required."""
+    if not required or prefill.get("unverified_friend_id"):
+        return None
+    return ui.TextInput(
+        label="Steam Friend ID",
+        placeholder="Your Friend ID (number from your Dotabuff URL)",
+        custom_id=SignupFriendId(event_id=event_id).encode(),
+        required=True,
+        max_length=20,
+        style=discord.TextStyle.short,
+        default=str(prefill.get("unverified_friend_id", "")),
+    )
+```
+
+`SignupButton.callback`'s `needs_modal` branch now asks the registry:
+
+```python
+            elif result["action"] == "needs_modal":
+                from discordbot.components.registry import get_component_provider
+                provider = get_component_provider(result["game_type"])
+                modal = provider.build_signup_modal(
+                    self.event_id, result.get("prefill", {}), result.get("modal_config", {}) or {}
+                )
+                await send_modal_v2(interaction, modal)
+```
+
+Keep the module-level bindings `signup_button`, `respond_to_signup_user` importable from `base.py` (tests patch them by path — Task 7 updates the path).
+
+- [ ] **Step 2: Create `dota.py` (`DotaComponents` + Dota views, with bug-2 defer-first)**
+
+Move verbatim: `DOTA_POSITIONS`, `DOTA_MEDALS`, `DOTA_STARS`, `_medal_options`, `_star_options`, `DotaSignupModal` (the Dota half of the old `EventSignupModal`, stashing the full config dict on `self`), `PositionSelectView`, `PositionConfirmButton`, `RankStatusSelectView`, `RankStatusSelect`, `RankDetailsView`, `MedalSelect`, `StarSelect`, `BattleCupTierSelect`.
+
+Each select/button now takes `provider: "DotaComponents"` and its `custom_id` uses the codec (e.g. `RankStatusId(event_id=event_id).encode()`). The callback bodies move into `DotaComponents` methods; each callback decodes its codec and delegates, forwarding View state. Apply the **bug-2 defer-first** change to the ORM-bearing methods. Example for `PositionConfirmButton` → `DotaComponents.position_confirm`:
+
+```python
+class DotaComponents(GameComponentProvider):
+    bare_select_ids = (PosSelectId,)
+
+    def build_signup_modal(self, event_id, prefill, config):
+        return DotaSignupModal(event_id, prefill, config, provider=self)
+
+    async def position_confirm(self, interaction, cid, *, rank_status, require_screenshot, min_mmr):
+        async with discord_log_context(interaction, custom_id=cid.encode(), event_id=cid.event_id) as ctx:
+            await interaction.response.defer()                      # bug-2: ACK before slow ORM
+            positions = [...]                                       # gather from view selects (verbatim)
+            result = await sync_to_async(save_positions, thread_sensitive=False)(
+                event_id=cid.event_id, discord_user_id=str(interaction.user.id), positions=positions
+            )
+            if result.get("action") == "error":
+                ctx.set_outcome("error")
+                await interaction.edit_original_response(content=f"❌ {result['message']}", view=None)
+                return
+            ctx.set_outcome("positions_saved")
+            view = RankDetailsView(cid.event_id, rank_status, require_screenshot=require_screenshot, min_mmr=min_mmr, provider=self)
+            await interaction.edit_original_response(content=..., view=view)
+
+    async def position_select(self, interaction, cid):               # bare select, routed by bot.py
+        if interaction.response.is_done():
+            return
+        # verbatim pos_select_ body: parse value, set_position, defer
+        ...
+
+    async def rank_medal_select(self, interaction, cid, *, rank_status, require_screenshot): ...
+    async def rank_star_select(self, interaction, cid, *, rank_status): ...
+    async def battle_cup_select(self, interaction, cid): ...
+    async def rank_status_select(self, interaction, cid): ...
+
+    async def dispatch_bare_select(self, interaction, cid):
+        await self.position_select(interaction, cid)
+```
+
+`StarSelect.callback` keeps the `"Herald"` sentinel + `Immortal` logic in the callback (the codec only round-trips the literal). Apply defer-first to `rank_medal_select`, `rank_star_select`, `battle_cup_select` the same way (`defer()` then `edit_original_response`). Also disable the Confirm button + selects on first activation before the await (double-click guard).
+
+- [ ] **Step 3: Create `deadlock.py`, `default.py`, `registry.py`**
+
+`deadlock.py` — `DeadlockComponents` with `build_signup_modal` returning `DeadlockSignupModal` (the Deadlock half of the old modal, friend-id + rank/date inputs), `bare_select_ids = ()`.
+
+`default.py` — `DefaultComponents` returning a minimal modal (friend-id only or none), `bare_select_ids = ()`.
+
+`registry.py`:
+
+```python
+from telemetry.logging import get_logger
+from app.models import GameType
+from discordbot.components.dota import DotaComponents
+from discordbot.components.deadlock import DeadlockComponents
+from discordbot.components.default import DefaultComponents
+
+log = get_logger(__name__)
+COMPONENT_PROVIDERS = {GameType.DOTA2: DotaComponents(), GameType.DEADLOCK: DeadlockComponents()}
+_DEFAULT = DefaultComponents()
+
+def get_component_provider(game_type):
+    p = COMPONENT_PROVIDERS.get(game_type)
+    if p is None:
+        log.error("provider_fallback", system="discord", subsystem="interaction",
+                  tags=["events", "signup"], tags_csv="events,signup", layer="components", game_type=game_type)
+        return _DEFAULT
+    return p
+
+def iter_component_providers():
+    return list(COMPONENT_PROVIDERS.values())
+```
+
+(Mirror the spec's "Adding a game type" checklist as this module's docstring.) Define the `GameComponentProvider` protocol in `base.py` (or `registry.py`): `build_signup_modal`, `bare_select_ids`, `dispatch_bare_select`.
+
+- [ ] **Step 4: `__init__.py` back-compat re-exports + delete the monolith**
+
+`backend/discordbot/components/__init__.py` re-exports every symbol current importers/tests use (per spec): `EventSignupView`, `SignupButton`, `NotifyButton`, `TentativeButton`, `DeclineButton`, `PositionSelectView`, `PositionConfirmButton`, `RankDetailsView`, `MedalSelect`, `StarSelect`, `BattleCupTierSelect`, `RankStatusSelect`, `RankStatusSelectView`, plus `signup_button`, `save_positions`, `set_position`, `respond_to_signup_user`. Then `git rm backend/discordbot/components.py`.
+
+- [ ] **Step 5: Verify import + component tests (defer to Task 7 for test edits)**
+
+Run: `just test::run 'python -c "import discordbot.components"'`
+Expected: no ImportError.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/discordbot/components/
+git rm backend/discordbot/components.py
+git commit -m "refactor(discord): split components into base + per-game providers, defer-first ORM (#268)"
+```
+
+---
+
+### Task 4: Wire `bot.py:on_interaction` to codecs + bare-select registry
+
+**Files:**
+- Modify: `backend/discordbot/bot.py` (`on_interaction`, ~162-207)
+
+- [ ] **Step 1: Replace the prefix string-matches with codecs + the bare-select loop**
+
+```python
+        if interaction.type == discord.InteractionType.component:
+            if SignupId.matches(custom_id):
+                await SignupButton(SignupId.decode(custom_id).event_id).callback(interaction)
+            elif TentativeId.matches(custom_id):
+                await TentativeButton(TentativeId.decode(custom_id).event_id).callback(interaction)
+            elif DeclineId.matches(custom_id):
+                await DeclineButton(DeclineId.decode(custom_id).event_id).callback(interaction)
+            elif NotifyId.matches(custom_id):
+                await NotifyButton(NotifyId.decode(custom_id).event_id).callback(interaction)
+            else:
+                for provider in iter_component_providers():
+                    for id_type in provider.bare_select_ids:
+                        if id_type.matches(custom_id):
+                            try:
+                                parsed = id_type.decode(custom_id)
+                            except ValueError:
+                                return
+                            await provider.dispatch_bare_select(interaction, parsed)
+                            return
+```
+
+Keep the surrounding comment about why the self-dispatching views are NOT routed here (the 40060 race). Update imports at the top of `bot.py` to pull the codecs and `iter_component_providers`.
+
+- [ ] **Step 2: Smoke-test the bot module imports**
+
+Run: `just test::run 'python -c "import discordbot.bot"'`
+Expected: no ImportError.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/discordbot/bot.py
+git commit -m "refactor(discord): codec-based interaction routing in on_interaction (#268)"
+```
+
+---
+
+### Task 5: `events/discord/` — `_shared.py` + `providers/` package + thin dispatcher
+
+**Files:**
+- Create: `backend/events/discord/_shared.py`, `providers/__init__.py`, `providers/base.py`, `providers/dota.py`, `providers/deadlock.py`, `providers/registry.py`
+- Modify: `backend/events/discord/handlers.py`, `backend/events/discord/__init__.py`
+
+- [ ] **Step 1: Extract shared helpers to `_shared.py`**
+
+Move `_get_org_user`, `_load_event` (factor the `Event.objects...get` pattern), `_direct_signup` (wrap `process_rsvp`), `_log_signup`, `_log_interaction`, and the dedupe/existing-signup check. **Keep every `from events.services import ...` import function-local** (preserves the documented `events.services → events.discord → handlers` cycle break — see spec).
+
+- [ ] **Step 2: Create `providers/base.py` + per-game handlers**
+
+`base.py`: `GameSignupHandler` protocol + `DefaultHandler` (4 methods, safe defaults). `dota.py`: `DotaHandler` with `_check_dota_profile_complete`, `modal_config` (returns `DotaModalConfig`), `apply_modal_submit`, and the 8 rank-flow methods (move bodies from `handlers.py`). `deadlock.py`: `DeadlockHandler`. `registry.py`: `SIGNUP_HANDLERS = {DOTA2: DotaHandler(), DEADLOCK: DeadlockHandler()}` + `get_signup_handler` with the same `provider_fallback` log. Mirror the "Adding a game type" checklist as the docstring.
+
+- [ ] **Step 2b: Preserve cache invalidation (cached models — do NOT drop)**
+
+The relocated bodies carry three `invalidate_obj` calls. Every model below is in
+`CACHEOPS` (verified in `backend/settings.py`, 1h TTL), so dropping any one serves
+stale data for up to an hour. Keep `from app.cache_utils import invalidate_obj`
+in the new modules and preserve:
+
+```
+DeadlockHandler.apply_modal_submit   profile.save(); invalidate_obj(profile)   # was handlers.py:346 — org.playerdeadlockprofile
+DotaHandler.set_position             invalidate_obj(profile)                   # was handlers.py:773 — org.playerdotaprofile
+NotifyHandler/handle_notify_button   invalidate_obj(event.event_repeater)      # was handlers.py:670 — events.eventrepeater
+```
+
+These are the **only three** direct `invalidate_obj` calls in `handlers.py`
+(verified). Note: `handle_save_positions` (the pos_confirm bulk save) does NOT
+call `invalidate_obj` directly — it writes via `events.services`
+(`apply_signup_input` / `process_rsvp`), which use `invalidate_after_commit` and
+are **not** relocated by this refactor, so their invalidation stays put. Only
+`handle_set_position` (the per-click `pos_select_` write) has the direct Dota
+call. These three are direct `invalidate_obj` (correct — the saves are outside
+`transaction.atomic`; the only atomic blocks are in `_get_org_user`'s user
+creation). Do not convert them to `invalidate_after_commit` and do not drop them.
+
+- [ ] **Step 3: Make `handlers.py` a thin dispatcher**
+
+Each `handle_*` entry function keeps its **name and route binding**, loads the event, resolves `get_signup_handler(event.game_type)`, and delegates. Rank-flow entries guard `if not isinstance(handler, DotaHandler): return {"action": "error", "message": "Not applicable."}`. `handle_signup_button` / `handle_signup_modal_submit` call the base methods. **All return values stay the same dict shape PR2 established** (no contract change). Update `events/discord/__init__.py` `__all__` so `_check_dota_profile_complete`/`_check_deadlock_profile_complete`/`_get_org_user` source from their new modules.
+
+- [ ] **Step 4: Smoke-test imports**
+
+Run: `just test::run 'python -c "import events.discord.handlers, events.discord.providers.registry, events.services"'`
+Expected: no ImportError (verifies no cycle reintroduced).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/events/discord/
+git commit -m "refactor(discord): split handlers into _shared + per-game providers (#268)"
+```
+
+---
+
+### Task 6: New guard tests (registry, fallback, rank-flow guard, parametrized round-trip)
+
+**Files:**
+- Create: `backend/events/tests/test_provider_registry.py`
+
+- [ ] **Step 1: Write the tests**
+
+```python
+import pytest
+from unittest.mock import patch
+from app.models import GameType
+from discordbot.components.registry import COMPONENT_PROVIDERS, get_component_provider
+from events.discord.providers.registry import SIGNUP_HANDLERS, get_signup_handler
+from events.discord.providers.dota import DotaHandler
+from events.schemas import DotaModalConfig, SignupActionResponse
+
+
+def test_registry_keysets_match():
+    assert set(COMPONENT_PROVIDERS) == set(SIGNUP_HANDLERS)
+
+
+def test_deadlock_signup_invalidates_profile_cache():
+    """Cache guardrail: PlayerDeadlockProfile is cached (settings.py); the
+    relocated apply_modal_submit must still invalidate it."""
+    with patch("events.discord.providers.deadlock.invalidate_obj") as inv:
+        # ... arrange a Deadlock event + org_user, call DeadlockHandler.apply_modal_submit
+        # assert inv.called and the invalidated obj is the saved profile
+        ...
+
+
+def test_set_position_invalidates_dota_profile_cache():
+    with patch("events.discord.providers.dota.invalidate_obj") as inv:
+        # ... call DotaHandler.set_position (the pos_select_ per-click write);
+        # assert inv.called with the dota profile
+        ...
+
+
+def test_notify_invalidates_event_repeater_cache():
+    with patch("events.discord._shared.invalidate_obj") as inv:  # or wherever notify lands
+        # ... call the notify/decline path; assert inv.called with event.event_repeater
+        ...
+
+
+def test_unregistered_game_type_falls_back(caplog):
+    bogus = 999
+    assert get_component_provider(bogus).__class__.__name__ == "DefaultComponents"
+    assert get_signup_handler(bogus).__class__.__name__ == "DefaultHandler"
+
+
+def test_each_handler_modal_config_round_trips():
+    for gt, handler in SIGNUP_HANDLERS.items():
+        cfg = handler.modal_config(_stub_event_for(gt))   # build a minimal stub Event per game
+        resp = SignupActionResponse(action="needs_modal", game_type=int(gt), modal_config=cfg)
+        rt = SignupActionResponse.model_validate(resp.model_dump()).modal_config
+        assert rt is not None
+        if isinstance(cfg, DotaModalConfig):
+            assert rt.min_mmr == cfg.min_mmr
+```
+
+(Provide `_stub_event_for` building a `MagicMock`/lightweight object with the fields each `modal_config` reads, or use a Django test fixture event. The rank-flow guard test: call `handle_rank_medal_select` for a Deadlock event and assert `action == "error"`.)
+
+- [ ] **Step 2: Run**
+
+Run: `just test::run 'python -m pytest events/tests/test_provider_registry.py -q'`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/events/tests/test_provider_registry.py
+git commit -m "test(discord): registry keyset, fallback, rank-flow guard, modal_config round-trip (#268)"
+```
+
+---
+
+### Task 7: Migrate existing tests (patch targets + imports)
+
+**Files:**
+- Modify: `backend/discordbot/tests/test_signup_logging.py`, `test_components.py`, `backend/events/tests/test_signup_interactions.py`, `backend/app/tests/test_discord_reclaim.py`
+
+- [ ] **Step 1: Update `patch()` targets to new defining modules**
+
+`patch("discordbot.components.signup_button")` → `patch("discordbot.components.base.signup_button")`; `...respond_to_signup_user` → `...base.respond_to_signup_user`; `discordbot.components.save_positions` → `discordbot.components.dota.save_positions`; `patch("events.discord.handlers._get_org_user")` → `patch("events.discord._shared._get_org_user")`. (`patch` binds to the **defining** module, not the re-export.)
+
+- [ ] **Step 2: Update `EventSignupModal` references**
+
+In `test_components.py`, replace any `EventSignupModal(...)` construction with the Dota provider: `DotaComponents().build_signup_modal(event_id, prefill, DotaModalConfig(...).model_dump())`.
+
+- [ ] **Step 3: Run the full Discord suite**
+
+Run: `just test::run 'python manage.py test discordbot.tests events.tests tests app.tests.test_discord_reclaim -v 2'`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/discordbot/tests backend/events/tests backend/app/tests/test_discord_reclaim.py
+git commit -m "test(discord): migrate patch targets + imports to provider packages (#268)"
+```
+
+---
+
+### Task 8: Update the logging skill doc
+
+**Files:**
+- Modify: `.claude/skills/logging/SKILL.md`
+
+- [ ] **Step 1: Update the taxonomy "Where" paths**
+
+In the `discord`/`interaction` row, change `discordbot/components.py` to `discordbot/components/{base,dota,deadlock,default}.py` and add `events/discord/providers/` to the same row (still `discord`/`interaction`, tag-differentiated — no new subsystem). Commit:
+
+```bash
+git add .claude/skills/logging/SKILL.md
+git commit -m "docs(logging): update taxonomy paths for components/providers split (#268)"
+```
+
+---
+
+### Task 9: Full regression + demo recordings
+
+- [ ] **Step 1: Full backend Discord regression**
+
+Run: `just test::run 'python manage.py test app.tests events.tests discordbot.tests tests -v 2'`
+Expected: all PASS.
+
+- [ ] **Step 2: Re-record demos if any herodraft/draft UI components changed**
+
+Per project CLAUDE.md, the signup flow is Discord-bot, not the web `herodraft/draft/bracket` components — so demo recording is likely **not** required. Confirm no files under `frontend/app/components/herodraft|draft|bracket/` changed; if none did, skip. If unsure: `git diff --name-only main -- 'frontend/app/components/**'`.
+
+- [ ] **Step 3: Final commit if anything pending**
+
+```bash
+git status
+```
+
+---
+
+## Self-Review
+- **Spec coverage:** codecs (T1), log_context (T2), components package + bug-2 (T3), bot routing (T4), providers + _shared + dispatcher (T5), guard tests (T6), test migration (T7), logging doc (T8), regression (T9). ✓
+- **Placeholders:** relocations are explicitly "move verbatim + noted change"; new code (codecs, registries, dispatch, defer-first, tests) is shown in full. The few `...` markers denote verbatim-moved bodies, not unwritten logic.
+- **Type consistency:** `GameComponentProvider`/`GameSignupHandler`/`DotaHandler`, `bare_select_ids`/`dispatch_bare_select`, codec class names match the spec table and PR2's `DotaModalConfig`.
+- **No contract change:** PR2 owns the wire shape; PR3 only moves code + fixes bug 2 (defer-first).

--- a/docs/superpowers/specs/2026-05-31-discord-game-type-providers-design.md
+++ b/docs/superpowers/specs/2026-05-31-discord-game-type-providers-design.md
@@ -1,0 +1,867 @@
+# Discord Game-Type Providers — Design
+
+**Date:** 2026-05-31
+**Branch:** `refactor/discord-game-type-providers`
+**Status:** Approved design (revised after two multi-agent review rounds), pending implementation plan
+
+## Problem
+
+The Discord event-signup UI and its business logic are entangled across game
+types. `discordbot/components.py` (1052 lines) mixes game-agnostic RSVP
+controls with Dota-specific MMR / position / Battle Cup flows and Deadlock
+text-field flows in one file. `events/discord/handlers.py` branches on
+`event.game_type` while the rank / medal / Battle Cup handlers are implicitly
+Dota-only with no marker saying so. The internal-API response schema
+(`SignupActionResponse`) is a god-envelope that flattens eight Dota-specific
+config flags plus write-only `medal` / `tier` into one model regardless of game.
+
+Adding or maintaining a game type means editing scattered `if game_type ==`
+branches in multiple files. The goal is to make per-game behavior easy to add
+and maintain by giving each game type an operation-owning provider behind a
+registry, with each interaction dispatched to a provider method via a typed
+Pydantic custom-id.
+
+## The process boundary (load-bearing constraint)
+
+`discordbot/` runs in the **bot process** and must never import the Django ORM
+(documented in `internal_client/signup_actions.py` — overlay-fs / page-cache
+divergence). `events/discord/` runs in the **backend process** with ORM access.
+They communicate only over HTTP via `signup_actions.py`.
+
+Consequence: there is **no single `DotaProvider` class**. "Dota" is realized as
+a *pair* of operation-owning objects across the boundary, plus its codecs:
+
+- `DotaComponents` (bot process) — owns Dota's **interaction/render** operations
+  as methods; calls the HTTP client; holds no ORM.
+- `DotaHandler` (backend process) — owns Dota's **persistence** operations as
+  methods; reads/writes the ORM.
+- Dota codec subclasses in `discordbot/custom_ids.py` — the typed wire format.
+
+They share only the `GameType` key and the typed `SignupActionResponse` /
+`SignupModalConfig` HTTP contract. "Adding a game" therefore means: a module in
+each layer + codecs + one registration per layer. The spec is explicit about
+this 2-objects-plus-codecs reality rather than chasing an impossible
+single-class facade.
+
+## Goals
+
+- An operation-owning provider per game in each layer. Adding a game touches a
+  bounded, enumerated set of ~6 sites (see "Adding a game type") — not literally
+  "two files," but a short, documented checklist with tests that fail loudly on
+  a missed step.
+- No `if game_type ==` branching in `bot.py` or `handlers.py`.
+- A `default`/general provider for any game type without a dedicated module.
+- Deadlock kept as its own provider alongside Dota and default.
+- **Composition spine:** each interaction is dispatched to a provider method
+  via a typed Pydantic custom-id (see "Dispatch & composition").
+- **No behavior change** except documented exceptions — (a) `game_type` for
+  modal submit resolves from `event.game_type` not the client-sent value (see
+  Handler layer); (b) two in-flight bug fixes for issue #268 (see "Bugs fixed
+  in-flight") — and **no custom-id wire-format change**, so already-posted
+  Discord messages keep working after deploy.
+
+## Non-Goals
+
+- No change to embed builders (`events/discord/embeds.py`) or the
+  announcement-message builder (`events/discord/components.py` raw-dict path).
+- No new game types (Dota + Deadlock + default only).
+- No discriminated-union `SignupActionResponse` (deferred). Only the eight
+  config flags collapse into a nested `modal_config`.
+- No change to `RankFlowStateResponse` (separate model, stays flat).
+- No change to `discordbot/schemas.py` request schemas unless the modal `values`
+  shape changes (see Open Items).
+
+## Dispatch & composition (the spine)
+
+**The "custom-id router" is per-callback typed decode + bound-method delegation,
+NOT a central dispatcher.** The Dota follow-up views are **ephemeral,
+session-scoped in-memory views** (`timeout=300`), registered in discord.py's
+view store by `store_view` at the moment they are sent
+(`interaction.response.send_message(view=...)` / `edit_message(view=...)`, e.g.
+`components.py:67-68,459,569,682`). They are NOT persistent (`add_view` /
+`timeout=None`) and do NOT survive a bot restart — discord.py dispatches their
+child-component callbacks directly while the bot process still holds them,
+without going through `on_interaction`. (The RSVP buttons are different: the
+announcement is posted via the **raw-dict `components=` path** in
+`discordbot/utils.py`, never handed to discord.py as a `ui.View`, so they are
+reconstructed from `custom_id` on every interaction in `on_interaction`
+— `bot.py:167-182`.)
+
+A central router in `on_interaction` for the ephemeral-view components would be
+a *second, competing* dispatcher; for any component with an overridden callback
+it both duplicates work and loses the documented 40060 ACK race (the HTTP
+round-trip to the backend is ~200ms, so discord.py ACKs first). See
+`bot.py:183-190` and the `MedalSelect.callback` scar at `components.py:748-754`.
+
+So composition is realized as: **each Dota View/Select callback decodes its own
+typed `CustomId` and delegates to a bound `DotaComponents` method, forwarding
+the View's transient state as explicit kwargs.** Per-interaction state
+(`rank_status`, `require_screenshot`, `min_mmr`, `selected_medal`) lives on the
+View instance as it does today — it is NOT in the custom-id and cannot be
+reconstructed from `cid` alone — so the provider methods receive it per-call.
+The provider itself stays a stateless singleton (it stores nothing on `self`).
+The relocated body MUST carry its `discord_log_context(...)` wrapper and
+`ctx.set_outcome`/`ctx.add` telemetry with it, or structured tracing is lost.
+
+```python
+# discordbot/components/dota.py
+class DotaComponents(GameComponentProvider):
+    """Stateless singleton. Owns Dota's interaction operations as methods. No ORM.
+    Transient flow-state is passed per call (it lives on the View, not here)."""
+    async def signup_event(self, interaction, cid: SignupId) -> None: ...
+    async def rank_status_select(self, interaction, cid: RankStatusId) -> None: ...   # cid-only: clean
+    async def rank_medal_select(self, interaction, cid: RankMedalId, *,
+                                rank_status: str, require_screenshot: bool) -> None: ...
+    async def rank_star_select(self, interaction, cid: RankStarId, *, rank_status: str) -> None: ...
+    async def battle_cup_select(self, interaction, cid: BattleCupTierId) -> None: ...  # screenshot is server-driven
+    async def position_confirm(self, interaction, cid: PosConfirmId, *,
+                               rank_status: str, require_screenshot: bool, min_mmr: int | None) -> None: ...
+    async def position_select(self, interaction, cid: PosSelectId) -> None: ...        # bare select
+    async def screenshot_upload(self, interaction, cid: ScreenshotUploadId) -> None: ...
+
+class StarSelect(ui.Select):
+    def __init__(self, event_id, provider, *, rank_status, ...):
+        super().__init__(custom_id=RankStarId(event_id=event_id, medal=...).encode(), ...)
+        self._provider, self.rank_status = provider, rank_status
+    async def callback(self, interaction):          # discord.py dispatches HERE — no race
+        await self._provider.rank_star_select(
+            interaction, RankStarId.decode(self.custom_id), rank_status=self.rank_status)
+```
+
+`rank_status_select` and `battle_cup_select` need only `cid` (their callbacks
+read only `self.event_id`/`self.values`; the Battle Cup screenshot branch is
+server-driven via `result["screenshot_type"]`). `position_confirm`,
+`rank_medal_select`, and `rank_star_select` forward View state. The ORM-bearing
+methods (`position_confirm`, `rank_medal_select`, `rank_star_select`,
+`battle_cup_select`) **defer first** then `edit_original_response` — the issue
+#268 bug-2 fix, see "Bugs fixed in-flight." This
+gives the requested `DotaComponents.<operation>(...)` composition keyed by typed
+Pydantic custom-ids, while the dispatch stays exactly where discord.py already
+puts it — so the 40060 race is never reintroduced.
+
+**The one genuine central-lookup case — bare selects.** `pos_select_` is a bare
+`ui.Select` with no overridden callback (discord.py's default callback is a
+no-op), so discord.py will NOT self-dispatch it. Only this prefix needs
+`on_interaction` to find a provider:
+
+```python
+# bot.py:on_interaction
+else:
+    for provider in iter_component_providers():
+        for id_type in provider.bare_select_ids:     # ONLY codecs whose component has NO overridden callback
+            if id_type.matches(custom_id):
+                try: cid = id_type.decode(custom_id)
+                except ValueError: return            # malformed -> unhandled no-op
+                await provider.dispatch_bare_select(interaction, cid)  # -> self.position_select(...)
+                return
+```
+
+`bare_select_ids` is named to carry the invariant: it lists ONLY codecs whose
+components have no overridden callback. `DotaComponents.bare_select_ids =
+(PosSelectId,)`; every other provider `= ()`. No "register all my codecs"
+convenience may populate it, or the self-dispatching components would get
+double-dispatched and resurrect 40060.
+
+## Architecture
+
+```
+backend/
+  discordbot/
+    custom_ids.py                 # NEW: typed custom-id codecs (pydantic, bot-internal)
+    components/                    # NEW package (replaces components.py)
+      __init__.py                 # re-exports public View classes for back-compat
+      base.py                     # shared: EventSignupView, RSVP buttons,
+                                  #   ScreenshotUpload* infra, send_modal_v2,
+                                  #   build_friend_id_input
+      dota.py                     # DotaComponents (operation-owning) + Dota views
+      deadlock.py                 # DeadlockComponents + Deadlock modal
+      default.py                  # DefaultComponents (minimal modal)
+      registry.py                 # get_component_provider / iter_component_providers
+
+  events/
+    schemas.py                    # EXTENDED: SignupModalConfig + game subclasses;
+                                  #   dota_require_screenshot(); SignupActionResponse tidied
+    discord/
+      handlers.py                 # thin dispatcher to provider registry
+      _shared.py                  # NEW: _get_org_user, _load_event, _direct_signup,
+                                  #   _log_signup, _log_interaction
+      providers/                  # NEW package
+        __init__.py
+        base.py                   # GameSignupHandler protocol + DefaultHandler
+        dota.py                   # DotaHandler (owns rank-flow ops as concrete methods)
+        deadlock.py               # DeadlockHandler
+        registry.py               # get_signup_handler
+```
+
+### Protocols (two, not three)
+
+**`GameComponentProvider`** (UI layer):
+
+- `build_signup_modal(event_id, prefill, config: SignupModalConfig) -> ui.Modal`
+- `bare_select_ids: tuple[type[CustomId], ...]` — see Dispatch (Dota: `(PosSelectId,)`; others `()`).
+- `dispatch_bare_select(interaction, cid) -> None` — routes a bare-select codec
+  to the owning method (Dota: `position_select`).
+- Plus the game's interaction-operation methods (the composition spine) and its
+  follow-up View classes, all in the game module.
+
+**`GameSignupHandler`** (logic layer, `providers/base.py`) — the four genuinely
+game-agnostic operations only:
+
+- `profile_complete(org_user, event) -> bool`   (Default: `True`)
+- `prefill(org_user) -> dict`                    (Default: `{}`)
+- `modal_config(event) -> SignupModalConfig`     (Default: `SignupModalConfig()`)
+- `apply_modal_submit(org_user, user, event, values) -> SignupActionResponse`
+
+**No `RankFlowHandler` protocol.** The eight Dota rank-flow operations are
+**concrete methods on `DotaHandler`** (a single-implementer Protocol would be
+ceremony and would fragment the "one class owns its methods" composition). The
+rank-flow entry functions in `handlers.py` resolve the handler and guard with
+`isinstance(handler, DotaHandler)`, returning an `error` response otherwise — so
+non-Dota games reject stray rank-flow calls without stubbing anything.
+
+### Registry + drift guard
+
+```python
+COMPONENT_PROVIDERS = {GameType.DOTA2: DotaComponents(), GameType.DEADLOCK: DeadlockComponents()}
+def get_component_provider(game_type) -> GameComponentProvider:
+    provider = COMPONENT_PROVIDERS.get(game_type)
+    if provider is None:
+        log.error("provider_fallback", layer="components", game_type=game_type)
+        return DefaultComponents()
+    return provider
+```
+
+`GameType` is `models.IntegerChoices` (an `IntEnum`), so `COMPONENT_PROVIDERS`
+keyed on `GameType` members is looked up correctly with the bare
+`int` `resp.game_type` (`GameType.DOTA2 == 1` and hashes equal). The handler
+registry mirrors this. Unregistered type → default provider + a loud
+`provider_fallback` `log.error` (never a silent degrade).
+
+**Drift guard:** a single test asserts `set(COMPONENT_PROVIDERS) ==
+set(SIGNUP_HANDLERS)` (both importable in the backend test env). No separate
+`SUPPORTED_GAME_TYPES` manifest — the two dicts are the sources of truth and the
+equality test catches the "added to one layer, forgot the other" failure mode.
+
+Provider instances are module-level singletons and **must be stateless** — every
+call passes `event_id`/`prefill`/`config`/`cid` and returns fresh
+objects. Storing per-interaction state on a provider would race across
+concurrent users. The protocol docstring states this; the per-game module
+docstrings cross-reference their counterpart in the other layer.
+
+## Component layer (`discordbot/components/`)
+
+**`base.py`** — game-agnostic, behavior unchanged:
+
+- `EventSignupView` (+ `SignupButton`, `NotifyButton`, `TentativeButton`,
+  `DeclineButton`). The RSVP button callbacks decode their typed codec and call
+  the HTTP client directly (game-agnostic; not Dota-specific).
+- `send_modal_v2`; `ScreenshotUploadPromptView` / `ScreenshotUploadButton` /
+  `ScreenshotUploadModal` generic upload infra (param: `screenshot_type`,
+  `example_url`).
+- `build_friend_id_input(event_id, prefill, required) -> ui.TextInput | None` —
+  shared helper, single label **"Steam Friend ID"**. **Preserves current
+  behavior exactly:** returns `None` (field omitted) when
+  `prefill.get("unverified_friend_id")` is set or `required` is False; else
+  renders with `default=prefill.get("unverified_friend_id", "")`. Prefill key
+  stays `unverified_friend_id` end-to-end.
+- `SignupButton.callback`: on `needs_modal`, asks the component registry for
+  `resp.game_type` and calls `provider.build_signup_modal(event_id,
+  resp.prefill, resp.modal_config)`.
+- **Module-level bindings preserved for test patching:** `signup_button`,
+  `respond_to_signup_user`, `save_positions`, `set_position` remain
+  importable/patchable at their new defining modules (see Testing).
+
+**`dota.py`** — `DotaComponents` (operation-owning, per Dispatch spine):
+
+- `build_signup_modal()` returns `DotaSignupModal`, which **stashes the full
+  `DotaModalConfig` on `self`** — `min_mmr` and the screenshot flags are read at
+  the *follow-up* step, not at render. `on_submit` extracts Dota values and
+  builds the follow-up chain (`PositionSelectView` → `RankDetailsView`).
+- Screenshot-required is computed by the shared pure function
+  `dota_require_screenshot(rank_status, config)` (in `events/schemas.py`, see
+  below) — NOT a duplicated ternary.
+- Owns `PositionSelectView`, `PositionConfirmButton`, `RankStatusSelectView`,
+  `RankStatusSelect`, `RankDetailsView`, `MedalSelect`, `StarSelect`,
+  `BattleCupTierSelect`, the `DOTA_POSITIONS`/`DOTA_MEDALS`/`DOTA_STARS`
+  constants + option builders. Each ephemeral-view callback delegates to a
+  `DotaComponents` method (forwarding its View state per call).
+- **`StarSelect` sentinel logic stays in the callback, not the codec:**
+  `medal_part = selected_medal or "Herald"`; on decode `parts[2] == "Herald"`
+  means "unset — scan sibling `MedalSelect.values`"; `"Immortal"` suppresses the
+  star. `RankStarId` round-trips the literal string only (one-line codec
+  docstring notes the sentinel lives in the callback).
+- `bare_select_ids = (PosSelectId,)`; `dispatch_bare_select` → `position_select`
+  (defer + `set_position`, exactly as today).
+
+**`deadlock.py`** — `DeadlockComponents`: `build_signup_modal()` →
+`DeadlockSignupModal` (friend-id + rank/date inputs); direct signup, no
+follow-up; `bare_select_ids = ()`.
+
+**`default.py`** — `DefaultComponents`: minimal modal (friend-id only, or none
+if `config.require_steam_id` is False); `bare_select_ids = ()`.
+
+**Back-compat (`components/__init__.py`):** re-exports every symbol any importer
+or test uses: `EventSignupView`, `SignupButton`, `NotifyButton`,
+`TentativeButton`, `DeclineButton`, `PositionSelectView`, `PositionConfirmButton`,
+`RankDetailsView`, `MedalSelect`, `StarSelect`, `BattleCupTierSelect`,
+`RankStatusSelect`, `RankStatusSelectView`, plus patchable bindings
+`signup_button` / `save_positions` / `set_position` / `respond_to_signup_user`.
+`EventSignupModal` is removed; the test importing it builds via the Dota provider.
+
+## Handler layer (`events/discord/providers/`)
+
+`handlers.py` keeps **every** public entry function with **unchanged names and
+`/discord/...` route bindings** — thin dispatchers. The complete 13-endpoint
+surface (matching `internal_client/signup_actions.py`) and where each lands:
+
+| Entry function (`handlers.py`) | Lands on |
+|---|---|
+| `handle_signup_button` | shared dispatch → `handler.profile_complete` / `_direct_signup` / `needs_modal` |
+| `handle_signup_modal_submit` | shared dispatch → `handler.apply_modal_submit` |
+| `handle_notify_button` | shared (game-agnostic RSVP) |
+| `handle_decline_button` | shared (game-agnostic RSVP) |
+| `handle_tentative_button` | shared (game-agnostic RSVP) |
+| `handle_rank_status_select` | `DotaHandler` (concrete method) |
+| `handle_rank_medal_select` | `DotaHandler` |
+| `handle_previous_rank_submit` | `DotaHandler` |
+| `handle_battle_cup_submit` | `DotaHandler` |
+| `handle_screenshot_upload` | `DotaHandler` |
+| `handle_save_positions` | `DotaHandler` |
+| `handle_set_position` | `DotaHandler` |
+| `handle_get_rank_flow_state` | `DotaHandler` (returns `RankFlowStateResponse`, unchanged) — **dead-but-retained** |
+
+**Dead-but-retained endpoints:** `handle_get_rank_flow_state` and
+`handle_previous_rank_submit` have **no live bot-side caller** today (the
+`pos_confirm` flow reads state off the View; the "previous" rank path routes
+through `rank_medal_select`). They remain wired to endpoints + tests, so they
+relocate to `DotaHandler` for completeness but get no new logic — in particular
+the `dota_require_screenshot` extraction is driven by the **live** copy at
+`components.py:444-452`; touching `handle_get_rank_flow_state` is dead-code
+hygiene only. Mark them dead in the plan so the per-endpoint round-trip test
+matrix doesn't imply they're live paths.
+
+**Producers return `.model_dump()` dicts, not Pydantic instances.** The DRF
+view layer (`internal_signup_views.py`) does `result.get("action")` then
+`Response(result)` — both require a plain dict (a `BaseModel` has no `.get()`
+and DRF's `JSONRenderer` has no Pydantic hook). So every handler builds the
+typed model for validation/safety and `.model_dump()`s it at the `return`,
+preserving the dict contract that `internal_signup_views.py` and the consumer's
+`signup_actions.py:43` (`model_validate(resp.json())`) both depend on.
+
+```python
+def handle_signup_button(event_id, discord_user_id, discord_username):
+    event = _load_event(event_id)                          # _shared
+    org_user, user = _get_org_user(event, discord_user_id) # _shared
+    ...                                                     # _shared dedupe check
+    handler = get_signup_handler(event.game_type)
+    if handler.profile_complete(org_user, event):
+        return _direct_signup(event, user)                 # _shared (already dict)
+    return SignupActionResponse(action="needs_modal", game_type=event.game_type,
+                                prefill=handler.prefill(org_user),
+                                modal_config=handler.modal_config(event)).model_dump()
+
+def handle_rank_medal_select(event_id, discord_user_id, medal):
+    handler = get_signup_handler(_load_event(event_id).game_type)
+    if not isinstance(handler, DotaHandler):
+        return SignupActionResponse(action="error", message="Not applicable.").model_dump()
+    return handler.rank_medal_select(...)   # also returns .model_dump()
+```
+
+**`game_type` resolution — an intentional tightening.** Today
+`handle_signup_modal_submit` branches on the **client-sent** `game_type`
+(`handlers.py:301,339`; `SignupModalSubmitRequest.game_type`), which the modal
+stashed from `handle_signup_button`. The new dispatch resolves the handler from
+**`event.game_type`** (server truth) and ignores the client-sent value. In the
+normal flow they always agree; resolving from the event removes a drift window
+(event re-typed between modal-open and submit). This is a deliberate, safe
+tightening — not strictly "no behavior change" — and makes
+`SignupModalSubmitRequest.game_type` vestigial (keep it accepted-but-ignored;
+see Open Items).
+
+- **`DefaultHandler` (base.py):** the four common methods with safe defaults.
+- **`DotaHandler` (dota.py):** `_check_dota_profile_complete`, `DotaModalConfig`
+  assembly, `apply_modal_submit`, and the eight rank-flow operations as concrete
+  methods.
+- **`DeadlockHandler` (deadlock.py):** `_check_deadlock_profile_complete`,
+  `apply_modal_submit` (save `PlayerDeadlockProfile` → direct signup).
+
+**`events/discord/_shared.py`:** `_get_org_user`, `_load_event`,
+`_direct_signup`, `_log_signup`, `_log_interaction`, dedupe check — imported by
+`handlers.py` and every provider (no provider→dispatcher inversion).
+`events/discord/__init__.py` `__all__` is updated so the re-exported helpers
+(`_check_dota_profile_complete`, `_check_deadlock_profile_complete`,
+`_get_org_user`) source from their new modules. **Load-bearing invariant:** the
+existing `events.services → events.discord(__init__) → handlers` cycle
+(`handlers.py:21`) is broken today by keeping all `from events.services import …`
+calls **function-local**. `_shared.py` (`_get_org_user` needs
+`resolve_or_create_org_user`; `_direct_signup` needs `process_rsvp`) and the
+providers MUST preserve that function-local discipline — a top-level
+`events.services` import in either re-introduces the cycle at import time.
+
+## Pydantic data layer
+
+### Typed custom-id codecs — `discordbot/custom_ids.py`
+
+Pydantic `BaseModel` subclasses, bot-internal. The Discord custom-id is a
+`prefix:field` **colon string** (100-char cap), so the wire uses `encode()`,
+**not** `model_dump()` JSON. (`model_dump()` is for the HTTP models below — the
+FastAPI-style "Pydantic model is the contract, dump to JSON on the wire" pattern
+that `signup_actions.py` already hand-rolls under DRF.)
+
+```python
+class CustomId(BaseModel):
+    PREFIX: ClassVar[str]
+    event_id: int
+    model_config = {"frozen": True}
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        assert getattr(cls, "PREFIX", None), f"{cls.__name__} must set PREFIX"
+    def encode(self) -> str: ...
+    @classmethod
+    def matches(cls, raw: str) -> bool: ...           # raw.startswith(PREFIX + ":")
+    @classmethod
+    def decode(cls, raw: str) -> "CustomId":
+        try: ...                                       # split + int + construct
+        except (ValueError, IndexError, ValidationError) as exc:
+            raise ValueError(f"bad custom_id {raw!r}") from exc
+```
+
+`decode` raises `ValueError` uniformly; routers/callers treat any `decode`
+exception as "unhandled". One subclass per existing prefix, byte-for-byte:
+
+| Model | Wire format | Owner |
+|---|---|---|
+| `SignupId` / `TentativeId` / `DeclineId` / `NotifyId` | `event_signup:{id}`, `event_tentative:{id}`, `event_decline:{id}`, `event_notify:{id}` | base |
+| `PosSelectId(slot)` | `pos_select_{slot}:{id}` | dota |
+| `PosConfirmId` | `pos_confirm:{id}` | dota |
+| `RankStatusId` | `rank_status:{id}` | dota |
+| `RankMedalId` | `rank_medal:{id}` | dota |
+| `RankStarId(medal)` | `rank_star:{id}:{medal}` | dota |
+| `BattleCupTierId` | `bcup_tier:{id}` | dota |
+| `ScreenshotUploadId(screenshot_type)` | `screenshot_upload:{id}:{type}` | base |
+| `ScreenshotFileId(screenshot_type)` | `screenshot_file:{id}:{type}` | base |
+| `ScreenshotUrlId(screenshot_type)` | `screenshot_url:{id}:{type}` | base |
+| `SignupFriendId` | `signup_friend_id:{id}` | base |
+| `SignupRankStatusId` | `signup_rank_status:{id}` | dota |
+| `SignupDeadlockRankId` / `SignupDeadlockDateId` | `signup_deadlock_rank:{id}`, `signup_deadlock_date:{id}` | deadlock |
+
+`PosSelectId` carries the slot **before** the colon, so it overrides
+`encode`/`decode`/`matches`. `ScreenshotUrlId` is the `FileUpload`-absent
+fallback (`components.py:986`) — a live prefix, must be included. Codecs live
+centrally in `custom_ids.py` (not per-game module) so the wire format has one
+home and `log_context.py` can derive from it.
+
+A **byte-for-byte round-trip test** asserts every model's `.encode()` equals the
+current literal and `.decode()` recovers fields; malformed input raises
+`ValueError`. **Single source of truth for prefixes:** `log_context.py`
+(`_SIGNUP_TAG_PREFIXES`) is refactored to derive its prefix list from
+`custom_ids.py`. **Mind the `pos_select_` slot shape:** `_SIGNUP_TAG_PREFIXES`
+today lists three literals `pos_select_1/2/3`, and `log_context._prefix()` does
+`custom_id.split(":",1)[0]` → `"pos_select_1"`. But `PosSelectId.PREFIX` is
+`"pos_select"` (slot is before the colon), so a naive derivation would yield
+`{"pos_select"}` and the runtime membership check `"pos_select_1" in {...}` would
+**fail**, silently dropping the `["events","signup"]` tags on position selects.
+The derivation must normalize/expand the `pos_select_{slot}` shape (e.g. match by
+`startswith("pos_select_")`), and `test_log_context` must assert the **runtime
+`_prefix("pos_select_1:42")` membership**, not merely set-equality of the two
+prefix lists.
+
+### Per-game modal config + shared selection logic — `events/schemas.py`
+
+Each config carries a `kind` **discriminator** literal so the models survive the
+HTTP `model_validate(dict) → model_dump()` round-trip in `signup_actions.py:43`.
+This is required: with a plain base annotation (`modal_config: SignupModalConfig`)
+Pydantic v2 serializes by the declared base type and **silently drops every Dota
+field** — empirically verified, `model_dump()` yields only
+`{'require_steam_id': True}`, losing `min_mmr` / `allow_*` / screenshot flags.
+`SerializeAsAny` does not fix it (validation coerces to base before dump). A
+discriminated union is the form that round-trips exactly.
+
+```python
+from typing import Literal
+from pydantic import Field
+
+class SignupModalConfig(BaseModel):           # base / default
+    kind: Literal["default"] = "default"
+    require_steam_id: bool = True
+class DotaModalConfig(SignupModalConfig):
+    kind: Literal["dota"] = "dota"
+    require_rank_screenshot: bool = False
+    require_battlecup_screenshot: bool = False
+    min_mmr: int | None = None
+    allow_active_mmr: bool = True
+    allow_previous_rank: bool = True
+    allow_battlecup_rating: bool = True
+class DeadlockModalConfig(SignupModalConfig):
+    kind: Literal["deadlock"] = "deadlock"
+
+# discriminated union alias used by the response envelope
+ModalConfig = Annotated[
+    DotaModalConfig | DeadlockModalConfig | SignupModalConfig,
+    Field(discriminator="kind"),
+]
+
+def dota_require_screenshot(rank_status: str, cfg: DotaModalConfig) -> bool:
+    if rank_status == "active": return cfg.require_rank_screenshot
+    if rank_status == "never":  return cfg.require_battlecup_screenshot
+    return False                                   # previous
+```
+
+`dota_require_screenshot` is the **single** home for the screenshot-required
+ternary (replacing the byte-identical copies at `components.py:444-452` and
+`handlers.py:799-807`). It's a pure function over the transported config, so
+both processes call it: the UI side passes the stashed `DotaModalConfig`;
+`handle_get_rank_flow_state` builds a `DotaModalConfig` from the event and calls
+the same function. (Keeping two *config flags* is fine and required — only the
+*selection logic* is deduplicated.) Both layers already import `events.schemas`
+(`signup_actions.py:27`), so no new dependency edge.
+
+`handler.modal_config(event) -> SignupModalConfig` returns the typed game
+config (a concrete subclass). A test pins the **producer-side** result —
+`DotaHandler.modal_config()` returns a `DotaModalConfig`, `DeadlockHandler` a
+`DeadlockModalConfig` — and a separate round-trip test asserts a
+`DotaModalConfig` survives `SignupActionResponse.model_validate(resp.model_dump()).modal_config`
+with all six Dota fields intact (this is what the `kind` discriminator buys).
+
+### Tidied response envelope — `events/schemas.py`
+
+**Minimal, safe change:** only the eight flat config flags collapse into nested
+`modal_config`. `screenshot_type` stays **flat** (the unchanged
+`StarSelect`/`BattleCupTierSelect` callbacks read `result["screenshot_type"]`
+with a bracket index at `components.py:825,875` — nesting would `KeyError`). The
+write-only-never-read `medal` / `tier` fields are **dropped**.
+
+```python
+class SignupActionResponse(BaseModel):
+    action: str | None = None
+    status: str | None = None
+    message: str | None = None
+    game_type: int | None = None              # bare int for wire compat; GameType is IntEnum
+    prefill: dict | None = None
+    modal_config: ModalConfig | None = None           # discriminated union (was 8 flat Dota flags)
+    screenshot_type: str | None = None                # stays FLAT (bracket-indexed by views)
+    subscribed: bool | None = None
+    success: bool | None = None
+    signed_up: bool | None = None
+    positions: list[int] | None = None
+    model_config = {"extra": "forbid"}                # was "ignore"
+```
+
+**CRITICAL — atomic with producer edits.** `extra: "forbid"` + dropping
+`medal`/`tier` means the three producers that currently return those keys
+(`handle_rank_medal_select` `handlers.py:433-437`, `handle_previous_rank_submit`
+`:490-494`, `handle_battle_cup_submit` `:545-549`) MUST stop emitting `medal=` /
+`tier=` in the same change — otherwise `model_validate` raises `ValidationError`
+(uncaught by `_validated()`) and the needs-screenshot flow crashes. No consumer
+reads `medal`/`tier` (verified: zero `result["medal"]`/`["tier"]` reads), so
+simply remove those keys from the three return dicts. **Equally fatal under
+`forbid`:** `handle_signup_button` currently returns the seven flat config flags
+(`require_steam_id` … `allow_battlecup_rating`); that return dict must be
+rewritten to `modal_config=DotaModalConfig(...)` in the same atomic change, or
+`forbid` rejects it too. The per-endpoint round-trip test (Testing) catches any
+producer still emitting a removed key.
+
+`extra: "forbid"` makes a missed producer key fail loudly in tests rather than
+silently become `None`.
+
+**Deploy-skew note (blast radius).** The producer (`handlers.py`) runs in the
+backend container; the consumer (`signup_actions.py` `model_validate`) runs in
+the discord-bot container. `extra:"forbid"` turns a version-skew window between
+the two containers into a hard `ValidationError` (signup crash), not a degrade.
+This is acceptable **because DraftForge builds all images at one `pyproject`
+version and deploys them together** — the only skew window is the restart, when
+the bot is already unavailable and signup interactions already fail. Requirement:
+**PR2 (the contract change) must deploy backend + bot from the same release tag**
+(the existing release model already does this). Do not hand-deploy one container
+ahead of the other.
+
+### Producer / consumer migration surface (atomic, one release)
+
+- **Producers** (`handlers.py`/`DotaHandler`): `handle_signup_button` emits
+  `modal_config=DotaModalConfig(...)` (was 8 flat flags); the three
+  needs-screenshot producers keep flat `screenshot_type` and **drop**
+  `medal`/`tier`.
+- **Pass-through:** `internal_signup_views.py` returns `Response(result)`;
+  `signup_actions.py:43` does `SignupActionResponse.model_validate(...).model_dump()`.
+- **Consumers** (`components.py`): the ~8 `result.get(<flag>)` /
+  `event_config.get(<flag>)` sites (`:171-185,307,367,445,448,457`) read the
+  nested `modal_config` dict instead. `result["screenshot_type"]`
+  (`:825,875`) unchanged.
+
+## Error handling
+
+- Unknown game_type → default provider + loud `provider_fallback` `log.error`.
+- Malformed custom-id → `decode` raises `ValueError`; router try/excepts → no-op.
+- Missing codec `PREFIX` → `__init_subclass__` assert fails at import.
+- Non-Dota handler receiving a rank-flow call → `isinstance(handler,
+  DotaHandler)` guard returns an `error` response.
+- Existing modal `on_error` handlers preserved per game modal.
+
+## Bugs fixed in-flight (issue #268)
+
+Two production bugs (Grafana-traced) live in code this refactor relocates.
+Fixing them in place during the move avoids refactor-then-refix, but they are
+**intentional behavior changes** layered on the behavior-preserving refactor.
+
+**Bug 1 — `view=None` crashes the DM-disabled ephemeral fallback**
+(`signup_responses.py:96`). `respond_to_signup_user`'s `Forbidden(50007)`
+fallback passes `view=view`/`embed=embed` (often `None`) to
+`interaction.followup.send` (discord.py `Webhook.send`), which raises
+`TypeError: expected view parameter to be of type View not NoneType` — `None`
+is not `MISSING` and lacks `__discord_ui_view__`. The DM path (`Messageable.send`)
+tolerates `None`, so only the fallback crashes. **Fix:** use the
+`discord.utils.MISSING` sentinel (`send_view = view if view is not None else
+MISSING`, same for embed) on the `followup.send` call (and defensively on
+`dm_channel.send`). `signup_responses.py` is not split by the refactor, so this
+is a small self-contained edit on the branch; `base.py`'s RSVP confirmation path
+depends on it.
+
+**Bug 2 — `pos_confirm` double-ACK 40060 from slow ORM before defer**
+(`components.py:682`, `PositionConfirmButton.callback`). The callback runs
+`sync_to_async(save_positions)` (slow ORM) **before** any ACK, then
+`interaction.response.edit_message(...)`; exceeding the ~3s window makes Discord
+redeliver and the second delivery 40060s. This is a **distinct 40060 source**
+from the router race the Dispatch section discusses (that one is a competing
+dispatcher; this one is slow-work-before-ACK in a single callback). **Fix
+(baked into the relocated provider methods):** the relocated `position_confirm`
+— and its ORM-bearing siblings `rank_medal_select` / `rank_star_select` /
+`battle_cup_select` — must **`await interaction.response.defer()` first** (plain
+`defer()` = type-6 `DEFERRED_MESSAGE_UPDATE`, which updates the source ephemeral;
+**not** `thinking=True`, which would spawn a new message — see
+`signup_responses.py:8-23`), then do the ORM call, then
+`interaction.edit_original_response(...)` instead of `response.edit_message(...)`.
+Add a double-click guard (disable the Confirm button/selects on first activation
+before the await). The bare `pos_select_` path is unaffected (it already defers
+in `on_interaction`).
+
+This means the composition spine's relocated methods change the ACK pattern
+(defer-first) — a deliberate fix, not pure relocation. The "no behavior change"
+goal already carries documented exceptions; these two join that list.
+
+## Adding a game type (the extension checklist)
+
+The DX goal is that a developer adding game type #3 (say CS2) months from now
+follows a checklist and copies `dota.py`/`deadlock.py` as a template — without
+re-reading the subsystem. The honest touch-point list (mirror this as a docstring
+on **both** `registry.py` files so the dev finds it where they land):
+
+1. `discordbot/components/<game>.py` — `<Game>Components` (build_signup_modal,
+   `bare_select_ids`, operation methods + any follow-up View classes).
+2. `events/discord/providers/<game>.py` — `<Game>Handler` (profile_complete,
+   prefill, modal_config, apply_modal_submit; rank-flow methods only if needed).
+3. `events/schemas.py` — `<Game>ModalConfig(SignupModalConfig)` with
+   `kind: Literal["<game>"]`, **AND add it to the `ModalConfig` discriminated
+   union alias.** (Skipping the union edit is silent — the config routes to base
+   and loses its fields. The parametrized round-trip test below catches it.)
+4. `app/models.py` `GameType` — add the member, **and sync
+   `frontend/app/components/game/constants.ts`** per the enum's own docstring.
+5. Register in `discordbot/components/registry.py` (`COMPONENT_PROVIDERS`).
+6. Register in `events/discord/providers/registry.py` (`SIGNUP_HANDLERS`).
+   (Steps 5+6 are guarded by the keyset-equality test — miss one and it goes red.)
+7. `discordbot/custom_ids.py` — only if the game has unique interaction flows
+   needing new codecs (a text-field game like Deadlock needs none).
+
+Most steps fail loudly if missed (import asserts, the keyset test, the
+parametrized round-trip test). Step 4's frontend sync and step 3's union edit are
+the two that need the checklist + the round-trip test to stay safe.
+
+## Logging & observability
+
+The refactor relocates every logging-bearing callback and handler, so it must
+preserve the `system`/`subsystem`/`tags` taxonomy and interaction correlation
+(`telemetry.logging` / `discord_log_context`). Requirements:
+
+1. **`discord_log_context` relocates with the operation body.** Each Dota
+   component callback today wraps its whole body in `async with
+   discord_log_context(interaction, custom_id=..., event_id=...) as ctx:` and
+   calls `ctx.set_outcome(...)` / `ctx.add(...)`. When the body moves into a
+   `DotaComponents.<operation>` method, **the method owns the CM** (it has the
+   `interaction` + decoded `cid`) and keeps the `ctx` plumbing. The bound fields
+   (`system="discord"`, `subsystem="interaction"`, `interaction_id`, `tags`,
+   `event_id`, …) and the `interaction_started/finished/failed` bookends must be
+   byte-identical. RSVP button callbacks in `base.py` keep their existing
+   `discord_log_context` wrapping unchanged.
+
+2. **`log_context.py` codec derivation covers all THREE uses, not just tags.**
+   `_prefix()` feeds `resolve_tags()` (the `["events","signup"]` tags +
+   `tags_csv`), `parse_event_id()` (the bound `event_id`), and `span_name()`
+   (the OTel span `discord.interaction.<prefix>`). All three currently
+   `custom_id.split(":")`. Route them through `custom_ids.py`: `event_id` from
+   `CustomId.decode(...).event_id`, tags/span from a codec-derived prefix. The
+   `pos_select_{slot}` shape (slot before the colon) is the trap (see Pydantic
+   layer): with codec `PREFIX="pos_select"`, `span_name` becomes
+   `discord.interaction.pos_select` (was `…pos_select_1`) — an acceptable
+   granularity change, but `resolve_tags` membership must still match
+   `pos_select_1:42` at runtime (`startswith("pos_select_")`), tested via the
+   runtime `_prefix(...)` membership assertion.
+
+3. **Give the relocated handler-layer logs `system`/`subsystem` + tags (fixes a
+   pre-existing gap).** `handlers.py` logs (`handler_invoked`,
+   `signup_persisted`, `signup_rejected`) carry **no `system`/`subsystem`** today
+   — they run in the backend process and don't inherit the bot-process
+   contextvars across the HTTP boundary. As these move into `providers/dota.py`
+   etc., bind `system="discord"`, **`subsystem="interaction"`** (keep the
+   subsystem stable — a Discord interaction spans concerns; do NOT mint a
+   per-flow subsystem like `signup`), and differentiate the flow type via the
+   **`tags`** list (`["events","signup"]`, plus `tags_csv`) — the multi-value
+   cross-cutting axis. New interaction types add a tag, not a subsystem.
+   Preserve the existing `bind_contextvars(org_user_id=..., user_id=...)` calls;
+   `bind_contextvars` at handler entry is the natural place to set
+   system/subsystem/tags since the bot-process context doesn't cross the HTTP
+   boundary.
+
+4. **Update the `logging` skill taxonomy doc in lockstep.** The skill's
+   system/subsystem table (`.claude/skills/logging/SKILL.md`) names
+   `discordbot/components.py` and `discordbot/log_context.py` under
+   `discord`/`interaction` (tags `["events","signup"]`). After the split those
+   paths become `discordbot/components/{base,dota,deadlock,default}.py` and
+   `events/discord/providers/` — all still `discord`/`interaction`, tag-
+   differentiated. Update the "Where" paths in the existing row; no new
+   subsystem row. Same lockstep discipline as the brand skill.
+
+## Testing
+
+New:
+- **Custom-id round-trip** (`discordbot/tests/`): `.encode()`/`.decode()`
+  byte-for-byte; malformed → `ValueError`.
+- **Registry keyset equality:** `set(COMPONENT_PROVIDERS) == set(SIGNUP_HANDLERS)`.
+- **Parametrized modal_config round-trip (auto-covers new games):** iterate
+  `SIGNUP_HANDLERS`, call each `handler.modal_config(<stub event>)`, and assert it
+  survives `SignupActionResponse.model_validate(model_dump()).modal_config` with
+  its subclass fields intact. A game added without the `ModalConfig` union edit
+  (checklist step 3) fails this test immediately — turning the silent footgun into
+  a red test for free.
+- **`modal_config` type pin:** `DotaHandler.modal_config()` → `DotaModalConfig`;
+  `DeadlockHandler` → `DeadlockModalConfig`.
+- **`log_context` prefix parity** with the codec set, including the runtime
+  `_prefix("pos_select_1:42") in _SIGNUP_TAG_PREFIXES` membership assertion (not
+  just set-equality) and `parse_event_id`/`span_name` codec routing.
+- **Handler-log taxonomy:** relocated provider/handler logs emit
+  `system="discord"`, `subsystem="interaction"`, `tags=["events","signup"]`
+  (via `capture_logs`), and the `discord_log_context` bookends still bind
+  `interaction_id`/`tags`/`event_id`.
+- **Per-endpoint forbid round-trip:** a representative payload from each of the
+  13 producers passes `SignupActionResponse.model_validate` under
+  `extra:"forbid"` (catches any producer still emitting a dropped key).
+- **`dota_require_screenshot`** truth table (active/previous/never × flags).
+- **Issue #268 bug 1:** `respond_to_signup_user` with `Forbidden(50007)` and no
+  `view`/`embed` returns `EPHEMERAL`, calls `followup.send(ephemeral=True)` with
+  the `<@user_id>` mention, and raises no `TypeError` (MISSING sentinel).
+- **Issue #268 bug 2:** the ORM-bearing provider methods `defer()` *before* the
+  `sync_to_async` call and use `edit_original_response` (not
+  `response.edit_message`); a second delivery / double-click is a no-op.
+- **Registry fallback path:** `get_component_provider(<unregistered>)` returns
+  the default provider AND emits the `provider_fallback` `log.error` (assert via
+  `capture_logs`). Same for `get_signup_handler`.
+- **Rank-flow guard:** calling a rank-flow entry function
+  (`handle_rank_medal_select` etc.) for a non-Dota event returns an `error`
+  `SignupActionResponse` (the `isinstance(handler, DotaHandler)` guard).
+- **Codec import guard:** a `CustomId` subclass without `PREFIX` raises at import
+  (the `__init_subclass__` assert).
+
+Update (enumerated from audit):
+- `discordbot/tests/test_components.py` — imports + `EventSignupModal` →
+  provider-built modal; patch target `discordbot.components.save_positions`.
+- `discordbot/tests/test_signup_logging.py` — **patch-target migration:**
+  `patch("discordbot.components.signup_button"|".respond_to_signup_user")` and
+  `patch("events.discord.handlers._get_org_user")` → new defining modules.
+- `discordbot/tests/test_log_context.py` — prefixes derived from codecs.
+- `events/tests/test_signup_interactions.py` — largest handler test; imports 8
+  handlers incl. `handle_set_position` / `handle_get_rank_flow_state`.
+- `events/tests/test_signup_schema.py` — nested `modal_config`, `extra:"forbid"`,
+  dropped `medal`/`tier`.
+- `tests/test_events_discord.py` — imports 4 handlers.
+- `app/tests/test_discord_reclaim.py` — `_get_org_user` now from `_shared`.
+
+Regression: `just test::run 'python manage.py test app.tests events.tests discordbot.tests tests -v 2'`.
+
+## PR sequencing (stacked, not big-bang)
+
+To keep blast radius low and each change independently reviewable/revertible,
+ship as three stacked PRs rather than one:
+
+- **PR1 — bug 1 (`signup_responses.py` MISSING sentinel).** ~10 lines,
+  independent of everything else, fixes live issue #268 (DM-disabled signup
+  crash) immediately. Ship first.
+- **PR2 — Pydantic contract tidy.** `DotaModalConfig`/`kind`/`ModalConfig`
+  discriminated union + `extra:"forbid"` on `SignupActionResponse` + the
+  producer edits (`handlers.py`: nest `modal_config`, drop `medal`/`tier`).
+  Behavior-preserving, small diff, lands before the structural churn so the
+  contract is stable when the providers arrive.
+- **PR3 — the structural refactor.** `components/` + `providers/` packages,
+  `custom_ids.py`, `log_context` rewrite, `bot.py` routing, `_shared.py`, and
+  bug 2 (defer-first) — which lives in the relocated `position_confirm` /
+  rank-flow methods, so it rides along naturally.
+
+Each PR is green before the next stacks on it. A regression reverts one PR, not
+all five changes.
+
+## Caching invariants (cacheops)
+
+The write models the providers touch are all in `CACHEOPS` (`settings.py`, 1h
+TTL): `org.playerdeadlockprofile`, `org.playerdotaprofile`, `org.orguser`,
+`events.event`, `events.eventsignup`, `events.eventrepeater`. The refactor is
+invalidation-**neutral** — it adds no new cached model or `@cached_as` site —
+but PR3's relocation must **preserve the three existing `invalidate_obj` calls**
+(Deadlock profile save `:346`, Dota per-click `set_position` write `:773`,
+event_repeater subscriber count `:670`). `handle_save_positions` invalidates via
+`events.services` (`invalidate_after_commit`, not relocated) — not a direct call.
+They are direct `invalidate_obj` (correct: the saves are outside
+`transaction.atomic`; do not convert to `invalidate_after_commit`). A guard test
+spies `invalidate_obj` on each relocated write path so a dropped call fails CI
+instead of silently serving stale data for an hour.
+
+## Migration / rollout
+
+Pure internal reorganization. No DB migration. No custom-id format change
+(round-trip test enforces it) — and no `add_view()`/startup view-registration
+exists to update: RSVP buttons are posted as raw dicts and rebuilt from
+`custom_id` per interaction in `on_interaction`, and the Dota follow-up views are
+ephemeral (`timeout=300`, `store_view`'d on send), so neither survives restart by
+design. The response change
+(8 flags → nested `modal_config`, drop `medal`/`tier`) ships atomically with its
+producers and consumers in one release; `extra:"forbid"` + the per-endpoint
+round-trip test catch any miss. Old import paths preserved via
+`components/__init__.py`; `patch()` targets updated where they bind to relocated
+defining modules.
+
+## Open items (resolve during planning)
+
+- **Request schemas (`discordbot/schemas.py`):** if per-game `apply_modal_submit`
+  changes the modal `values` shape, `SignupModalSubmitRequest.values` (untyped
+  `dict`) may warrant a typed per-game model. Default: leave untyped (no
+  behavior change). Also: `SignupModalSubmitRequest.game_type` becomes vestigial
+  (dispatch now uses `event.game_type`) — keep it accepted-but-ignored, or drop
+  it in a follow-up.
+- **Stale working docs:** `docs/superpowers/plans/2026-05-03-...`,
+  `2026-05-25-...` reference moved line numbers. Gitignored working docs —
+  update only if convenient.
+
+## Worktree parallelization (within PR3)
+
+PRs are sequential (PR1 → PR2 → PR3). Within **PR3** there are two largely
+independent lanes that can be built in parallel worktrees and merged:
+
+| Lane | Modules | Depends on |
+|---|---|---|
+| A | `discordbot/custom_ids.py`, `discordbot/components/`, `discordbot/log_context.py`, `bot.py` | PR2 contract |
+| B | `events/discord/providers/`, `events/discord/_shared.py`, `handlers.py` dispatch | PR2 contract |
+
+Both lanes depend on PR2's `events/schemas.py` contract (the shared types), so
+PR2 lands first; then A and B proceed in parallel and integrate at the
+`signup_actions` HTTP boundary. Conflict risk is low (disjoint app directories);
+the only shared file is `events/schemas.py`, already frozen by PR2.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not run (internal refactor) |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | scope reduced to 3-PR stack; 1 arch finding (deploy-skew) resolved; 3 test gaps added |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 1 | CLEAR | TRIAGE, add-a-game lens: 5/10 → 8/10 (checklist + parametrized round-trip test) |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | n/a (backend) |
+| Independent rounds | (Claude multi-agent) | Correctness/contract | 4 | CLEAR | 2 BLOCKERs caught + fixed (modal_config stripping, view-state loss); 1 DRF-serialization HIGH; bug fixes folded in |
+
+- **UNRESOLVED:** 0
+- **VERDICT:** ENG + DX CLEARED — ready to implement as the 3-PR stack (PR1 bug
+  fix → PR2 contract → PR3 structural refactor).


### PR DESCRIPTION
## Summary
First PR in the 3-PR Discord game-type provider stack. Fixes live issue #268 (bug 1): users with DMs disabled crash on signup.

`respond_to_signup_user`'s `Forbidden(50007)` fallback passed a literal `None` `view`/`embed` to `interaction.followup.send` (discord.py `Webhook.send`), which raises `TypeError: expected view parameter to be of type View not NoneType` — `None` is not `MISSING` and lacks `__discord_ui_view__`. The DM path (`Messageable.send`) tolerates `None`, so only the followup fallback was affected.

**Fix:** pass `discord.utils.MISSING` instead of `None` on the followup path only (smallest diff; DM path unchanged).

## Test
- New `RespondToSignupUserNoViewFallbackTest` simulates `Webhook.send`'s None-rejection — red before the fix (`TypeError` at signup_responses.py:96), green after.
- Full `test_signup_responses` suite: 9/9 pass, no regression.

## Stack
This branch also carries the design spec + 3-PR implementation plans (docs/superpowers/). PR2 (Pydantic contract) and PR3 (structural refactor) build on this.

Independently shippable — does not depend on PR2/PR3.