### PR TITLE
Copilot path-scoped logging review + structlog migration + ruff

### DIFF
--- a/.claude/skills/logging/SKILL.md
+++ b/.claude/skills/logging/SKILL.md
@@ -43,6 +43,9 @@ Every log MUST include `system` and `subsystem` kwargs. These are the primary Gr
 | `discord` | `dispatch` | `["events","signup"]` | `events/discord/dispatch.py` | `notify_*` dispatch visibility (queued vs skipped); threads `interaction_id` to Celery |
 | `discord` | `celery` | `["events","signup"]` | `events/tasks.py` (Discord-dispatching tasks) | `celery_task_started/finished/failed` bookend logs |
 | `cache` | `invalidate` | — | `app/cache_utils.py` | Per-object cacheops invalidation fired from `transaction.on_commit` |
+| `websocket` | `broadcast` | — | `app/broadcast.py` | Draft / herodraft event + state broadcast to channel groups (`kind` field distinguishes draft/herodraft/herodraft_state) |
+| `auth` | `internal` | — | `app/auth.py` | Internal-service auth (X-Internal-Token): IP-allowlist rejects, invalid-token failures |
+| `auth` | `social` | — | `app/pipelines.py` | Discord OAuth social-auth pipeline: account reclaim/merge, username matching |
 
 Add new systems/subsystems as features grow. Keep systems coarse (feature area), subsystems functional (what role the code plays).
 

--- a/.claude/skills/logging/SKILL.md
+++ b/.claude/skills/logging/SKILL.md
@@ -46,6 +46,18 @@ Every log MUST include `system` and `subsystem` kwargs. These are the primary Gr
 | `websocket` | `broadcast` | — | `app/broadcast.py` | Draft / herodraft event + state broadcast to channel groups (`kind` field distinguishes draft/herodraft/herodraft_state) |
 | `auth` | `internal` | — | `app/auth.py` | Internal-service auth (X-Internal-Token): IP-allowlist rejects, invalid-token failures |
 | `auth` | `social` | — | `app/pipelines.py` | Discord OAuth social-auth pipeline: account reclaim/merge, username matching |
+| `auth` | `merge` | — | `app/discord_accounts.py` | Discord account de-dup / merge |
+| `tournament` | `draft`, `registration`, `user` | — | `app/models.py`, `app/functions/tournament.py` | Draft build/pick/rebuild, captain/team registration, per-user avatar refresh |
+| `api` | `serializer`, `routing`, `main`, `csv_import`, `joke` | — | `app/serializers.py`, `app/views*.py`, `app/views/csv_import.py`, `backend/urls.py` | DRF serializer mutations, view cache-miss, CSV import, env/routing |
+| `user` | `functions` | — | `app/functions/user.py` | Profile-update request/validate/apply |
+| `app` | `signals` | — | `app/signals.py` | Model signal handlers (org/league user create, herodraft cleanup) |
+| `internal_client` | `http` | — | `app/internal_client/__init__.py` | Internal HTTP client JSON-parse failures |
+| `discord` | `bot`, `utils`, `views`, `channels`, `roles`, `users` | — | `discordbot/**` | Bot lifecycle, message utils, slash views, channel/role/user services |
+| `events` | `tasks`, `services`, `views`, `dispatch` | — | `events/**` | Event task lifecycle, signup services, manual fire, tournament-link dispatch |
+| `steam` | `api`, `game_linking`, `match`, `mmr`, `stats`, `model`, `league_sync`, `retry` | — | `steam/**` | Steam API, account/game linking, match fetch/store, MMR/stats, league sync, retry |
+| `bracket` | `generate`, `model` | — | `bracket/**` | Bracket generation + model-level cache logging |
+| `org` | `views` | — | `org/views.py` | Org admin actions (user delete/merge) |
+| `common` | `utils` | — | `common/utils.py` | Shared utility warnings (CI/IP detection) |
 
 Add new systems/subsystems as features grow. Keep systems coarse (feature area), subsystems functional (what role the code plays).
 

--- a/.claude/skills/logging/SKILL.md
+++ b/.claude/skills/logging/SKILL.md
@@ -31,6 +31,9 @@ Every log MUST include `system` and `subsystem` kwargs. These are the primary Gr
 | `herodraft` | `heartbeat` | — | `herodraft_tick.py` | Heartbeat staleness checks, heartbeat-triggered pauses |
 | `herodraft` | `timer` | — | `herodraft_tick.py` | Tick loop lifecycle, tick broadcast, timeout auto-pick, resume |
 | `websocket` | `heartbeat` | — | `consumers_base.py` | Heartbeat receive, captain register/unregister (generic WS infra) |
+| `websocket` | `connection` | — | `telemetry/websocket.py` | Generic WS connect/disconnect/receive instrumentation |
+| `herodraft` | `view` | — | `app/functions/herodraft_views.py` | HeroDraft HTTP actions: create, roll, choice/pick submit, abandon, reset |
+| `celery` | `task` | — | `telemetry/celery.py` | Generic Celery task lifecycle bookends (started/completed/failed) |
 | `events` | `discord` | — | `events/tasks.py` (cron sync, non-interaction tasks like `sync_discord_events`) | Cron-driven event sync to Discord that isn't triggered by an interaction |
 | `events` | `scheduling` | — | `events/tasks.py` | Event generation, signup opening, repeaters |
 | `tournament` | `discord` | — | `discordbot/tasks.py` | Tournament DMs, bracket notifications |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,7 @@ Each rule set below is canonical at `.claude/skills/<name>/SKILL.md`. The matchi
 | Skill | Canonical | Scope (Copilot `applyTo`) |
 |-------|-----------|---------------------------|
 | Backend caching | `.claude/skills/django-redis-caching/SKILL.md` | `backend/**/*.py` |
+| Backend logging | `.claude/skills/logging/SKILL.md` | `backend/**/*.py` (excl. management commands) |
 | Brand / theming | `.claude/skills/brand/SKILL.md` (+ `docs/THEMING-GUIDE.md`) | `frontend/app/components/**`, `routes/**`, `features/**`, `app.css` |
 | React patterns | global `react` skill | `frontend/**/*.{ts,tsx}` |
 | shadcn/ui | global `shadcn` skill (+ `frontend/components.json`) | `frontend/app/components/**/*.{ts,tsx}` |

--- a/.github/instructions/logging.instructions.md
+++ b/.github/instructions/logging.instructions.md
@@ -10,7 +10,8 @@ pipeline, so logs never reach Grafana.
 
 ## Rules
 
-- **Never `import logging` / `logging.getLogger(__name__)`.** Use
+- **Never `import logging` / `logging.getLogger(__name__)`** (except management
+  commands — see "Out of scope" below). Use
   `from telemetry.logging import get_logger` then `log = get_logger(__name__)`.
   This is enforced by ruff (`TID251` bans `logging.getLogger`); Copilot is the
   backup reviewer.

--- a/.github/instructions/logging.instructions.md
+++ b/.github/instructions/logging.instructions.md
@@ -1,0 +1,36 @@
+---
+applyTo: "backend/**/*.py"
+---
+
+# Structured logging (structlog → OpenTelemetry)
+
+Canonical: `.claude/skills/logging/SKILL.md`. Backend logs are structured JSON
+exported to Grafana Cloud via OpenTelemetry. Base stdlib `logging` bypasses that
+pipeline, so logs never reach Grafana.
+
+## Rules
+
+- **Never `import logging` / `logging.getLogger(__name__)`.** Use
+  `from telemetry.logging import get_logger` then `log = get_logger(__name__)`.
+  This is enforced by ruff (`TID251` bans `logging.getLogger`); Copilot is the
+  backup reviewer.
+- **Event name first, context in kwargs.** The first positional arg is a
+  snake_case event name (`"broadcast_sent"`), not a sentence. **No f-strings or
+  `%` formatting** in log calls — pass data as kwargs.
+- **Every log needs `system` and `subsystem` kwargs** — the primary Grafana
+  filter dimensions. Keep `system` coarse (feature area), `subsystem` functional.
+- **Include relevant entity IDs**: `draft_id`, `user_id`/`username`, `event_id`,
+  `tournament_id`, `reason` (for skipped/failed actions), `error=str(e)` (never
+  the full traceback).
+- **Pick the right level**: `DEBUG` (per-request/tick detail, not exported in
+  prod), `INFO` (state transitions/lifecycle), `WARNING` (self-recovering
+  anomalies), `ERROR` (failures needing attention).
+
+## Out of scope here
+
+- **Management commands** (`backend/**/management/commands/*.py`) are one-off CLI
+  tools, not part of the OTEL-exported request/task flow — they may keep stdlib
+  `logging` and `self.stdout.write`. They're excluded from the ruff ban too.
+- Caching, testing, and migration patterns — see their own `.instructions.md`.
+
+Canonical source: `.claude/skills/logging/SKILL.md` — update there first.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,15 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.3.0  # or latest stable version
+  # Ruff replaces black + isort. `ruff` lints (config in pyproject.toml
+  # [tool.ruff]): import order (I), bans base stdlib logging in OTEL-flow code
+  # (TID), enforces annotations (ANN). `ruff-format` does the formatting.
+  # Run `pre-commit autoupdate` to bump the rev.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
     hooks:
-      -   id: black
+      # Format first, then lint/check — so the check sees formatted code.
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
@@ -10,7 +17,3 @@ repos:
         args: ['--unsafe']
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,14 @@ repos:
         args: ['--unsafe']
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+  # Enforce structured-logging taxonomy: every get_logger(...) call must pass a
+  # string-literal event name + system= + subsystem=. Only files binding a
+  # logger via get_logger are checked (stdlib-logging files are ignored).
+  - repo: local
+    hooks:
+      - id: logging-taxonomy
+        name: structured logging taxonomy (system/subsystem)
+        entry: python3 backend/scripts/check_logging_taxonomy.py
+        language: system
+        files: \.py$
+        pass_filenames: true

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -13,13 +13,16 @@ Security layers:
 """
 
 import hmac
-import logging
+import ipaddress
 
 from django.conf import settings
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
 
-logger = logging.getLogger(__name__)
+from telemetry.logging import get_logger
+
+log = get_logger(__name__)
 
 # Default allowed IPs: localhost + Docker bridge networks
 DEFAULT_ALLOWED_IPS = [
@@ -31,7 +34,7 @@ DEFAULT_ALLOWED_IPS = [
 ]
 
 
-def _get_client_ip(request):
+def _get_client_ip(request: Request) -> str:
     """Extract client IP from request, handling proxy headers."""
     forwarded = request.META.get("HTTP_X_FORWARDED_FOR")
     if forwarded:
@@ -39,10 +42,8 @@ def _get_client_ip(request):
     return request.META.get("REMOTE_ADDR", "")
 
 
-def _ip_in_allowlist(ip, allowed):
+def _ip_in_allowlist(ip: str, allowed: list[str]) -> bool:
     """Check if IP matches any entry in the allowlist (supports CIDR)."""
-    import ipaddress
-
     try:
         addr = ipaddress.ip_address(ip)
     except ValueError:
@@ -70,14 +71,16 @@ class InternalServiceUser:
     pk = -1
     username = "_internal_service"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.username
 
 
 class InternalServiceAuth(BaseAuthentication):
     """Authenticate via X-Internal-Token header + IP whitelist."""
 
-    def authenticate(self, request):
+    def authenticate(
+        self, request: Request
+    ) -> tuple["InternalServiceUser", None] | None:
         token = (
             request.headers.get("X-Internal-Token")
             or request.META.get("HTTP_X_INTERNAL_TOKEN")
@@ -94,19 +97,31 @@ class InternalServiceAuth(BaseAuthentication):
         )
         client_ip = _get_client_ip(request)
         if not _ip_in_allowlist(client_ip, allowed_ips):
-            logger.warning("Internal auth rejected: IP %s not in allowlist", client_ip)
+            log.warning(
+                "internal_auth_rejected",
+                system="auth",
+                subsystem="internal",
+                reason="ip_not_allowed",
+                client_ip=client_ip,
+            )
             return None
 
         # Token comparison (timing-safe)
         if hmac.compare_digest(token, expected):
             return (InternalServiceUser(), None)
 
-        logger.warning("Internal auth failed: invalid token from IP %s", client_ip)
+        log.warning(
+            "internal_auth_failed",
+            system="auth",
+            subsystem="internal",
+            reason="invalid_token",
+            client_ip=client_ip,
+        )
         return None
 
 
 class IsInternalService(BasePermission):
     """Allow only authenticated internal service requests."""
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: object) -> bool:
         return isinstance(request.user, InternalServiceUser)

--- a/backend/app/broadcast.py
+++ b/backend/app/broadcast.py
@@ -2,7 +2,7 @@
 Broadcast helper for sending draft events to WebSocket channel groups.
 """
 
-import logging
+from typing import TYPE_CHECKING
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -14,11 +14,15 @@ from app.serializers import (
     HeroDraftSerializer,
     _build_users_dict,
 )
+from telemetry.logging import get_logger
 
-log = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from app.models import DraftEvent, DraftTeam, HeroDraft
+
+log = get_logger(__name__)
 
 
-def broadcast_event(event, include_draft_state=True):
+def broadcast_event(event: "DraftEvent", include_draft_state: bool = True) -> None:
     """
     Broadcast a DraftEvent to both draft-specific and tournament channel groups.
 
@@ -33,7 +37,14 @@ def broadcast_event(event, include_draft_state=True):
     """
     channel_layer = get_channel_layer()
     if channel_layer is None:
-        log.warning("No channel layer configured, skipping broadcast")
+        log.warning(
+            "broadcast_skipped",
+            system="websocket",
+            subsystem="broadcast",
+            kind="draft",
+            reason="no_channel_layer",
+            draft_id=event.draft_id,
+        )
         return
 
     payload = DraftEventSerializer(event).data
@@ -60,7 +71,14 @@ def broadcast_event(event, include_draft_state=True):
                 str(k): v for k, v in _build_users_dict(draft.tournament).items()
             }
         except Exception as e:
-            log.warning(f"Failed to serialize draft state: {e}")
+            log.warning(
+                "broadcast_serialize_failed",
+                system="websocket",
+                subsystem="broadcast",
+                kind="draft",
+                draft_id=event.draft_id,
+                error=str(e),
+            )
 
     try:
         message = {
@@ -83,18 +101,34 @@ def broadcast_event(event, include_draft_state=True):
         )
 
         log.info(
-            f"Broadcast {event.event_type} to draft_{event.draft_id} and tournament_{tournament_id}"
-            + (" (with draft state)" if draft_state else "")
+            "broadcast_sent",
+            system="websocket",
+            subsystem="broadcast",
+            kind="draft",
+            event_type=event.event_type,
+            draft_id=event.draft_id,
+            tournament_id=tournament_id,
+            with_state=bool(draft_state),
         )
     except Exception as e:
         # Log the error but don't fail the draft operation
         log.warning(
-            f"Failed to broadcast {event.event_type} to channels: {e}. "
-            "WebSocket clients will not receive real-time updates for this event."
+            "broadcast_failed",
+            system="websocket",
+            subsystem="broadcast",
+            kind="draft",
+            event_type=event.event_type,
+            draft_id=event.draft_id,
+            error=str(e),
         )
 
 
-def broadcast_herodraft_event(draft, event_type: str, draft_team=None, metadata=None):
+def broadcast_herodraft_event(
+    draft: "HeroDraft",
+    event_type: str,
+    draft_team: "DraftTeam | None" = None,
+    metadata: dict | None = None,
+) -> None:
     """
     Broadcast a HeroDraft event to WebSocket consumers.
 
@@ -108,7 +142,14 @@ def broadcast_herodraft_event(draft, event_type: str, draft_team=None, metadata=
 
     channel_layer = get_channel_layer()
     if channel_layer is None:
-        log.warning("No channel layer configured, skipping herodraft broadcast")
+        log.warning(
+            "broadcast_skipped",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft",
+            reason="no_channel_layer",
+            draft_id=draft.id,
+        )
         return
 
     # Create event record (if not already created by the view)
@@ -140,22 +181,47 @@ def broadcast_herodraft_event(draft, event_type: str, draft_team=None, metadata=
         ).get(id=draft.id)
         payload["draft_state"] = HeroDraftSerializer(draft).data
     except Exception as e:
-        log.warning(f"Failed to serialize herodraft state: {e}")
+        log.warning(
+            "broadcast_serialize_failed",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft",
+            draft_id=draft.id,
+            error=str(e),
+        )
 
     # Send to channel group
     room_group_name = f"herodraft_{draft.id}"
 
     try:
         async_to_sync(channel_layer.group_send)(room_group_name, payload)
-        log.debug(f"Broadcast herodraft {event_type} to {room_group_name}")
+        log.debug(
+            "broadcast_sent",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft",
+            event_type=event_type,
+            draft_id=draft.id,
+            event_id=event.id,
+        )
     except Exception as e:
         log.warning(
-            f"Failed to broadcast herodraft {event_type} to channels: {e}. "
-            "WebSocket clients will not receive real-time updates for this event."
+            "broadcast_failed",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft",
+            event_type=event_type,
+            draft_id=draft.id,
+            error=str(e),
         )
 
 
-def broadcast_herodraft_state(draft, event_type: str, metadata=None, draft_team=None):
+def broadcast_herodraft_state(
+    draft: "HeroDraft",
+    event_type: str,
+    metadata: dict | None = None,
+    draft_team: "DraftTeam | None" = None,
+) -> None:
     """
     Broadcast the current HeroDraft state to WebSocket consumers.
 
@@ -170,7 +236,14 @@ def broadcast_herodraft_state(draft, event_type: str, metadata=None, draft_team=
     """
     channel_layer = get_channel_layer()
     if channel_layer is None:
-        log.warning("No channel layer configured, skipping herodraft state broadcast")
+        log.warning(
+            "broadcast_skipped",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft_state",
+            reason="no_channel_layer",
+            draft_id=draft.id,
+        )
         return
 
     # Build payload with current state
@@ -197,7 +270,14 @@ def broadcast_herodraft_state(draft, event_type: str, metadata=None, draft_team=
         ).get(id=draft.id)
         payload["draft_state"] = HeroDraftSerializer(draft).data
     except Exception as e:
-        log.warning(f"Failed to serialize herodraft state: {e}")
+        log.warning(
+            "broadcast_serialize_failed",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft_state",
+            draft_id=draft.id,
+            error=str(e),
+        )
         return  # Don't broadcast without state
 
     # Send to channel group
@@ -205,9 +285,21 @@ def broadcast_herodraft_state(draft, event_type: str, metadata=None, draft_team=
 
     try:
         async_to_sync(channel_layer.group_send)(room_group_name, payload)
-        log.debug(f"Broadcast herodraft state ({event_type}) to {room_group_name}")
+        log.debug(
+            "broadcast_sent",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft_state",
+            event_type=event_type,
+            draft_id=draft.id,
+        )
     except Exception as e:
         log.warning(
-            f"Failed to broadcast herodraft state to channels: {e}. "
-            "WebSocket clients will not receive real-time updates."
+            "broadcast_failed",
+            system="websocket",
+            subsystem="broadcast",
+            kind="herodraft_state",
+            event_type=event_type,
+            draft_id=draft.id,
+            error=str(e),
         )

--- a/backend/app/consumers.py
+++ b/backend/app/consumers.py
@@ -58,8 +58,11 @@ class DraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
     async def draft_event(self, event):
         """Handle draft.event messages from channel layer."""
         log.debug(
-            f"DraftConsumer sending draft_event to client "
-            f"(draft={self.draft_id}, channel={self.channel_name})"
+            "draft_event_send",
+            system="herodraft",
+            subsystem="connection",
+            draft_id=self.draft_id,
+            channel_name=self.channel_name,
         )
         message = {
             "type": "draft_event",

--- a/backend/app/consumers_base.py
+++ b/backend/app/consumers_base.py
@@ -207,7 +207,11 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
             self._connection_tracked = True
         except Exception as e:
             log.warning(
-                f"Failed to increment connection for draft {self.draft_id}: {e}"
+                "connection_count_increment_failed",
+                system="websocket",
+                subsystem="heartbeat",
+                draft_id=self.draft_id,
+                error=str(e),
             )
 
     @database_sync_to_async
@@ -220,7 +224,11 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
             self._connection_tracked = False
         except Exception as e:
             log.warning(
-                f"Failed to decrement connection for draft {self.draft_id}: {e}"
+                "connection_count_decrement_failed",
+                system="websocket",
+                subsystem="heartbeat",
+                draft_id=self.draft_id,
+                error=str(e),
             )
 
     # --- Tick broadcaster ---
@@ -234,7 +242,11 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
             start_tick_broadcaster(self.draft_id)
         except Exception as e:
             log.warning(
-                f"Failed to start tick broadcaster for draft {self.draft_id}: {e}"
+                "tick_broadcaster_start_failed",
+                system="websocket",
+                subsystem="heartbeat",
+                draft_id=self.draft_id,
+                error=str(e),
             )
 
     # --- Server-side ping loop ---
@@ -252,7 +264,13 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            log.debug(f"Ping loop ended for draft {self.draft_id}: {e}")
+            log.debug(
+                "ping_loop_ended",
+                system="websocket",
+                subsystem="heartbeat",
+                draft_id=self.draft_id,
+                error=str(e),
+            )
 
     # --- Span helpers ---
 
@@ -332,7 +350,10 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
 
         with tracer.start_as_current_span(
             "ws.connect",
-            attributes={**self._base_span_attrs(), "ws.path": self.scope.get("path", "")},
+            attributes={
+                **self._base_span_attrs(),
+                "ws.path": self.scope.get("path", ""),
+            },
         ) as span:
             # OTel's start_as_current_span auto-records propagating
             # exceptions and sets ERROR status on context exit, so no
@@ -344,7 +365,13 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
             exists = await self.draft_exists(self.draft_id)
             if not exists:
                 span.set_attribute("ws.connect_outcome", "draft_not_found")
-                log.warning(f"{prefix} {self.draft_id} not found, closing connection")
+                log.warning(
+                    "draft_not_found",
+                    system="websocket",
+                    subsystem="heartbeat",
+                    draft_id=self.draft_id,
+                    reason="closing connection",
+                )
                 await self.close()
                 return False
 
@@ -382,14 +409,21 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
                 # Start tick broadcaster if draft is in an active state
                 if (
                     initial_state
-                    and initial_state.get("state") in self.get_active_draft_state_values()
+                    and initial_state.get("state")
+                    in self.get_active_draft_state_values()
                 ):
                     await self._maybe_start_tick_broadcaster()
 
             except Exception as e:
                 span.record_exception(e)
                 span.set_status(Status(StatusCode.ERROR, "initial_state_failed"))
-                log.error(f"Failed to send initial state for {prefix} {self.draft_id}: {e}")
+                log.error(
+                    "initial_state_send_failed",
+                    system="websocket",
+                    subsystem="heartbeat",
+                    draft_id=self.draft_id,
+                    error=str(e),
+                )
                 await self.close()
                 return False
 
@@ -436,8 +470,11 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
             if was_kicked:
                 span.set_attribute("ws.kicked", True)
                 log.info(
-                    f"Skipping disconnect handling for kicked connection "
-                    f"(user {getattr(self, 'user', None)}, draft {getattr(self, 'draft_id', None)})"
+                    "kicked_disconnect_skipped",
+                    system="websocket",
+                    subsystem="heartbeat",
+                    draft_id=getattr(self, "draft_id", None),
+                    user_id=getattr(getattr(self, "user", None), "id", None),
                 )
                 if hasattr(self, "room_group_name"):
                     await self.channel_layer.group_discard(
@@ -462,7 +499,11 @@ class BaseDraftConsumer(TelemetryConsumerMixin, AsyncWebsocketConsumer):
                     # Tempo shows what failed.
                     span.record_exception(e)
                     log.error(
-                        f"Failed to mark captain disconnected for draft {self.draft_id}: {e}"
+                        "captain_disconnect_cleanup_failed",
+                        system="websocket",
+                        subsystem="heartbeat",
+                        draft_id=self.draft_id,
+                        error=str(e),
                     )
 
             # Leave room group

--- a/backend/app/discord_accounts.py
+++ b/backend/app/discord_accounts.py
@@ -14,12 +14,11 @@ This module reconciles the two rows: it keeps the account that already owns the
 it, moving the social-auth link and any other related data across.
 """
 
-from telemetry.logging import get_logger
-
 from django.db import IntegrityError, transaction
 
 from app.cache_utils import invalidate_obj
 from app.models import CustomUser
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -149,12 +148,14 @@ def merge_discord_accounts(keep: CustomUser, drop: CustomUser) -> CustomUser:
             keep.save(update_fields=changed)
 
         logger.info(
-            "Merged Discord account #%s (%s) into #%s (%s) discordId=%s",
-            drop.pk,
-            drop.username,
-            keep.pk,
-            keep.username,
-            keep.discordId,
+            "discord_accounts_merged",
+            system="auth",
+            subsystem="merge",
+            dropped_user_id=drop.pk,
+            dropped_username=drop.username,
+            kept_user_id=keep.pk,
+            kept_username=keep.username,
+            discord_id=keep.discordId,
         )
         drop.delete()
     invalidate_obj(keep)
@@ -176,9 +177,7 @@ def find_split_discord_accounts():
     )
     # Single query for all candidate owners instead of one per social row (N+1).
     uids = {str(sa.uid) for sa in socials}
-    owners = {
-        u.discordId: u for u in CustomUser.objects.filter(discordId__in=uids)
-    }
+    owners = {u.discordId: u for u in CustomUser.objects.filter(discordId__in=uids)}
 
     pairs = []
     for sa in socials:

--- a/backend/app/discord_accounts.py
+++ b/backend/app/discord_accounts.py
@@ -14,14 +14,14 @@ This module reconciles the two rows: it keeps the account that already owns the
 it, moving the social-auth link and any other related data across.
 """
 
-import logging
+from telemetry.logging import get_logger
 
 from django.db import IntegrityError, transaction
 
 from app.cache_utils import invalidate_obj
 from app.models import CustomUser
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Discord identity / profile fields copied from the duplicate onto the kept
 # account when the kept account is missing them. Split into two groups because

--- a/backend/app/functions/herodraft_views.py
+++ b/backend/app/functions/herodraft_views.py
@@ -10,8 +10,6 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
-from telemetry.logging import get_logger
-
 from app.broadcast import broadcast_herodraft_event
 from app.functions.herodraft import (
     get_available_heroes,
@@ -22,6 +20,7 @@ from app.functions.herodraft import (
 from app.models import DraftTeam, Game, HeroDraft, HeroDraftEvent, HeroDraftState
 from app.permissions_org import IsTournamentStaff
 from app.serializers import HeroDraftEventSerializer, HeroDraftSerializer
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -122,7 +121,13 @@ def create_herodraft(request, game_pk):
     DraftTeam.objects.create(draft=draft, tournament_team=game.radiant_team)
     DraftTeam.objects.create(draft=draft, tournament_team=game.dire_team)
 
-    log.info(f"Created HeroDraft {draft.pk} for game {game.pk}")
+    log.info(
+        "herodraft_created",
+        system="herodraft",
+        subsystem="view",
+        draft_id=draft.pk,
+        game_id=game.pk,
+    )
 
     # Create event
     HeroDraftEvent.objects.create(
@@ -209,7 +214,12 @@ def set_ready(request, draft_pk):
     if all_ready:
         draft.state = HeroDraftState.ROLLING
         draft.save()
-        log.info(f"HeroDraft {draft.pk} transitioning to rolling state")
+        log.info(
+            "herodraft_state_rolling",
+            system="herodraft",
+            subsystem="view",
+            draft_id=draft.pk,
+        )
 
     broadcast_herodraft_event(draft, "captain_ready", draft_team)
 
@@ -251,7 +261,12 @@ def do_trigger_roll(request, draft_pk):
     winner = trigger_roll(draft, draft_team)
 
     log.info(
-        f"HeroDraft {draft.pk} roll triggered by team {draft_team.pk}, winner: {winner.pk}"
+        "herodraft_roll_triggered",
+        system="herodraft",
+        subsystem="view",
+        draft_id=draft.pk,
+        draft_team_id=draft_team.pk,
+        winner_team_id=winner.pk,
     )
 
     broadcast_herodraft_event(draft, "roll_result", winner)
@@ -336,7 +351,6 @@ def do_submit_choice(request, draft_pk):
             )
 
     # Roll winner must make first choice
-    other_team = draft.draft_teams.exclude(pk=draft_team.pk).first()
     if is_roll_winner:
         # Roll winner makes first choice (either pick_order or side)
         pass
@@ -361,7 +375,13 @@ def do_submit_choice(request, draft_pk):
     submit_choice(draft, draft_team, choice_type, value)
 
     log.info(
-        f"HeroDraft {draft.pk} choice submitted: {choice_type}={value} by team {draft_team.pk}"
+        "herodraft_choice_submitted",
+        system="herodraft",
+        subsystem="view",
+        draft_id=draft.pk,
+        draft_team_id=draft_team.pk,
+        choice_type=choice_type,
+        value=value,
     )
 
     broadcast_herodraft_event(draft, "choice_made", draft_team)
@@ -453,7 +473,13 @@ def do_submit_pick(request, draft_pk):
         return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     log.info(
-        f"HeroDraft {draft.pk} pick submitted: hero {hero_id} by team {draft_team.pk} (round {completed_round.round_number})"
+        "herodraft_pick_submitted",
+        system="herodraft",
+        subsystem="view",
+        draft_id=draft.pk,
+        draft_team_id=draft_team.pk,
+        hero_id=hero_id,
+        round_number=completed_round.round_number,
     )
 
     # Include hero_id and action_type in metadata for the toast notification
@@ -546,7 +572,12 @@ def abandon_draft(request, draft_pk):
     draft.save()
 
     log.info(
-        f"HeroDraft {draft.pk} abandoned by user {request.user.pk} (staff={is_staff})"
+        "herodraft_abandoned",
+        system="herodraft",
+        subsystem="view",
+        draft_id=draft.pk,
+        user_id=request.user.pk,
+        is_staff=is_staff,
     )
 
     # Create event for audit trail
@@ -600,7 +631,13 @@ def reset_draft(request, draft_pk):
     draft.is_manual_pause = False
     draft.save()
 
-    log.info(f"HeroDraft {draft.pk} reset by admin {request.user.pk}")
+    log.info(
+        "herodraft_reset",
+        system="herodraft",
+        subsystem="view",
+        draft_id=draft.pk,
+        user_id=request.user.pk,
+    )
 
     # Create event for audit trail
     HeroDraftEvent.objects.create(

--- a/backend/app/functions/user.py
+++ b/backend/app/functions/user.py
@@ -1,5 +1,5 @@
 import json
-import logging
+from telemetry.logging import get_logger
 
 import requests
 from django.contrib.auth import login
@@ -34,7 +34,7 @@ from app.serializers import (
 )
 from backend import settings
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 # This allows a user to update only for certain fields

--- a/backend/app/functions/user.py
+++ b/backend/app/functions/user.py
@@ -1,38 +1,16 @@
-import json
-from telemetry.logging import get_logger
-
-import requests
-from django.contrib.auth import login
-from django.contrib.auth import logout as auth_logout
-from django.contrib.auth.decorators import login_required
 from django.db import transaction
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
-from django.shortcuts import redirect, render
-from rest_framework import generics, permissions, serializers, status, viewsets
+from rest_framework import serializers
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.generics import GenericAPIView
-from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
-from social_core.backends.oauth import BaseOAuth1, BaseOAuth2
 
 # Create your views here.
-from social_django.models import USER_MODEL  # fix: skip
-from social_django.models import AbstractUserSocialAuth, DjangoStorage
-from social_django.utils import load_strategy, psa
-
-from app.models import CustomUser, Draft, DraftRound, PositionsModel, Team, Tournament
-from app.permissions import IsStaff
+from app.models import CustomUser, PositionsModel
 from app.serializers import (
-    DraftRoundSerializer,
-    DraftSerializer,
-    GameSerializer,
     PositionsSerializer,
-    TeamSerializer,
-    TournamentSerializer,
     UserSerializer,
 )
-from backend import settings
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -53,7 +31,6 @@ class ProfileUserSerializer(serializers.ModelSerializer):
 
 
 class ProfileUpdateSerializer(serializers.Serializer):
-
     positions = PositionsSerializer(many=False, required=False)
     nickname = serializers.CharField(required=False, allow_blank=True, max_length=100)
     steam_account_id = serializers.IntegerField(required=False, allow_null=True)
@@ -67,7 +44,9 @@ def profile_update(request):
         return Response({"error": "Unauthorized"}, status=401)
 
     serializer = ProfileUpdateSerializer(data=request.data)
-    log.debug(request.data)
+    log.debug(
+        "profile_update_request", system="user", subsystem="functions", user_id=user.pk
+    )
     if serializer.is_valid():
         positions = serializer.validated_data.get("positions", None)
         steam_account_id = serializer.validated_data.get("steam_account_id", None)
@@ -75,7 +54,12 @@ def profile_update(request):
 
     else:
         return Response(serializer.errors, status=400)
-    log.debug(serializer.validated_data)
+    log.debug(
+        "profile_update_validated",
+        system="user",
+        subsystem="functions",
+        user_id=user.pk,
+    )
 
     try:
         posObj = PositionsModel.objects.get(pk=user.positions.pk)
@@ -105,7 +89,15 @@ def profile_update(request):
             user.steam_account_id = steam_account_id
     if nickname is not None:
         user.nickname = nickname
-    log.debug(f"{positions}, {steam_account_id}, {nickname}")
+    log.debug(
+        "profile_update_fields",
+        system="user",
+        subsystem="functions",
+        user_id=user.pk,
+        has_positions=positions is not None,
+        has_steam_account_id=steam_account_id is not None,
+        has_nickname=nickname is not None,
+    )
     with transaction.atomic():
         posObj.save()
         user.save()

--- a/backend/app/internal_client/__init__.py
+++ b/backend/app/internal_client/__init__.py
@@ -575,7 +575,12 @@ def list_discord_linked_users():
     try:
         return resp.json()
     except ValueError:
-        logger.error("discord-linked-users returned non-JSON: %s", resp.text[:200])
+        logger.error(
+            "discord_linked_users_invalid_json",
+            system="internal_client",
+            subsystem="http",
+            body_excerpt=resp.text[:200],
+        )
         return []
 
 
@@ -590,7 +595,12 @@ def list_discord_guild_ids():
     try:
         return resp.json().get("guild_ids", [])
     except ValueError:
-        logger.error("discord-guild-ids returned non-JSON: %s", resp.text[:200])
+        logger.error(
+            "discord_guild_ids_invalid_json",
+            system="internal_client",
+            subsystem="http",
+            body_excerpt=resp.text[:200],
+        )
         return []
 
 
@@ -636,5 +646,10 @@ def sweep_discord_leases(pending_threshold_minutes=5, failed_threshold_hours=1):
     try:
         return resp.json()
     except ValueError:
-        logger.error("sweep-stale-leases returned non-JSON: %s", resp.text[:200])
+        logger.error(
+            "sweep_stale_leases_invalid_json",
+            system="internal_client",
+            subsystem="http",
+            body_excerpt=resp.text[:200],
+        )
         return {"pending_swept": 0, "failed_swept": 0, "total": 0}

--- a/backend/app/internal_client/__init__.py
+++ b/backend/app/internal_client/__init__.py
@@ -9,14 +9,13 @@ Config:
     INTERNAL_SERVICE_TOKEN: shared secret for X-Internal-Token header.
 """
 
-import logging
 import os
 
 import requests
 
 from telemetry.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 log = get_logger("app.internal_client")
 
 INTERNAL_API_URL = os.environ.get(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,24 +1,17 @@
-from telemetry.logging import get_logger
-
-import nh3
 import requests
-from cacheops import cached_as
-
-from app.cache_utils import invalidate_obj
 from django.conf import settings
-from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models
 from django.db.utils import IntegrityError
 from django.utils import timezone
-from social_django.models import USER_MODEL  # fix: skip
-from social_django.models import AbstractUserSocialAuth, DjangoStorage
+
+from app.cache_utils import invalidate_obj
+from telemetry.logging import get_logger
 
 User = settings.AUTH_USER_MODEL
 
 from enum import IntEnum, StrEnum
 
 from django.contrib.auth.models import AbstractUser
-from django.db.models import JSONField
 
 log = get_logger(__name__)
 
@@ -158,6 +151,7 @@ class CustomUser(AbstractUser):
         """
         # Use a local import to avoid the circular at module load.
         from app.cache_utils import invalidate_after_commit
+
         bp = getattr(self, "base_profile", None)
         if bp is None:
             # User hasn't been saved yet (no pk) — buffer the value and apply
@@ -176,6 +170,7 @@ class CustomUser(AbstractUser):
     @avatar.setter
     def avatar(self, value):
         from app.cache_utils import invalidate_after_commit
+
         bp = getattr(self, "base_profile", None)
         if bp is None:
             self._pending_avatar = value
@@ -230,7 +225,11 @@ class CustomUser(AbstractUser):
             return response.status_code == 200
         except requests.RequestException:
             log.warning(
-                f"Failed to validate avatar URL for user {self.username}: {url}"
+                "avatar_url_validation_failed",
+                system="tournament",
+                subsystem="user",
+                username=self.username,
+                url=url,
             )
             return False
 
@@ -248,7 +247,11 @@ class CustomUser(AbstractUser):
         discord_bot_token = getattr(settings, "DISCORD_BOT_TOKEN", None)
         if not discord_bot_token:
             log.debug(
-                f"Skipping avatar fetch for {self.username}: DISCORD_BOT_TOKEN not configured"
+                "avatar_fetch_skipped",
+                system="tournament",
+                subsystem="user",
+                username=self.username,
+                reason="DISCORD_BOT_TOKEN not configured",
             )
             return False
 
@@ -274,25 +277,41 @@ class CustomUser(AbstractUser):
                     # model field.
                     self.avatar = new_avatar
                     log.info(
-                        f"Updated avatar for user {self.username} (Discord ID: {self.discordId})"
+                        "avatar_updated",
+                        system="tournament",
+                        subsystem="user",
+                        username=self.username,
+                        discord_id=self.discordId,
                     )
                     return True
                 return False
 
             else:
                 log.warning(
-                    f"Failed to fetch Discord user data for {self.username}: {response.status_code}"
+                    "avatar_fetch_failed",
+                    system="tournament",
+                    subsystem="user",
+                    username=self.username,
+                    status_code=response.status_code,
                 )
                 return False
 
         except requests.RequestException as e:
             log.error(
-                f"Error fetching Discord avatar for user {self.username}: {str(e)}"
+                "avatar_fetch_error",
+                system="tournament",
+                subsystem="user",
+                username=self.username,
+                error=str(e),
             )
             return False
         except Exception as e:
             log.error(
-                f"Unexpected error updating avatar for user {self.username}: {str(e)}"
+                "avatar_update_unexpected_error",
+                system="tournament",
+                subsystem="user",
+                username=self.username,
+                error=str(e),
             )
             return False
 
@@ -327,6 +346,7 @@ class CustomUser(AbstractUser):
         # 4. BaseUserProfile auto-create. Idempotent via get_or_create.
         # Local import avoids the circular: user.models -> app.CustomUser.
         from user.models import BaseUserProfile
+
         bp, _ = BaseUserProfile.objects.get_or_create(user=self)
 
         # 5. Flush pending nickname/avatar values buffered by the property
@@ -344,6 +364,7 @@ class CustomUser(AbstractUser):
             fields_to_update.append("avatar")
         if fields_to_update:
             from app.cache_utils import invalidate_after_commit
+
             bp.save(update_fields=fields_to_update)
             invalidate_after_commit(bp)
             if pending_nickname is not None:
@@ -369,7 +390,7 @@ class CustomUser(AbstractUser):
             # New default avatar URL logic based on user ID
             return f"https://cdn.discordapp.com/embed/avatars/{(int(self.discordId) >> 22) % 6}.png"
 
-        return f"https://cdn.discordapp.com/embed/avatars/0.png"  # Fallback
+        return "https://cdn.discordapp.com/embed/avatars/0.png"  # Fallback
 
     class Meta:
         indexes = [
@@ -932,11 +953,7 @@ class Game(models.Model):
             invalidate_obj(self.league)
 
 
-from cacheops import cached_as
-
-
 class Draft(models.Model):
-
     tournament = models.OneToOneField(
         Tournament,
         related_name="draft",
@@ -976,7 +993,13 @@ class Draft(models.Model):
 
         def get_simulation_data(draft_style=draft_style):
             teams = list(self.tournament.teams.order_by("draft_order"))
-            log.debug(f"Getting Simulation for {draft_style} teams: {teams}")
+            log.debug(
+                "simulation_teams_loaded",
+                system="tournament",
+                subsystem="draft",
+                draft_style=draft_style,
+                team_count=len(teams),
+            )
             if not teams:
                 return {}
 
@@ -1018,7 +1041,6 @@ class Draft(models.Model):
             num_teams = len(teams)
             total_picks = num_teams * picks_per_team
             pick_number = 1
-            phase = 1
 
             for round_num in range(picks_per_team):
                 if draft_style == "snake":
@@ -1035,7 +1057,6 @@ class Draft(models.Model):
 
                 # Each team in the pick order gets one pick this round
                 for team in pick_order:
-
                     if pick_number <= total_picks and available_players:
                         # Pick highest MMR available player
                         player_id, player_mmr = available_players.pop(0)
@@ -1044,14 +1065,26 @@ class Draft(models.Model):
                         team_rosters[team.id].append((player_id, player_mmr))
 
                         log.debug(
-                            f"{draft_style} sim: Team {team.name} picked player {player_id} with MMR {player_mmr}"
+                            "simulation_pick",
+                            system="tournament",
+                            subsystem="draft",
+                            draft_style=draft_style,
+                            team_name=team.name,
+                            player_id=player_id,
+                            player_mmr=player_mmr,
                         )
                         pick_number += 1
 
             return team_rosters
 
         data = get_simulation_data(draft_style=draft_style)
-        log.debug(data)
+        log.debug(
+            "simulation_complete",
+            system="tournament",
+            subsystem="draft",
+            draft_style=draft_style,
+            team_count=len(data),
+        )
         return data
 
     @property
@@ -1162,18 +1195,38 @@ class Draft(models.Model):
                 "choice_id", flat=True
             )
         )
-        log.debug(f"Picked user IDs: {list(picked_user_ids)}")
+        log.debug(
+            "draft_picked_user_ids",
+            system="tournament",
+            subsystem="draft",
+            picked_user_ids=list(picked_user_ids),
+        )
         captain_ids = list(
             self.tournament.teams.filter(captain__isnull=False).values_list(
                 "captain_id", flat=True
             )
         )
-        log.debug(f"Captain IDs: {captain_ids}")
+        log.debug(
+            "draft_captain_ids",
+            system="tournament",
+            subsystem="draft",
+            captain_ids=captain_ids,
+        )
         excluded_ids = set(picked_user_ids + captain_ids)
-        log.debug(f"All excluded IDs: {excluded_ids}")
+        log.debug(
+            "draft_excluded_ids",
+            system="tournament",
+            subsystem="draft",
+            excluded_count=len(excluded_ids),
+        )
         users = self.tournament.users.exclude(id__in=excluded_ids).distinct()
 
-        log.debug(f"Users remaining: {[user.pk for user in users ]}")
+        log.debug(
+            "draft_users_remaining",
+            system="tournament",
+            subsystem="draft",
+            user_ids=[user.pk for user in users],
+        )
         return users
 
     @property
@@ -1189,7 +1242,12 @@ class Draft(models.Model):
         Returns the latest draft round.
         """
         if not self.draft_rounds.exists():
-            log.error("No draft rounds exist")
+            log.error(
+                "no_draft_rounds_exist",
+                system="tournament",
+                subsystem="draft",
+                draft_id=self.pk,
+            )
             return
 
         latest_round = (
@@ -1210,16 +1268,30 @@ class Draft(models.Model):
             clear_only: If True, only clear teams to captain-only (for draft restart).
                        If False (default), also re-add players from existing draft rounds.
         """
-        log.debug(f"Creating draft round for {self.tournament.name} ")
+        log.debug(
+            "rebuild_teams_started",
+            system="tournament",
+            subsystem="draft",
+            tournament_name=self.tournament.name if self.tournament else None,
+        )
         if not self.tournament:
             raise ValueError("Draft must be associated with a tournament.")
 
         if not self.tournament.captains:
             raise ValueError("Draft must have captains to build teams.")
-        log.debug(f"Creating draft round 2 for {self.tournament.name} ")
+        log.debug(
+            "rebuild_teams_clearing",
+            system="tournament",
+            subsystem="draft",
+            tournament_name=self.tournament.name,
+        )
         for team in self.tournament.teams.all():
             log.debug(
-                f"Rebuilding team {team.name} for tournament {self.tournament.name}"
+                "rebuild_team",
+                system="tournament",
+                subsystem="draft",
+                team_name=team.name,
+                tournament_name=self.tournament.name,
             )
             # Remove all members except captain to avoid triggering empty team deletion
             # (using remove() instead of clear() keeps captain as member during operation)
@@ -1231,11 +1303,15 @@ class Draft(models.Model):
 
         # Skip re-adding draft choices if we're just clearing for a restart
         if clear_only:
-            log.debug("clear_only=True, skipping re-adding draft choices")
+            log.debug(
+                "rebuild_teams_clear_only",
+                system="tournament",
+                subsystem="draft",
+                draft_id=self.pk,
+            )
             return
 
         for captain in self.captains.all():
-
             team = Team.objects.get(
                 captain=captain,
                 tournament=self.tournament,
@@ -1247,18 +1323,32 @@ class Draft(models.Model):
                 if not draft_round.choice:
                     continue  # Skip rounds with no choice (e.g., after restart)
                 log.debug(
-                    f"Rebuild_TEAMS: Creating draft round for {team.name} for tournament {self.tournament.name}"
+                    "rebuild_teams_adding_pick",
+                    system="tournament",
+                    subsystem="draft",
+                    team_name=team.name,
+                    tournament_name=self.tournament.name,
                 )
                 team.members.add(draft_round.choice)
                 team.save()
 
     def build_rounds(self):
-        log.debug(f"Building draft rounds with style: {self.draft_style}")
+        log.debug(
+            "build_rounds_started",
+            system="tournament",
+            subsystem="draft",
+            draft_style=self.draft_style,
+            draft_id=self.pk,
+        )
 
         # Clear existing draft rounds
         for round in self.draft_rounds.all():
             log.debug(
-                f"Draft round {round.pk} already exists for {self.tournament.name}"
+                "build_rounds_clearing_existing",
+                system="tournament",
+                subsystem="draft",
+                draft_round_id=round.pk,
+                tournament_name=self.tournament.name,
             )
             round.delete()
 
@@ -1271,7 +1361,12 @@ class Draft(models.Model):
 
         teams = list(self.tournament.teams.order_by("draft_order"))
         if not teams:
-            log.error("No teams found for tournament")
+            log.error(
+                "no_teams_found",
+                system="tournament",
+                subsystem="draft",
+                tournament_id=self.tournament_id,
+            )
             return
 
         num_teams = len(teams)
@@ -1290,14 +1385,23 @@ class Draft(models.Model):
                     pick_phase=phase_num,
                 )
                 log.debug(
-                    f"Draft round {draft_round.pk} created for {captain.username} "
-                    f"in phase {phase_num}, pick {pick_num}"
+                    "draft_round_created",
+                    system="tournament",
+                    subsystem="draft",
+                    draft_round_id=draft_round.pk,
+                    username=captain.username,
+                    pick_phase=phase_num,
+                    pick_number=pick_num,
                 )
                 return True
             except IntegrityError:
                 log.error(
-                    f"IntegrityError: Draft round already exists for {captain.username} "
-                    f"in phase {phase_num}, pick {pick_num}"
+                    "draft_round_integrity_error",
+                    system="tournament",
+                    subsystem="draft",
+                    username=captain.username,
+                    pick_phase=phase_num,
+                    pick_number=pick_num,
                 )
                 return False
 
@@ -1325,7 +1429,11 @@ class Draft(models.Model):
             phase += 1
 
         log.debug(
-            f"Created {pick_number - 1} draft rounds for {self.tournament.name}"
+            "build_rounds_complete",
+            system="tournament",
+            subsystem="draft",
+            rounds_created=pick_number - 1,
+            tournament_name=self.tournament.name,
         )
         self.save()
 
@@ -1515,13 +1623,29 @@ class DraftRound(models.Model):
 
         captain_name = self.captain.username if self.captain else "unassigned"
         log.debug(
-            f"Draft round {self.pk} picking player {user.username} for captain {captain_name}"
+            "draft_round_pick_started",
+            system="tournament",
+            subsystem="draft",
+            draft_round_id=self.pk,
+            username=user.username,
+            captain_name=captain_name,
         )
-        log.debug(self.draft.users_remaining)
+        log.debug(
+            "draft_users_remaining_snapshot",
+            system="tournament",
+            subsystem="draft",
+            draft_id=self.draft_id,
+        )
 
         # Debug the current state
         remaining_count_before = self.draft.users_remaining.count()
-        log.debug(f"Users remaining before pick: {remaining_count_before}")
+        log.debug(
+            "draft_remaining_before_pick",
+            system="tournament",
+            subsystem="draft",
+            draft_round_id=self.pk,
+            remaining_count=remaining_count_before,
+        )
 
         if self.draft.users_remaining.filter(id=user.id).exists():
             self.choice = user
@@ -1532,14 +1656,30 @@ class DraftRound(models.Model):
             self.save()  # This triggers cache invalidation
 
             remaining_count_after = self.draft.users_remaining.count()
-            log.debug(f"Users remaining after pick: {remaining_count_after}")
-            log.debug(f"Successfully picked {user.username}")
+            log.debug(
+                "draft_remaining_after_pick",
+                system="tournament",
+                subsystem="draft",
+                draft_round_id=self.pk,
+                remaining_count=remaining_count_after,
+            )
+            log.debug(
+                "draft_pick_success",
+                system="tournament",
+                subsystem="draft",
+                username=user.username,
+                draft_round_id=self.pk,
+            )
         else:
             available_users = list(
                 self.draft.users_remaining.values_list("username", flat=True)
             )
             log.error(
-                f"User {user.username} is not available. Available: {available_users}"
+                "draft_pick_user_unavailable",
+                system="tournament",
+                subsystem="draft",
+                username=user.username,
+                available_usernames=available_users,
             )
             raise ValueError("User is not available for drafting.")
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-import logging
+from telemetry.logging import get_logger
 
 import nh3
 import requests
@@ -20,7 +20,7 @@ from enum import IntEnum, StrEnum
 from django.contrib.auth.models import AbstractUser
 from django.db.models import JSONField
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class PositionsModel(models.Model):
@@ -229,7 +229,7 @@ class CustomUser(AbstractUser):
             response = requests.head(url, timeout=5)
             return response.status_code == 200
         except requests.RequestException:
-            logging.warning(
+            log.warning(
                 f"Failed to validate avatar URL for user {self.username}: {url}"
             )
             return False
@@ -247,7 +247,7 @@ class CustomUser(AbstractUser):
         # Skip if Discord bot token is not configured (e.g., in CI)
         discord_bot_token = getattr(settings, "DISCORD_BOT_TOKEN", None)
         if not discord_bot_token:
-            logging.debug(
+            log.debug(
                 f"Skipping avatar fetch for {self.username}: DISCORD_BOT_TOKEN not configured"
             )
             return False
@@ -273,25 +273,25 @@ class CustomUser(AbstractUser):
                     # here would crash now that `avatar` is a property, not a
                     # model field.
                     self.avatar = new_avatar
-                    logging.info(
+                    log.info(
                         f"Updated avatar for user {self.username} (Discord ID: {self.discordId})"
                     )
                     return True
                 return False
 
             else:
-                logging.warning(
+                log.warning(
                     f"Failed to fetch Discord user data for {self.username}: {response.status_code}"
                 )
                 return False
 
         except requests.RequestException as e:
-            logging.error(
+            log.error(
                 f"Error fetching Discord avatar for user {self.username}: {str(e)}"
             )
             return False
         except Exception as e:
-            logging.error(
+            log.error(
                 f"Unexpected error updating avatar for user {self.username}: {str(e)}"
             )
             return False
@@ -1210,15 +1210,15 @@ class Draft(models.Model):
             clear_only: If True, only clear teams to captain-only (for draft restart).
                        If False (default), also re-add players from existing draft rounds.
         """
-        logging.debug(f"Creating draft round for {self.tournament.name} ")
+        log.debug(f"Creating draft round for {self.tournament.name} ")
         if not self.tournament:
             raise ValueError("Draft must be associated with a tournament.")
 
         if not self.tournament.captains:
             raise ValueError("Draft must have captains to build teams.")
-        logging.debug(f"Creating draft round 2 for {self.tournament.name} ")
+        log.debug(f"Creating draft round 2 for {self.tournament.name} ")
         for team in self.tournament.teams.all():
-            logging.debug(
+            log.debug(
                 f"Rebuilding team {team.name} for tournament {self.tournament.name}"
             )
             # Remove all members except captain to avoid triggering empty team deletion
@@ -1231,7 +1231,7 @@ class Draft(models.Model):
 
         # Skip re-adding draft choices if we're just clearing for a restart
         if clear_only:
-            logging.debug("clear_only=True, skipping re-adding draft choices")
+            log.debug("clear_only=True, skipping re-adding draft choices")
             return
 
         for captain in self.captains.all():
@@ -1246,18 +1246,18 @@ class Draft(models.Model):
                     continue
                 if not draft_round.choice:
                     continue  # Skip rounds with no choice (e.g., after restart)
-                logging.debug(
+                log.debug(
                     f"Rebuild_TEAMS: Creating draft round for {team.name} for tournament {self.tournament.name}"
                 )
                 team.members.add(draft_round.choice)
                 team.save()
 
     def build_rounds(self):
-        logging.debug(f"Building draft rounds with style: {self.draft_style}")
+        log.debug(f"Building draft rounds with style: {self.draft_style}")
 
         # Clear existing draft rounds
         for round in self.draft_rounds.all():
-            logging.debug(
+            log.debug(
                 f"Draft round {round.pk} already exists for {self.tournament.name}"
             )
             round.delete()
@@ -1271,7 +1271,7 @@ class Draft(models.Model):
 
         teams = list(self.tournament.teams.order_by("draft_order"))
         if not teams:
-            logging.error("No teams found for tournament")
+            log.error("No teams found for tournament")
             return
 
         num_teams = len(teams)
@@ -1289,13 +1289,13 @@ class Draft(models.Model):
                     pick_number=pick_num,
                     pick_phase=phase_num,
                 )
-                logging.debug(
+                log.debug(
                     f"Draft round {draft_round.pk} created for {captain.username} "
                     f"in phase {phase_num}, pick {pick_num}"
                 )
                 return True
             except IntegrityError:
-                logging.error(
+                log.error(
                     f"IntegrityError: Draft round already exists for {captain.username} "
                     f"in phase {phase_num}, pick {pick_num}"
                 )
@@ -1324,7 +1324,7 @@ class Draft(models.Model):
             # Increment phase after all teams have picked
             phase += 1
 
-        logging.debug(
+        log.debug(
             f"Created {pick_number - 1} draft rounds for {self.tournament.name}"
         )
         self.save()

--- a/backend/app/pipelines.py
+++ b/backend/app/pipelines.py
@@ -21,6 +21,11 @@ def save_discord(
 ) -> dict:
     from app.discord_accounts import merge_discord_accounts
 
+    # save_discord runs after create_user, so user is always present here;
+    # guard makes the None-path explicit and narrows the type for the body.
+    if user is None:
+        raise ValueError("save_discord requires an authenticated user")
+
     social_auth = user.social_auth.filter(provider="discord").first()
     discordId = social_auth.extra_data["id"]
     avatar = social_auth.extra_data["avatar"]

--- a/backend/app/pipelines.py
+++ b/backend/app/pipelines.py
@@ -1,25 +1,38 @@
+from typing import Any
+
 from django.contrib.auth import get_user_model
-from social_core.pipeline.partial import partial
+
+from telemetry.logging import get_logger
 
 from .models import CustomUser, PositionsModel
 
 User = get_user_model()
-import logging
 
-# Get an instance of a logger
-logger = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def save_discord(
-    strategy, details, user: CustomUser = None, is_new=False, *args, **kwargs
-):
+    strategy: Any,
+    details: Any,
+    user: CustomUser | None = None,
+    is_new: bool = False,
+    *args: Any,
+    **kwargs: Any,
+) -> dict:
     from app.discord_accounts import merge_discord_accounts
 
     social_auth = user.social_auth.filter(provider="discord").first()
     discordId = social_auth.extra_data["id"]
     avatar = social_auth.extra_data["avatar"]
-    logger.info(f"SAVE_DISCORD {social_auth.extra_data}")
     discordUsername = social_auth.extra_data["username"]
+    log.info(
+        "discord_social_save",
+        system="auth",
+        subsystem="social",
+        user_id=user.pk,
+        discord_id=discordId,
+        discord_username=discordUsername,
+    )
 
     # Defense-in-depth: a Discord *button* signup may have already created a
     # separate account holding this discordId (unique). If so, fold this
@@ -28,9 +41,7 @@ def save_discord(
     # associate_by_discord_id reclaims it before create_user in the common case;
     # this covers logins where a prior failed attempt left a duplicate behind.
     conflict = (
-        CustomUser.objects.filter(discordId=str(discordId))
-        .exclude(pk=user.pk)
-        .first()
+        CustomUser.objects.filter(discordId=str(discordId)).exclude(pk=user.pk).first()
     )
     if conflict:
         merge_discord_accounts(keep=conflict, drop=user)
@@ -41,9 +52,7 @@ def save_discord(
     # the unclaimed one in before writing the handle, so we can't hit
     # `UNIQUE constraint failed: username`.
     username_owner = (
-        CustomUser.objects.filter(username=discordUsername)
-        .exclude(pk=user.pk)
-        .first()
+        CustomUser.objects.filter(username=discordUsername).exclude(pk=user.pk).first()
     )
     if username_owner is not None and not username_owner.discordId:
         merge_discord_accounts(keep=user, drop=username_owner)
@@ -68,8 +77,14 @@ def save_discord(
 
 
 def associate_by_discord_id(
-    backend=None, uid=None, user=None, response=None, details=None, *args, **kwargs
-):
+    backend: Any = None,
+    uid: Any = None,
+    user: CustomUser | None = None,
+    response: Any = None,
+    details: Any = None,
+    *args: Any,
+    **kwargs: Any,
+) -> dict | None:
     """Reclaim an existing CustomUser that already holds this Discord ID.
 
     Runs before `create_user` so a login adopts the row a Discord *button*
@@ -90,16 +105,24 @@ def associate_by_discord_id(
 
     existing_user = User.objects.filter(discordId=str(discord_id)).first()
     if existing_user:
-        logger.info(
-            "Reclaiming existing account #%s by discordId=%s",
-            existing_user.pk,
-            discord_id,
+        log.info(
+            "discord_account_reclaimed",
+            system="auth",
+            subsystem="social",
+            user_id=existing_user.pk,
+            discord_id=discord_id,
         )
         return {"user": existing_user}
     return None
 
 
-def associate_by_discord_username(backend, details, user=None, *args, **kwargs):
+def associate_by_discord_username(
+    backend: Any,
+    details: Any,
+    user: CustomUser | None = None,
+    *args: Any,
+    **kwargs: Any,
+) -> dict | None:
     """
     Connect to a user if their discord username matches an existing user.
     `username` is the Discord username from the provider.
@@ -108,20 +131,37 @@ def associate_by_discord_username(backend, details, user=None, *args, **kwargs):
         return None  # Already authenticated or linked
 
     discordUsername = details.get("username")
-    logger.warning(f"discordUsername: {discordUsername}")
+    log.debug(
+        "discord_username_lookup",
+        system="auth",
+        subsystem="social",
+        discord_username=discordUsername,
+    )
     if not discordUsername:
         return None
 
     try:
         existing_user = User.objects.get(username=discordUsername)
-        logger.warning(f"Found existing user: {existing_user}")
+        log.info(
+            "discord_user_matched",
+            system="auth",
+            subsystem="social",
+            match_by="username",
+            user_id=existing_user.pk,
+        )
         return {"user": existing_user}
     except User.DoesNotExist:
         pass
 
     try:
         existing_user = User.objects.get(discordUsername=discordUsername)
-        logger.warning(f"Found existing user: {existing_user}")
+        log.info(
+            "discord_user_matched",
+            system="auth",
+            subsystem="social",
+            match_by="discord_username",
+            user_id=existing_user.pk,
+        )
         return {"user": existing_user}
     except User.DoesNotExist:
         return None

--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -1,5 +1,4 @@
 from ast import alias
-from logging import getLogger
 from typing import TypeAlias
 
 import nh3
@@ -8,8 +7,9 @@ from django.db import transaction
 from rest_framework import serializers
 
 from app.cache_utils import invalidate_after_commit
+from telemetry.logging import get_logger
 
-log = getLogger(__name__)
+log = get_logger(__name__)
 from .models import (
     CustomUser,
     Draft,

--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -1,8 +1,4 @@
-from ast import alias
-from typing import TypeAlias
-
 import nh3
-from django.contrib.auth.models import User
 from django.db import transaction
 from rest_framework import serializers
 
@@ -10,6 +6,7 @@ from app.cache_utils import invalidate_after_commit
 from telemetry.logging import get_logger
 
 log = get_logger(__name__)
+
 from .models import (
     CustomUser,
     Draft,
@@ -552,7 +549,6 @@ class LeaguesSerializer(serializers.ModelSerializer):
 
 
 class DraftRoundForDraftSerializer(serializers.ModelSerializer):
-
     captain = serializers.SerializerMethodField()
     pick_phase = serializers.IntegerField()
     pick_number = serializers.IntegerField()
@@ -674,7 +670,6 @@ class TournamentSerializerDraft(serializers.ModelSerializer):
 
 
 class DraftSerializer(serializers.ModelSerializer):
-
     tournament = TournamentSerializerDraft(
         many=False,
         read_only=True,
@@ -703,7 +698,6 @@ class DraftSerializer(serializers.ModelSerializer):
 
 
 class DraftSerializerMMRs(serializers.ModelSerializer):
-
     class Meta:
         model = Draft
         fields = (
@@ -1036,7 +1030,11 @@ class TournamentSerializer(serializers.ModelSerializer):
                     )
                     if captain_teams.exists():
                         log.info(
-                            f"Removing {captain_teams.count()} captain team(s) from tournament {instance.name}"
+                            "captain_teams_removed",
+                            system="api",
+                            subsystem="serializer",
+                            count=captain_teams.count(),
+                            tournament_id=instance.pk,
                         )
                         captain_teams.delete()
 
@@ -1187,14 +1185,23 @@ class UserSerializer(serializers.ModelSerializer):
                     for key, value in positions_data.items():
                         setattr(positions_instance, key, value)
                     positions_instance.save()
-                    log.debug(positions_data)
+                    log.debug(
+                        "positions_updated",
+                        system="api",
+                        subsystem="serializer",
+                    )
             except KeyError:
                 pass
             for key, value in validated_data.items():
                 setattr(instance, key, value)
 
             instance.save()
-            log.debug("Updated User")
+            log.debug(
+                "user_updated",
+                system="api",
+                subsystem="serializer",
+                user_id=instance.pk,
+            )
 
             # Invalidate all cached views that include this user.
             # Deferred until after commit so cacheops sees committed state.
@@ -1220,19 +1227,19 @@ class UserSerializer(serializers.ModelSerializer):
         fields = self.Meta.fields
 
         with transaction.atomic():
-
             for key in validated_data.keys():
                 if key not in fields:
                     raise KeyError(f"Invalid field: {key}")
 
             if "positions" in validated_data:
-
                 positions_data = validated_data.pop("positions")
                 positions = PositionsModel.objects.create(**positions_data)
                 user = CustomUser.objects.create(positions=positions, **validated_data)
 
             else:
-                log.debug(validated_data)
+                log.debug(
+                    "user_create_no_positions", system="api", subsystem="serializer"
+                )
                 positions = PositionsModel.objects.create()
                 user = CustomUser(positions=positions, **validated_data)
 
@@ -1241,7 +1248,6 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class GameSerializer(serializers.ModelSerializer):
-
     tournament_id = serializers.PrimaryKeyRelatedField(
         source="tournament",
         many=False,

--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -9,11 +9,11 @@ Handles:
 - Purge stale HeroDraft when a Game's teams change (issue #235)
 """
 
-from telemetry.logging import get_logger
-
 from django.db import transaction
 from django.db.models.signals import m2m_changed, pre_save
 from django.dispatch import receiver
+
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -154,8 +154,12 @@ def handle_tournament_user_addition(sender, instance, action, pk_set, **kwargs):
         )
         if org_created:
             log.info(
-                f"Created OrgUser for {user.username} in org {org.name} "
-                f"(via tournament {tournament.name})"
+                "org_user_created",
+                system="app",
+                subsystem="signals",
+                username=user.username,
+                user_id=user.pk,
+                tournament_id=tournament.pk,
             )
 
         # Step 2: Create LeagueUser if it doesn't exist
@@ -169,8 +173,12 @@ def handle_tournament_user_addition(sender, instance, action, pk_set, **kwargs):
         )
         if league_created:
             log.info(
-                f"Created LeagueUser for {user.username} in league {league.name} "
-                f"(via tournament {tournament.name})"
+                "league_user_created",
+                system="app",
+                subsystem="signals",
+                username=user.username,
+                user_id=user.pk,
+                tournament_id=tournament.pk,
             )
 
 
@@ -234,25 +242,32 @@ def reset_herodraft_on_team_change(sender, instance, **kwargs):
     if not draft:
         return
 
-    teams_cleared = (
-        instance.radiant_team_id is None or instance.dire_team_id is None
-    )
+    teams_cleared = instance.radiant_team_id is None or instance.dire_team_id is None
 
-    log.info(
-        "herodraft_deleted_on_team_cleared"
-        if teams_cleared
-        else "herodraft_reset_on_team_change",
-        extra={
-            "system": "bracket",
-            "subsystem": "herodraft",
-            "game_id": instance.pk,
-            "herodraft_id": draft.pk,
-            "prior_radiant_team_id": prior.radiant_team_id,
-            "new_radiant_team_id": instance.radiant_team_id,
-            "prior_dire_team_id": prior.dire_team_id,
-            "new_dire_team_id": instance.dire_team_id,
-        },
-    )
+    if teams_cleared:
+        log.info(
+            "herodraft_deleted_on_team_cleared",
+            system="app",
+            subsystem="signals",
+            game_id=instance.pk,
+            herodraft_id=draft.pk,
+            prior_radiant_team_id=prior.radiant_team_id,
+            new_radiant_team_id=instance.radiant_team_id,
+            prior_dire_team_id=prior.dire_team_id,
+            new_dire_team_id=instance.dire_team_id,
+        )
+    else:
+        log.info(
+            "herodraft_reset_on_team_change",
+            system="app",
+            subsystem="signals",
+            game_id=instance.pk,
+            herodraft_id=draft.pk,
+            prior_radiant_team_id=prior.radiant_team_id,
+            new_radiant_team_id=instance.radiant_team_id,
+            prior_dire_team_id=prior.dire_team_id,
+            new_dire_team_id=instance.dire_team_id,
+        )
 
     if teams_cleared:
         draft_pk = draft.pk
@@ -355,5 +370,10 @@ def _broadcast_draft_event(draft_pk, event_type, game_id):
         )
     except Exception as exc:
         log.warning(
-            f"Failed to broadcast {event_type} for HeroDraft {draft_pk}: {exc}"
+            "herodraft_broadcast_failed",
+            system="app",
+            subsystem="signals",
+            event_type=event_type,
+            herodraft_id=draft_pk,
+            error=str(exc),
         )

--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -9,13 +9,13 @@ Handles:
 - Purge stale HeroDraft when a Game's teams change (issue #235)
 """
 
-import logging
+from telemetry.logging import get_logger
 
 from django.db import transaction
 from django.db.models.signals import m2m_changed, pre_save
 from django.dispatch import receiver
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 @receiver(m2m_changed, sender="app.Team_members")

--- a/backend/app/tasks/herodraft_tick.py
+++ b/backend/app/tasks/herodraft_tick.py
@@ -26,8 +26,8 @@ from telemetry.logging import get_logger
 log = get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
-TICK_STEP_SLOW_THRESHOLD_S = 0.3       # 30% of the 1s budget
-TICK_GAP_STALL_THRESHOLD_S = 1.5       # expected gap is 1.0s
+TICK_STEP_SLOW_THRESHOLD_S = 0.3  # 30% of the 1s budget
+TICK_GAP_STALL_THRESHOLD_S = 1.5  # expected gap is 1.0s
 TICK_ITERATION_SLOW_THRESHOLD_S = 1.5  # backstop if no single step crossed
 
 # Redis client for locking and connection tracking
@@ -62,7 +62,13 @@ def increment_connection_count(draft_id: int) -> int:
     key = CONN_COUNT_KEY.format(draft_id=draft_id)
     count = r.incr(key)
     r.expire(key, 300)  # Expire after 5 min of no activity
-    log.debug(f"Draft {draft_id} connection count incremented to {count}")
+    log.debug(
+        "connection_count_incremented",
+        system="herodraft",
+        subsystem="timer",
+        draft_id=draft_id,
+        count=count,
+    )
     return count
 
 
@@ -74,7 +80,13 @@ def decrement_connection_count(draft_id: int) -> int:
     if count <= 0:
         r.delete(key)
         count = 0
-    log.debug(f"Draft {draft_id} connection count decremented to {count}")
+    log.debug(
+        "connection_count_decremented",
+        system="herodraft",
+        subsystem="timer",
+        draft_id=draft_id,
+        count=count,
+    )
     return count
 
 
@@ -192,7 +204,9 @@ async def broadcast_tick(draft_id: int):
             round=current_round.round_number,
             server_time=now.isoformat(),
             round_started_at=(
-                current_round.started_at.isoformat() if current_round.started_at else None
+                current_round.started_at.isoformat()
+                if current_round.started_at
+                else None
             ),
         )
 
@@ -205,7 +219,9 @@ async def broadcast_tick(draft_id: int):
             "current_round": current_round.round_number - 1,  # 0-indexed
             "active_team_id": current_round.draft_team_id,
             "round_started_at": (
-                current_round.started_at.isoformat() if current_round.started_at else None
+                current_round.started_at.isoformat()
+                if current_round.started_at
+                else None
             ),
             "round_grace_time_ms": current_round.grace_time_ms,
             # DraftTeam.reserve_time_remaining — the team's cumulative
@@ -215,13 +231,9 @@ async def broadcast_tick(draft_id: int):
             # The client subtracts the IN-ROUND consumption locally for
             # display on the active team only.
             "team_a_id": team_a.id if team_a else None,
-            "team_a_reserve_ms": (
-                team_a.reserve_time_remaining if team_a else None
-            ),
+            "team_a_reserve_ms": (team_a.reserve_time_remaining if team_a else None),
             "team_b_id": team_b.id if team_b else None,
-            "team_b_reserve_ms": (
-                team_b.reserve_time_remaining if team_b else None
-            ),
+            "team_b_reserve_ms": (team_b.reserve_time_remaining if team_b else None),
         }
 
     tick_data = await get_tick_data()
@@ -373,10 +385,19 @@ async def check_resume_countdown(draft_id: int):
                     "rounds",
                 ).get(id=draft_id)
                 broadcast_herodraft_state(draft, "draft_resumed")
-                log.debug(f"Broadcast draft_resumed for draft {draft_id}")
+                log.debug(
+                    "draft_resumed_broadcast",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                )
             except Exception as e:
                 log.error(
-                    f"Failed to broadcast draft_resumed for draft {draft_id}: {e}"
+                    "draft_resumed_broadcast_failed",
+                    system="herodraft",
+                    subsystem="timer",
+                    draft_id=draft_id,
+                    error=str(e),
                 )
 
         return transitioned
@@ -704,7 +725,13 @@ def start_tick_broadcaster(draft_id: int) -> bool:
     acquired = r.set(lock_key, "locked", nx=True, ex=LOCK_TIMEOUT)
 
     if not acquired:
-        log.debug(f"Tick broadcaster already running for draft {draft_id} (lock held)")
+        log.debug(
+            "tick_broadcaster_already_running",
+            system="herodraft",
+            subsystem="timer",
+            draft_id=draft_id,
+            reason="lock_held",
+        )
         return False
 
     def run_in_thread():
@@ -713,7 +740,13 @@ def start_tick_broadcaster(draft_id: int) -> bool:
         try:
             loop.run_until_complete(run_tick_loop(draft_id, stop_event))
         except Exception as e:
-            log.error(f"Tick broadcaster error for draft {draft_id}: {e}")
+            log.error(
+                "tick_broadcaster_error",
+                system="herodraft",
+                subsystem="timer",
+                draft_id=draft_id,
+                error=str(e),
+            )
         finally:
             loop.close()
             try:
@@ -721,6 +754,8 @@ def start_tick_broadcaster(draft_id: int) -> bool:
             except Exception as e:
                 log.debug(
                     "tick_lock_release_failed",
+                    system="herodraft",
+                    subsystem="timer",
                     draft_id=draft_id,
                     phase="run_in_thread",
                     error=str(e),
@@ -739,7 +774,12 @@ def start_tick_broadcaster(draft_id: int) -> bool:
         _active_tick_tasks[draft_id] = TaskInfo(stop_event, thread)
 
     thread.start()
-    log.info(f"Started tick broadcaster for draft {draft_id}")
+    log.info(
+        "tick_broadcaster_started",
+        system="herodraft",
+        subsystem="timer",
+        draft_id=draft_id,
+    )
     return True
 
 
@@ -753,7 +793,12 @@ def stop_tick_broadcaster(draft_id: int):
         task_info = _active_tick_tasks.get(draft_id)
 
     if task_info:
-        log.info(f"Stopping tick broadcaster for draft {draft_id}")
+        log.info(
+            "tick_broadcaster_stopping",
+            system="herodraft",
+            subsystem="timer",
+            draft_id=draft_id,
+        )
         task_info.stop_event.set()
         task_info.thread.join(timeout=2.0)
 
@@ -762,6 +807,8 @@ def stop_tick_broadcaster(draft_id: int):
     except Exception as e:
         log.debug(
             "tick_lock_release_failed",
+            system="herodraft",
+            subsystem="timer",
             draft_id=draft_id,
             phase="stop_tick_broadcaster",
             error=str(e),
@@ -779,7 +826,12 @@ def stop_all_broadcasters():
     for draft_id in draft_ids:
         stop_tick_broadcaster(draft_id)
 
-    log.info(f"Stopped {len(draft_ids)} tick broadcasters on shutdown")
+    log.info(
+        "tick_broadcasters_shutdown",
+        system="herodraft",
+        subsystem="timer",
+        count=len(draft_ids),
+    )
 
 
 # Register cleanup on process exit

--- a/backend/app/views/csv_import.py
+++ b/backend/app/views/csv_import.py
@@ -1,8 +1,5 @@
 """CSV import views for bulk-adding users to organizations and tournaments."""
 
-from telemetry.logging import get_logger
-
-from app.cache_utils import invalidate_obj
 from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -10,6 +7,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from app.cache_utils import invalidate_obj
 from app.models import (
     CustomUser,
     Organization,
@@ -22,6 +20,7 @@ from app.permissions_org import has_org_staff_access
 from app.serializers import TournamentUserSerializer
 from league.models import LeagueUser
 from org.models import OrgUser
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -250,10 +249,11 @@ def import_csv_org(request, org_id):
     rows = request.data.get("rows", [])
     update_mmr = bool(request.data.get("update_mmr", False))
     log.info(
-        "CSV org import: update_mmr=%s, raw=%r, rows=%d",
-        update_mmr,
-        request.data.get("update_mmr"),
-        len(rows) if isinstance(rows, list) else 0,
+        "csv_org_import_started",
+        system="api",
+        subsystem="csv_import",
+        update_mmr=update_mmr,
+        count=len(rows) if isinstance(rows, list) else 0,
     )
 
     if not isinstance(rows, list):
@@ -325,10 +325,12 @@ def import_csv_org(request, org_id):
                 )
         except IntegrityError:
             log.info(
-                "Row %d: existing member, update_mmr=%s, base_mmr=%r",
-                i + 1,
-                update_mmr,
-                base_mmr,
+                "csv_row_existing_member",
+                system="api",
+                subsystem="csv_import",
+                row=i + 1,
+                update_mmr=update_mmr,
+                base_mmr=base_mmr,
             )
             if update_mmr and base_mmr is not None:
                 OrgUser.objects.filter(user=user, organization=org).update(mmr=base_mmr)
@@ -423,11 +425,13 @@ def import_csv_tournament(request, tournament_id):
         "mmr_target", "organization"
     )  # "organization" | "league"
     log.info(
-        "CSV tournament import: update_mmr=%s, mmr_target=%s, raw_update_mmr=%r, rows=%d",
-        update_mmr,
-        mmr_target,
-        request.data.get("update_mmr"),
-        len(rows) if isinstance(rows, list) else 0,
+        "csv_tournament_import_started",
+        system="api",
+        subsystem="csv_import",
+        update_mmr=update_mmr,
+        mmr_target=mmr_target,
+        tournament_id=tournament.pk,
+        count=len(rows) if isinstance(rows, list) else 0,
     )
 
     if not isinstance(rows, list):

--- a/backend/app/views/csv_import.py
+++ b/backend/app/views/csv_import.py
@@ -1,6 +1,6 @@
 """CSV import views for bulk-adding users to organizations and tournaments."""
 
-import logging
+from telemetry.logging import get_logger
 
 from app.cache_utils import invalidate_obj
 from django.db import IntegrityError, transaction
@@ -23,7 +23,7 @@ from app.serializers import TournamentUserSerializer
 from league.models import LeagueUser
 from org.models import OrgUser
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 MAX_ROWS = 500
 STEAM_ID_64_MIN = 76561197960265728  # Smallest valid Steam64 ID

--- a/backend/app/views_joke.py
+++ b/backend/app/views_joke.py
@@ -1,11 +1,11 @@
 """Views for joke-related endpoints (tangoes, etc.)."""
 
-from telemetry.logging import get_logger
-
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+
+from telemetry.logging import get_logger
 
 from .models import Joke
 from .serializers import JokeSerializer

--- a/backend/app/views_joke.py
+++ b/backend/app/views_joke.py
@@ -1,6 +1,6 @@
 """Views for joke-related endpoints (tangoes, etc.)."""
 
-import logging
+from telemetry.logging import get_logger
 
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from .models import Joke
 from .serializers import JokeSerializer
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 @api_view(["GET"])

--- a/backend/app/views_main.py
+++ b/backend/app/views_main.py
@@ -1,31 +1,32 @@
 import json
-from telemetry.logging import get_logger
 from datetime import timedelta
 
-import requests
 from cacheops import cached_as
 from django.contrib.auth import login
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.db.models import Count, Q
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
-from django.shortcuts import redirect, render
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.shortcuts import redirect
 from django.utils import timezone
-from rest_framework import generics, permissions, status, viewsets
+from rest_framework import generics, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
-from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 from social_core.backends.oauth import BaseOAuth1, BaseOAuth2
-from social_django.models import USER_MODEL  # fix: skip
-from social_django.models import AbstractUserSocialAuth, DjangoStorage
 from social_django.utils import load_strategy, psa
 
 # Create your views here.
 from app.permissions_org import has_org_staff_access
-from backend import settings
+from telemetry.logging import get_logger
+
+# BaseUserProfile owns nickname/avatar (T1 epic). Every @cached_as site below
+# that ships nickname or avatar in its payload MUST list BaseUserProfile as a
+# dependency, otherwise PATCH /api/users/me/profile/base/ won't invalidate the
+# cached response. See backend/user/tests/test_cacheops.py for the grep
+# guardrail that enforces this.
+from user.models import BaseUserProfile
 
 from .decorators import render_to
 from .models import (
@@ -47,13 +48,10 @@ from .permissions_org import (
     CanEditTournament,
     CanManageGame,
     IsLeagueAdmin,
-    IsLeagueStaff,
     IsOrgAdmin,
     IsOrgOwner,
-    can_edit_tournament,
     can_manage_game,
     has_league_admin_access,
-    has_org_admin_access,
 )
 from .serializers import (
     DraftRoundSerializer,
@@ -71,15 +69,7 @@ from .serializers import (
     TournamentUserSerializer,
     UserSerializer,
     _build_users_dict,
-    _serialize_users_with_mmr,
 )
-
-# BaseUserProfile owns nickname/avatar (T1 epic). Every @cached_as site below
-# that ships nickname or avatar in its payload MUST list BaseUserProfile as a
-# dependency, otherwise PATCH /api/users/me/profile/base/ won't invalidate the
-# cached response. See backend/user/tests/test_cacheops.py for the grep
-# guardrail that enforces this.
-from user.models import BaseUserProfile
 
 log = get_logger(__name__)
 from .utils.avatar_utils import refresh_user_avatar
@@ -170,13 +160,6 @@ def ajax_auth(request, backend):
     login(request, user)
     data = {"id": user.id, "username": user.username}
     return HttpResponse(json.dumps(data), mimetype="application/json")
-
-
-from django.contrib.auth.models import User
-from django.db import transaction
-
-from .models import CustomUser
-from .serializers import UserSerializer
 
 
 @permission_classes((IsStaff,))
@@ -459,7 +442,12 @@ class TournamentView(viewsets.ModelViewSet):
             timeout=60 * 10,
         )
         def get_data():
-            log.debug("get_tournament: fetching data")
+            log.debug(
+                "tournament_cache_miss",
+                system="api",
+                subsystem="main",
+                tournament_id=pk,
+            )
             instance = self.get_object()
             serializer = self.get_serializer(instance)
             data = serializer.data
@@ -562,7 +550,7 @@ class TeamView(viewsets.ModelViewSet):
             timeout=60 * 60,
         )
         def get_data():
-            log.debug("get_team: fetching data")
+            log.debug("team_list_cache_miss", system="api", subsystem="main")
             queryset = self.filter_queryset(self.get_queryset())
             serializer = self.get_serializer(queryset, many=True)
             return serializer.data
@@ -768,7 +756,7 @@ def current_user(request):
         active_drafts = []
 
         # Team drafts: user is captain with pending pick in in_progress tournament
-        from app.models import DraftTeam, HeroDraft
+        from app.models import DraftTeam
 
         pending_team_round = (
             DraftRound.objects.filter(
@@ -1137,7 +1125,9 @@ class OrganizationView(viewsets.ModelViewSet):
         org = self.get_object()
         cache_key = f"organization_users:{pk}"
 
-        @cached_as(OrgUser, CustomUser, BaseUserProfile, extra=cache_key, timeout=60 * 10)
+        @cached_as(
+            OrgUser, CustomUser, BaseUserProfile, extra=cache_key, timeout=60 * 10
+        )
         def get_data():
             org_users = OrgUser.objects.filter(organization=org).select_related(
                 "user", "user__positions", "user__base_profile"
@@ -1284,7 +1274,9 @@ class LeagueView(viewsets.ModelViewSet):
         league = self.get_object()
         cache_key = f"league_users:{pk}"
 
-        @cached_as(LeagueUser, CustomUser, BaseUserProfile, extra=cache_key, timeout=60 * 10)
+        @cached_as(
+            LeagueUser, CustomUser, BaseUserProfile, extra=cache_key, timeout=60 * 10
+        )
         def get_data():
             league_users = LeagueUser.objects.filter(league=league).select_related(
                 "user", "user__positions", "user__base_profile"

--- a/backend/app/views_main.py
+++ b/backend/app/views_main.py
@@ -1,5 +1,5 @@
 import json
-import logging
+from telemetry.logging import get_logger
 from datetime import timedelta
 
 import requests
@@ -81,7 +81,7 @@ from .serializers import (
 # guardrail that enforces this.
 from user.models import BaseUserProfile
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 from .utils.avatar_utils import refresh_user_avatar
 
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,10 +1,10 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 from django.views.generic.base import RedirectView
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,8 +1,8 @@
-from telemetry.logging import get_logger
-
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
+
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -373,12 +373,12 @@ from app.views.internal import (
     clear_event_signup_state,
     create_discord_event_log,
     create_discord_message_log,
-    finalize_discord_message_log,
     create_event_dm,
     create_herodraft_for_game,
     create_or_update_announcement,
     create_or_update_signup_message,
     create_tournament_log,
+    finalize_discord_message_log,
     generate_repeater_events,
     get_active_repeaters,
     get_discord_event_state,
@@ -521,9 +521,11 @@ urlpatterns += [
     path("api/internal/steam/recalculate-mmr/<int:user_id>/", recalculate_mmr),
 ]
 
-log.debug(f"Test Environ:  {isTestEnvironment()}")
+log.debug(
+    "test_environ_check", system="api", subsystem="routing", is_test=isTestEnvironment()
+)
 if isTestEnvironment():
-    log.debug("Adding test environment URLs")
+    log.debug("test_urls_added", system="api", subsystem="routing")
     urlpatterns += [
         path("api/tests/", include("tests.urls")),
     ]

--- a/backend/bracket/functions/generate.py
+++ b/backend/bracket/functions/generate.py
@@ -1,5 +1,5 @@
 import json
-import logging
+from telemetry.logging import get_logger
 
 import requests
 from django.contrib.auth import login
@@ -20,7 +20,7 @@ from app.models import CustomUser, Draft, DraftRound, Team, Tournament
 from app.permissions import IsStaff
 from app.serializers import TournamentSerializer
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 from bracket.models import BracketSlot, TournamentBracket
 
 

--- a/backend/bracket/functions/generate.py
+++ b/backend/bracket/functions/generate.py
@@ -1,27 +1,14 @@
-import json
-from telemetry.logging import get_logger
-
-import requests
-from django.contrib.auth import login
-from django.contrib.auth import logout as auth_logout
-from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
-from django.shortcuts import redirect, render
-from rest_framework import generics, permissions, serializers, status, viewsets
+from rest_framework import serializers
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 # Create your views here.
-from social_django.models import USER_MODEL  # fix: skip
-from social_django.utils import load_strategy, psa
-
-from app.models import CustomUser, Draft, DraftRound, Team, Tournament
+from app.models import CustomUser, Tournament
 from app.permissions import IsStaff
-from app.serializers import TournamentSerializer
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
-from bracket.models import BracketSlot, TournamentBracket
+from bracket.models import TournamentBracket
 
 
 class CreateDoubleElminationSerializer(serializers.Serializer):
@@ -50,7 +37,12 @@ def gen_double_elim(request):
     try:
         brackets = tournament.brackets.all()
         for b in brackets:
-            log.debug(f"Deleting previous bracket: {b}")
+            log.debug(
+                "bracket_deleted",
+                system="bracket",
+                subsystem="generate",
+                bracket=str(b),
+            )
             b.delete()
 
     except TournamentBracket.DoesNotExist:

--- a/backend/bracket/models.py
+++ b/backend/bracket/models.py
@@ -1,11 +1,11 @@
-import logging
+from telemetry.logging import get_logger
 import math
 
 from django.db import models
 
 from app.models import TOURNAMNET_TYPE_CHOICES, CustomUser, Game, Team, Tournament
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Create your models here.
 # TODO Move tournament related stuff to here

--- a/backend/bracket/models.py
+++ b/backend/bracket/models.py
@@ -1,9 +1,9 @@
-from telemetry.logging import get_logger
 import math
 
 from django.db import models
 
-from app.models import TOURNAMNET_TYPE_CHOICES, CustomUser, Game, Team, Tournament
+from app.models import TOURNAMNET_TYPE_CHOICES, Game, Team, Tournament
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -44,10 +44,21 @@ class TournamentBracket(models.Model):
         Winners' Bracket and a Losers' Bracket, culminating in a Grand Final.
         """
         if not self.tournament:
-            log.error("No Tournament")
+            log.error(
+                "bracket_generate_skipped",
+                system="bracket",
+                subsystem="model",
+                reason="no_tournament",
+            )
             return
         if not self.tournament.teams.exists():
-            log.error("No Teams in Tournament")
+            log.error(
+                "bracket_generate_skipped",
+                system="bracket",
+                subsystem="model",
+                tournament_id=self.tournament.pk,
+                reason="no_teams",
+            )
             return
 
         teams = list(self.tournament.teams.all())

--- a/backend/common/utils.py
+++ b/backend/common/utils.py
@@ -1,12 +1,12 @@
 import ipaddress
-import logging
+from telemetry.logging import get_logger
 import os
 
 from django.conf import settings
 from social_core.backends.google import GooglePlusAuth
 from social_core.backends.utils import load_backends
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def _is_ip_allowed(ip_str, allowed_ranges):

--- a/backend/common/utils.py
+++ b/backend/common/utils.py
@@ -1,10 +1,11 @@
 import ipaddress
-from telemetry.logging import get_logger
 import os
 
 from django.conf import settings
 from social_core.backends.google import GooglePlusAuth
 from social_core.backends.utils import load_backends
+
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -61,7 +62,13 @@ def isTestEnvironment(request=None):
             else request.META.get("REMOTE_ADDR")
         )
         # TODO(#84): Temporary logging to diagnose CI test failures
-        log.warning(f"isTestEnvironment: CI={ci_env}, IP={remote_addr}")
+        log.warning(
+            "test_environ_ip_check",
+            system="common",
+            subsystem="utils",
+            ci=ci_env,
+            ip=remote_addr,
+        )
         if remote_addr and not _is_ip_allowed(remote_addr, allowed_ips):
             return False
 

--- a/backend/discordbot/bot.py
+++ b/backend/discordbot/bot.py
@@ -1,6 +1,5 @@
 """Discord bot client with slash commands."""
 
-from telemetry.logging import get_logger
 import sys
 
 import discord
@@ -23,6 +22,7 @@ from discordbot.internal_client.bot_actions import (
     set_legacy_rsvp,
 )
 from discordbot.internal_client.signup_actions import set_position
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -80,12 +80,22 @@ class KettleBot(discord.Client):
         guild = discord.Object(id=self.guild_id)
         self.tree.copy_global_to(guild=guild)
         await self.tree.sync(guild=guild)
-        log.info(f"Synced commands to guild {self.guild_id}")
+        log.info(
+            "commands_synced", system="discord", subsystem="bot", guild_id=self.guild_id
+        )
 
     async def on_ready(self):
         """Called when bot successfully connects."""
-        log.info(f"Bot connected as {self.user} (ID: {self.user.id})")
-        log.info(f"Connected to {len(self.guilds)} guilds")
+        log.info(
+            "bot_connected",
+            system="discord",
+            subsystem="bot",
+            discord_user_id=str(self.user.id),
+            discord_username=str(self.user),
+        )
+        log.info(
+            "bot_guild_count", system="discord", subsystem="bot", count=len(self.guilds)
+        )
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         """Track RSVP when user reacts."""
@@ -104,13 +114,21 @@ class KettleBot(discord.Client):
             detail = result.get("detail") or ""
             if result.get("success"):
                 log.info(
-                    f"Event signup via reaction: user={payload.user_id} detail={detail}"
+                    "reaction_signup",
+                    system="discord",
+                    subsystem="bot",
+                    discord_user_id=str(payload.user_id),
+                    reason=detail,
                 )
                 return
             elif detail != "not_event_message":
                 # Was an event message but signup failed (already signed up, event closed, etc.)
                 log.info(
-                    f"Event signup skipped: user={payload.user_id} detail={detail}"
+                    "reaction_signup_skipped",
+                    system="discord",
+                    subsystem="bot",
+                    discord_user_id=str(payload.user_id),
+                    reason=detail,
                 )
                 return
             # Fall through to old ScheduledEvent RSVP system
@@ -122,11 +140,20 @@ class KettleBot(discord.Client):
             )
             detail = result.get("detail") or ""
             if result.get("success"):
-                log.info(f"Event cancel via reaction: user={payload.user_id}")
+                log.info(
+                    "reaction_cancel",
+                    system="discord",
+                    subsystem="bot",
+                    discord_user_id=str(payload.user_id),
+                )
                 return
             elif detail != "not_event_message":
                 log.info(
-                    f"Event cancel skipped: user={payload.user_id} detail={detail}"
+                    "reaction_cancel_skipped",
+                    system="discord",
+                    subsystem="bot",
+                    discord_user_id=str(payload.user_id),
+                    reason=detail,
                 )
                 return
 
@@ -148,7 +175,12 @@ class KettleBot(discord.Client):
             )
             detail = result.get("detail") or ""
             if result.get("success"):
-                log.info(f"Event cancel via reaction remove: user={payload.user_id}")
+                log.info(
+                    "reaction_remove_cancel",
+                    system="discord",
+                    subsystem="bot",
+                    discord_user_id=str(payload.user_id),
+                )
                 return
             elif detail != "not_event_message":
                 return
@@ -223,12 +255,16 @@ class KettleBot(discord.Client):
         )
         if result.get("success"):
             log.info(
-                f"RSVP: {username} marked {status} for {result.get('event_name')}"
+                "rsvp_set",
+                system="discord",
+                subsystem="bot",
+                discord_user_id=str(payload.user_id),
+                discord_username=username,
+                rsvp_status=status,
+                event_name=result.get("event_name"),
             )
 
-    async def _remove_rsvp(
-        self, payload: discord.RawReactionActionEvent
-    ) -> None:
+    async def _remove_rsvp(self, payload: discord.RawReactionActionEvent) -> None:
         """Remove a legacy ScheduledEvent RSVP record."""
         result = await sync_to_async(remove_legacy_rsvp, thread_sensitive=False)(
             discord_message_id=str(payload.message_id),
@@ -236,7 +272,11 @@ class KettleBot(discord.Client):
         )
         if result.get("success"):
             log.info(
-                f"RSVP removed: user {payload.user_id} for {result.get('event_name')}"
+                "rsvp_removed",
+                system="discord",
+                subsystem="bot",
+                discord_user_id=str(payload.user_id),
+                event_name=result.get("event_name"),
             )
 
 
@@ -298,7 +338,7 @@ def run_bot():
     """Run the Discord bot."""
     token = settings.DISCORD_BOT_TOKEN
     if not token:
-        log.error("DISCORD_BOT_TOKEN not set!")
+        log.error("bot_token_missing", system="discord", subsystem="bot")
         sys.exit(1)
 
     bot.run(token, log_handler=None)

--- a/backend/discordbot/bot.py
+++ b/backend/discordbot/bot.py
@@ -1,6 +1,6 @@
 """Discord bot client with slash commands."""
 
-import logging
+from telemetry.logging import get_logger
 import sys
 
 import discord
@@ -24,7 +24,7 @@ from discordbot.internal_client.bot_actions import (
 )
 from discordbot.internal_client.signup_actions import set_position
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def is_site_admin():

--- a/backend/discordbot/components.py
+++ b/backend/discordbot/components.py
@@ -193,7 +193,9 @@ class NotifyButton(ui.Button):
         self.event_id = event_id
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             result = await sync_to_async(notify_button, thread_sensitive=False)(
                 event_id=self.event_id,
                 discord_user_id=str(interaction.user.id),
@@ -225,7 +227,9 @@ class TentativeButton(ui.Button):
         self.event_id = event_id
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             result = await sync_to_async(tentative_button, thread_sensitive=False)(
                 event_id=self.event_id,
                 discord_user_id=str(interaction.user.id),
@@ -257,7 +261,9 @@ class DeclineButton(ui.Button):
         self.event_id = event_id
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             result = await sync_to_async(decline_button, thread_sensitive=False)(
                 event_id=self.event_id,
                 discord_user_id=str(interaction.user.id),
@@ -265,9 +271,13 @@ class DeclineButton(ui.Button):
             ctx.set_outcome(result["action"])
 
             if result["action"] == "declined":
-                await respond_to_signup_user(interaction, content="You've declined the event.")
+                await respond_to_signup_user(
+                    interaction, content="You've declined the event."
+                )
             elif result["action"] == "not_signed_up":
-                await interaction.response.send_message("You weren't signed up for this event.", ephemeral=True)
+                await interaction.response.send_message(
+                    "You weren't signed up for this event.", ephemeral=True
+                )
             else:
                 await interaction.response.send_message(
                     result.get("message", "Something went wrong."), ephemeral=True
@@ -430,11 +440,13 @@ class EventSignupModal(ui.Modal):
                 from events.schemas import DotaModalConfig, dota_require_screenshot
 
                 rank_status = values.get("rank_status", "never")
-                cfg = DotaModalConfig(**{
-                    k: v
-                    for k, v in self.event_config.items()
-                    if k in DotaModalConfig.model_fields
-                })
+                cfg = DotaModalConfig(
+                    **{
+                        k: v
+                        for k, v in self.event_config.items()
+                        if k in DotaModalConfig.model_fields
+                    }
+                )
                 require_screenshot = dota_require_screenshot(rank_status, cfg)
                 view = PositionSelectView(
                     self.event_id,
@@ -536,7 +548,9 @@ class RankStatusSelect(ui.Select):
         self.event_id = event_id
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             rank_status = self.values[0]
             await sync_to_async(rank_status_select, thread_sensitive=False)(
                 event_id=self.event_id,
@@ -625,7 +639,9 @@ class PositionConfirmButton(ui.Button):
         self.min_mmr = min_mmr
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             positions = []
             for item in self.view.children:
                 if isinstance(item, ui.Select) and item.values:
@@ -636,7 +652,9 @@ class PositionConfirmButton(ui.Button):
             except (TypeError, ValueError):
                 ctx.set_outcome("error")
                 ctx.add(reason="invalid_positions")
-                await interaction.response.edit_message(content="❌ Invalid positions.", view=None)
+                await interaction.response.edit_message(
+                    content="❌ Invalid positions.", view=None
+                )
                 return
 
             result = await sync_to_async(save_positions, thread_sensitive=False)(
@@ -738,7 +756,9 @@ class MedalSelect(ui.Select):
         and StarSelect keeps custom_id=rank_star:{event_id}:Herald. Doing the rebuild
         here removes the race.
         """
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             medal = self.values[0] if self.values else "Herald"
             ctx.set_outcome("medal_selected")
             ctx.add(medal=medal)
@@ -783,7 +803,9 @@ class StarSelect(ui.Select):
         self.require_screenshot = require_screenshot
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             parts = self.custom_id.split(":")
             medal = parts[2] if len(parts) > 2 and parts[2] != "Herald" else None
 
@@ -808,7 +830,9 @@ class StarSelect(ui.Select):
             label = "Rank" if self.rank_status == "active" else "Previous rank"
 
             if result.get("action") == "needs_screenshot":
-                view = ScreenshotUploadPromptView(self.event_id, result["screenshot_type"])
+                view = ScreenshotUploadPromptView(
+                    self.event_id, result["screenshot_type"]
+                )
                 await interaction.response.edit_message(
                     content=(
                         f"\U0001f3c5 {label} set to **{medal_with_star}**\n\n"
@@ -847,7 +871,9 @@ class BattleCupTierSelect(ui.Select):
         self.require_screenshot = require_screenshot
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             tier = self.values[0]
             result = await sync_to_async(battle_cup_submit, thread_sensitive=False)(
                 event_id=self.event_id,
@@ -858,7 +884,9 @@ class BattleCupTierSelect(ui.Select):
             ctx.add(tier=tier)
 
             if result.get("action") == "needs_screenshot":
-                view = ScreenshotUploadPromptView(self.event_id, result["screenshot_type"])
+                view = ScreenshotUploadPromptView(
+                    self.event_id, result["screenshot_type"]
+                )
                 await interaction.response.edit_message(
                     content=(
                         f"\U0001f3c6 Battle Cup tier {tier} saved\n\n"
@@ -919,9 +947,15 @@ class ScreenshotUploadButton(ui.Button):
         self.screenshot_type = screenshot_type
 
     async def callback(self, interaction: discord.Interaction):
-        async with discord_log_context(interaction, custom_id=self.custom_id, event_id=self.event_id) as ctx:
+        async with discord_log_context(
+            interaction, custom_id=self.custom_id, event_id=self.event_id
+        ) as ctx:
             if interaction.response.is_done():
-                log.warning("screenshot_upload_already_acknowledged")
+                log.warning(
+                    "screenshot_upload_already_acknowledged",
+                    system="discord",
+                    subsystem="interaction",
+                )
                 ctx.set_outcome("already_acknowledged")
                 return
             modal = ScreenshotUploadModal(self.event_id, self.screenshot_type)
@@ -996,7 +1030,13 @@ class ScreenshotUploadModal(ui.Modal):
                 screenshot_type=self.screenshot_type,
                 attachment_url=attachment_url,
             )
-            ctx.set_outcome("signed_up" if result.get("signed_up") else "screenshot_saved" if result.get("success") else "error")
+            ctx.set_outcome(
+                "signed_up"
+                if result.get("signed_up")
+                else "screenshot_saved"
+                if result.get("success")
+                else "error"
+            )
             ctx.add(screenshot_type=self.screenshot_type)
 
             if result.get("success"):

--- a/backend/discordbot/services/channels.py
+++ b/backend/discordbot/services/channels.py
@@ -1,7 +1,5 @@
 """Discord channel listing with Redis caching."""
 
-from telemetry.logging import get_logger
-
 import requests
 from django.conf import settings
 from django.core.cache import cache
@@ -11,6 +9,7 @@ from rest_framework.response import Response
 
 from app.models import Organization
 from app.permissions_org import has_org_staff_access
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -80,7 +79,13 @@ def get_discord_channels(request, pk):
     try:
         channels = _get_channels_cached(org.discord_server_id)
     except Exception as e:
-        log.error("Failed to fetch Discord channels for org %s: %s", org.pk, e)
+        log.error(
+            "channels_fetch_failed",
+            system="discord",
+            subsystem="channels",
+            org_id=org.pk,
+            error=str(e),
+        )
         return Response({"error": "Failed to fetch Discord channels"}, status=502)
 
     return Response({"channels": channels})

--- a/backend/discordbot/services/channels.py
+++ b/backend/discordbot/services/channels.py
@@ -1,6 +1,6 @@
 """Discord channel listing with Redis caching."""
 
-import logging
+from telemetry.logging import get_logger
 
 import requests
 from django.conf import settings
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from app.models import Organization
 from app.permissions_org import has_org_staff_access
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 CHANNELS_CACHE_TTL = 600  # 10 minutes
 

--- a/backend/discordbot/services/roles.py
+++ b/backend/discordbot/services/roles.py
@@ -1,6 +1,6 @@
 """Discord role listing with Redis caching."""
 
-import logging
+from telemetry.logging import get_logger
 
 import requests
 from django.conf import settings
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from app.models import Organization
 from app.permissions_org import has_org_staff_access
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 ROLES_CACHE_TTL = 600  # 10 minutes
 

--- a/backend/discordbot/services/roles.py
+++ b/backend/discordbot/services/roles.py
@@ -1,7 +1,5 @@
 """Discord role listing with Redis caching."""
 
-from telemetry.logging import get_logger
-
 import requests
 from django.conf import settings
 from django.core.cache import cache
@@ -11,6 +9,7 @@ from rest_framework.response import Response
 
 from app.models import Organization
 from app.permissions_org import has_org_staff_access
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -85,7 +84,13 @@ def get_discord_roles(request, pk):
     try:
         roles = _get_roles_cached(org.discord_server_id)
     except Exception as e:
-        log.error("Failed to fetch Discord roles for org %s: %s", org.pk, e)
+        log.error(
+            "roles_fetch_failed",
+            system="discord",
+            subsystem="roles",
+            org_id=org.pk,
+            error=str(e),
+        )
         return Response({"error": "Failed to fetch Discord roles"}, status=502)
 
     return Response({"roles": roles})

--- a/backend/discordbot/services/users.py
+++ b/backend/discordbot/services/users.py
@@ -1,5 +1,5 @@
 import json
-import logging
+from telemetry.logging import get_logger
 
 import requests
 from django.contrib.auth import login
@@ -43,7 +43,7 @@ from app.serializers import (
 )
 from backend import settings
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 from django.core.cache import cache
 

--- a/backend/discordbot/services/users.py
+++ b/backend/discordbot/services/users.py
@@ -1,47 +1,17 @@
-import json
-from telemetry.logging import get_logger
-
 import requests
-from django.contrib.auth import login
-from django.contrib.auth import logout as auth_logout
-from django.contrib.auth.decorators import login_required
-from django.db import transaction
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
-from django.shortcuts import redirect, render
-from rest_framework import generics, permissions, serializers, status, viewsets
+from django.http import JsonResponse
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.generics import GenericAPIView
-from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.reverse import reverse
-from social_core.backends.oauth import BaseOAuth1, BaseOAuth2
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
 # Create your views here.
-from social_django.models import USER_MODEL  # fix: skip
-from social_django.models import AbstractUserSocialAuth, DjangoStorage
-from social_django.utils import load_strategy, psa
-
 from app.models import (
     CustomUser,
-    Draft,
-    DraftRound,
     Organization,
-    PositionsModel,
-    Team,
-    Tournament,
 )
 from app.permissions import IsStaff
 from app.permissions_org import has_org_staff_access
-from app.serializers import (
-    DraftRoundSerializer,
-    DraftSerializer,
-    GameSerializer,
-    PositionsSerializer,
-    TeamSerializer,
-    TournamentSerializer,
-    UserSerializer,
-)
 from backend import settings
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -56,7 +26,7 @@ def get_user_guilds(request):
     ]
     url = "https://discord.com/api/users/@me/guilds"
     headers = {"Authorization": f"Bearer {access_token}"}
-    cache_key = f"discord_guilds"
+    cache_key = "discord_guilds"
     cached_guilds = cache.get(cache_key)
     if cached_guilds:
         return JsonResponse({"guilds": cached_guilds}, safe=True)
@@ -94,7 +64,7 @@ def get_discord_members_api():
         return JsonResponse({"error": str(e)}, status=500)
 
 
-from cacheops import cached, cached_view
+from cacheops import cached
 
 
 @api_view(["GET"])
@@ -188,7 +158,6 @@ def get_discord_voice_channel_activity(request):
             {"error": f"Error communicating with Discord API: {str(e)}"}, status=500
         )
     except Exception as e:
-
         # Catch any other unexpected errors during processing
         return JsonResponse(
             {"error": f"An unexpected error occurred: {str(e)}"}, status=500
@@ -228,7 +197,13 @@ def get_organization_discord_members(request, pk):
         members = get_discord_members_data(guild_id=org.discord_server_id)
         return JsonResponse({"members": members}, safe=True)
     except Exception as e:
-        log.error(f"Error fetching Discord members for org {pk}: {e}")
+        log.error(
+            "members_fetch_failed",
+            system="discord",
+            subsystem="users",
+            org_id=pk,
+            error=str(e),
+        )
         return JsonResponse({"error": str(e)}, status=500)
 
 
@@ -276,7 +251,13 @@ def search_discord_members(request):
         try:
             members = get_discord_members_data(guild_id=org.discord_server_id)
         except Exception as e:
-            log.error(f"Error fetching Discord members for org {org.pk}: {e}")
+            log.error(
+                "members_search_fetch_failed",
+                system="discord",
+                subsystem="users",
+                org_id=org.pk,
+                error=str(e),
+            )
             return JsonResponse(
                 {"error": "Failed to fetch Discord members"}, status=502
             )
@@ -358,7 +339,13 @@ def refresh_discord_members(request):
     try:
         members = get_discord_members_data(guild_id=org.discord_server_id)
     except Exception as e:
-        log.error(f"Error refreshing Discord members for org {org.pk}: {e}")
+        log.error(
+            "members_refresh_failed",
+            system="discord",
+            subsystem="users",
+            org_id=org.pk,
+            error=str(e),
+        )
         return JsonResponse({"error": "Failed to fetch Discord members"}, status=502)
     cache.set(cache_key, members, timeout=DISCORD_MEMBERS_CACHE_TTL)
     cache.set(cooldown_key, True, timeout=300)  # 5-minute cooldown

--- a/backend/discordbot/utils.py
+++ b/backend/discordbot/utils.py
@@ -7,6 +7,8 @@ import redis as _redis
 import requests
 from django.conf import settings
 
+from telemetry.logging import get_logger
+
 from .embeds import event_announcement_embed
 
 log = get_logger(__name__)
@@ -29,6 +31,7 @@ class MessageDeletedError(Exception):
         super().__init__(
             f"Discord message {self.message_id} in channel {self.channel_id} was deleted"
         )
+
 
 _REDIS_HOST = getattr(settings, "REDIS_HOST", "redis")
 redis_client = _redis.Redis(host=_REDIS_HOST, port=6379, db=2, socket_timeout=2)
@@ -80,7 +83,9 @@ def _acquire_rate_limit_token(max_wait=10.0):
             if result == 1:
                 return True
         except _redis.RedisError:
-            log.warning("Rate limiter Redis unavailable, allowing request")
+            log.warning(
+                "rate_limiter_redis_unavailable", system="discord", subsystem="utils"
+            )
             return True
         if _time.monotonic() >= deadline:
             raise RuntimeError(f"Discord rate limit: no token within {max_wait}s")
@@ -98,7 +103,12 @@ def _rate_limited_request(method, url, max_retries=3, **kwargs):
         if response.status_code == 429:
             retry_after = response.json().get("retry_after", 1.0)
             log.warning(
-                "Discord 429 on %s %s, retry_after=%.1fs", method, url, retry_after
+                "discord_rate_limited",
+                system="discord",
+                subsystem="utils",
+                method=method,
+                url=url,
+                retry_after=retry_after,
             )
             _time.sleep(retry_after)
             continue
@@ -157,9 +167,11 @@ def _log_discord_message(
             time.sleep(1)  # Brief retry delay
 
     log.error(
-        "Failed to log Discord message via internal API after 2 attempts (source=%s, source_id=%s)",
-        source,
-        source_id,
+        "message_log_failed",
+        system="discord",
+        subsystem="utils",
+        source=source,
+        source_id=source_id,
     )
     return None
 
@@ -223,11 +235,13 @@ def sync_send_embed(
             success=True,
         )
         log.info(
-            "Sent embed to channel %s: %s (source=%s, source_id=%s)",
-            channel_id,
-            title,
-            source,
-            source_id,
+            "embed_sent",
+            system="discord",
+            subsystem="utils",
+            channel_id=str(channel_id),
+            title=title,
+            source=source,
+            source_id=source_id,
         )
         return response_data
     except requests.RequestException as e:
@@ -253,11 +267,13 @@ def sync_send_embed(
             success=False,
         )
         log.error(
-            "Failed to send embed to channel %s: %s (source=%s, source_id=%s)",
-            channel_id,
-            e,
-            source,
-            source_id,
+            "embed_send_failed",
+            system="discord",
+            subsystem="utils",
+            channel_id=str(channel_id),
+            source=source,
+            source_id=source_id,
+            error=str(e),
         )
         return None
 
@@ -294,7 +310,7 @@ def sync_send_tournament_created(tournament, channel_id=None):
 
     channel = channel_id or getattr(settings, "DISCORD_ADMIN_CHANNEL_ID", None)
     if not channel:
-        log.warning("No channel_id provided and DISCORD_ADMIN_CHANNEL_ID not set")
+        log.warning("admin_channel_not_configured", system="discord", subsystem="utils")
         return None
 
     embed = tournament_created_embed(tournament)
@@ -315,7 +331,7 @@ def sync_send_draft_ready(draft, channel_id=None):
 
     channel = channel_id or getattr(settings, "DISCORD_ADMIN_CHANNEL_ID", None)
     if not channel:
-        log.warning("No channel_id provided and DISCORD_ADMIN_CHANNEL_ID not set")
+        log.warning("admin_channel_not_configured", system="discord", subsystem="utils")
         return None
 
     embed = draft_ready_embed(draft)
@@ -335,7 +351,7 @@ def sync_send_results_posted(tournament, channel_id=None):
 
     channel = channel_id or getattr(settings, "DISCORD_ADMIN_CHANNEL_ID", None)
     if not channel:
-        log.warning("No channel_id provided and DISCORD_ADMIN_CHANNEL_ID not set")
+        log.warning("admin_channel_not_configured", system="discord", subsystem="utils")
         return None
 
     embed = results_posted_embed(tournament)
@@ -383,9 +399,7 @@ def sync_send_embed_with_components_no_log(
         url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
         payload = message_content
 
-    response = _rate_limited_request(
-        "POST", url, json=payload, headers=_get_headers()
-    )
+    response = _rate_limited_request("POST", url, json=payload, headers=_get_headers())
     response_data = response.json()
     response.raise_for_status()
     return response_data, response.status_code
@@ -431,8 +445,15 @@ def sync_send_embed_with_components(
     # so dedup is meaningless.
     if source_id is None:
         return _send_with_post_log(
-            channel_id, embed, components, source, source_id,
-            forum_thread_name, content, allowed_mentions, fired_by_user_id,
+            channel_id,
+            embed,
+            components,
+            source,
+            source_id,
+            forum_thread_name,
+            content,
+            allowed_mentions,
+            fired_by_user_id,
         )
 
     log_pk = claim_discord_message_log(
@@ -444,8 +465,11 @@ def sync_send_embed_with_components(
     )
     if log_pk is None:
         log.info(
-            "Lease already held for %s:%s — skipping Discord send",
-            source, source_id,
+            "send_lease_held",
+            system="discord",
+            subsystem="utils",
+            source=source,
+            source_id=source_id,
         )
         return None
 
@@ -461,14 +485,23 @@ def sync_send_embed_with_components(
         if forum_thread_name and response_data.get("message"):
             msg_id = response_data["message"].get("id")
             log.info(
-                "Created forum thread '%s' in channel %s (source=%s, thread_id=%s)",
-                forum_thread_name, channel_id, source, response_data.get("id"),
+                "forum_thread_created",
+                system="discord",
+                subsystem="utils",
+                forum_thread_name=forum_thread_name,
+                channel_id=str(channel_id),
+                source=source,
+                thread_id=response_data.get("id"),
             )
         else:
             msg_id = response_data.get("id")
             log.info(
-                "Sent embed to channel %s (source=%s, source_id=%s)",
-                channel_id, source, source_id,
+                "embed_sent",
+                system="discord",
+                subsystem="utils",
+                channel_id=str(channel_id),
+                source=source,
+                source_id=source_id,
             )
 
         finalize_discord_message_log(
@@ -499,13 +532,26 @@ def sync_send_embed_with_components(
             status_code=status_code,
             response_data=resp_data,
         )
-        log.error("Failed to send to channel %s: %s", channel_id, e)
+        log.error(
+            "embed_send_failed",
+            system="discord",
+            subsystem="utils",
+            channel_id=str(channel_id),
+            error=str(e),
+        )
         return None
 
 
 def _send_with_post_log(
-    channel_id, embed, components, source, source_id,
-    forum_thread_name, content, allowed_mentions, fired_by_user_id,
+    channel_id,
+    embed,
+    components,
+    source,
+    source_id,
+    forum_thread_name,
+    content,
+    allowed_mentions,
+    fired_by_user_id,
 ):
     """Send + post-log path for callers without a meaningful source_id.
 
@@ -517,8 +563,11 @@ def _send_with_post_log(
     embed_data = embeds[0] if embeds else {}
     try:
         response_data, status_code = sync_send_embed_with_components_no_log(
-            channel_id=channel_id, embed=embed, components=components,
-            forum_thread_name=forum_thread_name, content=content,
+            channel_id=channel_id,
+            embed=embed,
+            components=components,
+            forum_thread_name=forum_thread_name,
+            content=content,
             allowed_mentions=allowed_mentions,
         )
         if forum_thread_name and response_data.get("message"):
@@ -561,7 +610,13 @@ def _send_with_post_log(
             success=False,
             fired_by_user_id=fired_by_user_id,
         )
-        log.error("Failed to send to channel %s: %s", channel_id, e)
+        log.error(
+            "embed_send_failed",
+            system="discord",
+            subsystem="utils",
+            channel_id=str(channel_id),
+            error=str(e),
+        )
         return None
 
 
@@ -605,14 +660,21 @@ def sync_send_v2_message(
         if forum_thread_name and response_data.get("message"):
             msg_id = response_data["message"].get("id")
             log.info(
-                "Created V2 forum thread '%s' in %s (thread=%s)",
-                forum_thread_name,
-                channel_id,
-                response_data.get("id"),
+                "v2_forum_thread_created",
+                system="discord",
+                subsystem="utils",
+                forum_thread_name=forum_thread_name,
+                channel_id=str(channel_id),
+                thread_id=response_data.get("id"),
             )
         else:
             msg_id = response_data.get("id")
-            log.info("Sent V2 message to %s", channel_id)
+            log.info(
+                "v2_message_sent",
+                system="discord",
+                subsystem="utils",
+                channel_id=str(channel_id),
+            )
 
         _log_discord_message(
             channel_id=channel_id,
@@ -647,7 +709,13 @@ def sync_send_v2_message(
             response_data=resp_data,
             success=False,
         )
-        log.error("Failed to send V2 message to %s: %s", channel_id, e)
+        log.error(
+            "v2_message_send_failed",
+            system="discord",
+            subsystem="utils",
+            channel_id=str(channel_id),
+            error=str(e),
+        )
         return None
 
 
@@ -665,10 +733,22 @@ def sync_edit_v2_message(channel_id, message_id, v2_payload):
             "PATCH", url, json=v2_payload, headers=_get_headers()
         )
         response.raise_for_status()
-        log.info("Edited V2 message %s in %s", message_id, channel_id)
+        log.info(
+            "v2_message_edited",
+            system="discord",
+            subsystem="utils",
+            channel_id=str(channel_id),
+            message_id=str(message_id),
+        )
         return response.json()
     except requests.RequestException as e:
-        log.error("Failed to edit V2 message %s: %s", message_id, e)
+        log.error(
+            "v2_message_edit_failed",
+            system="discord",
+            subsystem="utils",
+            message_id=str(message_id),
+            error=str(e),
+        )
         return None
 
 
@@ -684,9 +764,6 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
     Returns:
         dict: API response or None on error
     """
-    from telemetry.logging import get_logger
-    structured_log = get_logger(__name__)
-
     url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
 
     payload = {}
@@ -695,10 +772,10 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
     if components is not None:
         payload["components"] = components
 
-    structured_log.info(
+    log.info(
         "discord_message_edit_attempt",
-        system="events",
-        subsystem="discord",
+        system="discord",
+        subsystem="utils",
         channel_id=str(channel_id),
         message_id=str(message_id),
         embed_count=len(payload.get("embeds", []) or []),
@@ -720,10 +797,10 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
                 body = (response.text or "")[:500]
             discord_code = body.get("code") if isinstance(body, dict) else None
             discord_msg = body.get("message") if isinstance(body, dict) else None
-            structured_log.error(
+            log.error(
                 "discord_message_edit_failed",
-                system="events",
-                subsystem="discord",
+                system="discord",
+                subsystem="utils",
                 channel_id=str(channel_id),
                 message_id=str(message_id),
                 status_code=response.status_code,
@@ -739,10 +816,10 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
             ):
                 raise MessageDeletedError(channel_id, message_id)
             response.raise_for_status()
-        structured_log.info(
+        log.info(
             "discord_message_edit_success",
-            system="events",
-            subsystem="discord",
+            system="discord",
+            subsystem="utils",
             channel_id=str(channel_id),
             message_id=str(message_id),
         )
@@ -750,10 +827,10 @@ def sync_edit_message(channel_id, message_id, embed=None, components=None):
     except requests.RequestException as e:
         # Already logged the structured failure above when status_code was bad;
         # this branch also catches network errors (timeouts, DNS, etc.).
-        structured_log.error(
+        log.error(
             "discord_message_edit_exception",
-            system="events",
-            subsystem="discord",
+            system="discord",
+            subsystem="utils",
             channel_id=str(channel_id),
             message_id=str(message_id),
             error=str(e),
@@ -781,7 +858,13 @@ def sync_create_dm_channel(user_id):
         data = response.json()
         return data.get("id")
     except requests.RequestException as e:
-        log.error("Failed to create DM channel for user %s: %s", user_id, e)
+        log.error(
+            "dm_channel_create_failed",
+            system="discord",
+            subsystem="utils",
+            discord_user_id=str(user_id),
+            error=str(e),
+        )
         return None
 
 
@@ -810,9 +893,11 @@ def sync_send_dm(
         test_user_id = getattr(settings, "TEST_DISCORD_USER_ID", "")
         if test_user_id and str(user_id) != str(test_user_id):
             log.info(
-                "TEST mode: skipping DM to %s (only sending to test user %s)",
-                user_id,
-                test_user_id,
+                "dm_skipped_test_mode",
+                system="discord",
+                subsystem="utils",
+                discord_user_id=str(user_id),
+                test_user_id=str(test_user_id),
             )
             return {"id": "test-fake-message-id", "test_skipped": True}
 
@@ -830,7 +915,12 @@ def sync_send_dm(
         payload["components"] = components
 
     if not payload:
-        log.warning("sync_send_dm called with no content or embed")
+        log.warning(
+            "dm_empty_payload",
+            system="discord",
+            subsystem="utils",
+            discord_user_id=str(user_id),
+        )
         return None
 
     try:
@@ -839,7 +929,13 @@ def sync_send_dm(
         )
         response.raise_for_status()
         data = response.json()
-        log.info("Sent DM to user %s (message_id=%s)", user_id, data.get("id"))
+        log.info(
+            "dm_sent",
+            system="discord",
+            subsystem="utils",
+            discord_user_id=str(user_id),
+            message_id=data.get("id"),
+        )
         if tournament_log_id:
             _log_discord_message(
                 channel_id=dm_channel_id,
@@ -854,7 +950,13 @@ def sync_send_dm(
             )
         return data
     except requests.RequestException as e:
-        log.error("Failed to send DM to user %s: %s", user_id, e)
+        log.error(
+            "dm_send_failed",
+            system="discord",
+            subsystem="utils",
+            discord_user_id=str(user_id),
+            error=str(e),
+        )
         if tournament_log_id:
             _log_discord_message(
                 channel_id=dm_channel_id,
@@ -885,4 +987,12 @@ def sync_add_reactions(channel_id, message_id, emojis=None):
             response = _rate_limited_request("PUT", url, headers=_get_headers())
             response.raise_for_status()
         except requests.RequestException as e:
-            log.error(f"Failed to add reaction {emoji}: {e}")
+            log.error(
+                "reaction_add_failed",
+                system="discord",
+                subsystem="utils",
+                channel_id=str(channel_id),
+                message_id=str(message_id),
+                emoji=emoji,
+                error=str(e),
+            )

--- a/backend/discordbot/utils.py
+++ b/backend/discordbot/utils.py
@@ -1,7 +1,6 @@
 # backend/discordbot/utils.py
 """Admin utility functions for sending Discord messages."""
 
-import logging
 import time as _time
 
 import redis as _redis
@@ -10,7 +9,7 @@ from django.conf import settings
 
 from .embeds import event_announcement_embed
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
 

--- a/backend/discordbot/views.py
+++ b/backend/discordbot/views.py
@@ -1,14 +1,14 @@
 """Discord bot HTTP interaction endpoints."""
 
 import json
-import logging
+from telemetry.logging import get_logger
 
 from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def verify_discord_signature(request) -> bool:

--- a/backend/discordbot/views.py
+++ b/backend/discordbot/views.py
@@ -1,12 +1,13 @@
 """Discord bot HTTP interaction endpoints."""
 
 import json
-from telemetry.logging import get_logger
 
 from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -30,19 +31,19 @@ def verify_discord_signature(request) -> bool:
         except ImportError:
             from nacl.exceptions import BadSignature
     except ImportError as e:
-        log.error("PyNaCl not installed - cannot verify Discord signatures: %s", e)
+        log.error("pynacl_missing", system="discord", subsystem="views", error=str(e))
         return False
 
     public_key = getattr(settings, "DISCORD_PUBLIC_KEY", None)
     if not public_key:
-        log.error("DISCORD_PUBLIC_KEY not configured in settings")
+        log.error("discord_public_key_missing", system="discord", subsystem="views")
         return False
 
     signature = request.headers.get("X-Signature-Ed25519")
     timestamp = request.headers.get("X-Signature-Timestamp")
 
     if not signature or not timestamp:
-        log.warning("Missing Discord signature headers")
+        log.warning("signature_headers_missing", system="discord", subsystem="views")
         return False
 
     try:
@@ -51,10 +52,12 @@ def verify_discord_signature(request) -> bool:
         verify_key.verify(message, bytes.fromhex(signature))
         return True
     except BadSignature:
-        log.warning("Invalid Discord signature")
+        log.warning("signature_invalid", system="discord", subsystem="views")
         return False
     except Exception as e:
-        log.error(f"Error verifying Discord signature: {e}")
+        log.error(
+            "signature_verify_error", system="discord", subsystem="views", error=str(e)
+        )
         return False
 
 
@@ -86,7 +89,7 @@ def discord_interactions(request):
 
     # Type 1: PING - Discord is verifying the endpoint
     if interaction_type == 1:
-        log.info("Discord PING received - responding with PONG")
+        log.info("ping_received", system="discord", subsystem="views")
         return JsonResponse({"type": 1})  # PONG
 
     # Type 2: APPLICATION_COMMAND - Slash command
@@ -101,7 +104,12 @@ def discord_interactions(request):
     if interaction_type == 5:
         return handle_modal_submit(data)
 
-    log.warning(f"Unhandled interaction type: {interaction_type}")
+    log.warning(
+        "interaction_type_unhandled",
+        system="discord",
+        subsystem="views",
+        interaction_type=interaction_type,
+    )
     return JsonResponse({"type": 4, "data": {"content": "Unknown interaction type"}})
 
 
@@ -111,7 +119,13 @@ def handle_application_command(data: dict) -> JsonResponse:
     user = data.get("member", {}).get("user", {}) or data.get("user", {})
     username = user.get("username", "Unknown")
 
-    log.info(f"Slash command '{command_name}' from {username}")
+    log.info(
+        "slash_command_received",
+        system="discord",
+        subsystem="views",
+        command_name=command_name,
+        discord_username=username,
+    )
 
     # Respond with deferred message - actual handling done by gateway bot
     # This is useful for commands that need database access or complex processing
@@ -128,7 +142,13 @@ def handle_message_component(data: dict) -> JsonResponse:
     user = data.get("member", {}).get("user", {}) or data.get("user", {})
     username = user.get("username", "Unknown")
 
-    log.info(f"Component interaction '{custom_id}' from {username}")
+    log.info(
+        "component_interaction_received",
+        system="discord",
+        subsystem="views",
+        custom_id=custom_id,
+        discord_username=username,
+    )
 
     # Acknowledge the interaction
     return JsonResponse(
@@ -144,7 +164,13 @@ def handle_modal_submit(data: dict) -> JsonResponse:
     user = data.get("member", {}).get("user", {}) or data.get("user", {})
     username = user.get("username", "Unknown")
 
-    log.info(f"Modal submit '{custom_id}' from {username}")
+    log.info(
+        "modal_submit_received",
+        system="discord",
+        subsystem="views",
+        custom_id=custom_id,
+        discord_username=username,
+    )
 
     return JsonResponse(
         {

--- a/backend/events/discord/embeds.py
+++ b/backend/events/discord/embeds.py
@@ -4,12 +4,11 @@ Embed builders for Discord event notifications.
 Pure functions that construct embed dicts for the Discord API.
 """
 
-from telemetry.logging import get_logger
-
 from django.conf import settings
 
 from app.constants import LOGO_URL
 from app.internal_client import get_event_signups
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -108,11 +107,13 @@ def build_user_list_fields(signups, *, name, inline=True, max_items=40, numbered
     for line in lines:
         added = len(line) + (1 if bucket else 0)  # +1 for "\n" separator
         if bucket_len + added > EMBED_FIELD_VALUE_LIMIT:
-            fields.append({
-                "name": name if not fields else f"{name} (cont.)",
-                "value": "\n".join(bucket),
-                "inline": inline,
-            })
+            fields.append(
+                {
+                    "name": name if not fields else f"{name} (cont.)",
+                    "value": "\n".join(bucket),
+                    "inline": inline,
+                }
+            )
             bucket = [line]
             bucket_len = len(line)
         else:
@@ -120,11 +121,13 @@ def build_user_list_fields(signups, *, name, inline=True, max_items=40, numbered
             bucket_len += added
 
     if bucket:
-        fields.append({
-            "name": name if not fields else f"{name} (cont.)",
-            "value": "\n".join(bucket),
-            "inline": inline,
-        })
+        fields.append(
+            {
+                "name": name if not fields else f"{name} (cont.)",
+                "value": "\n".join(bucket),
+                "inline": inline,
+            }
+        )
     return fields
 
 
@@ -400,7 +403,7 @@ def build_announcement_notice(event, signup_link=None):
     date_line = local_dt.strftime("%A, %B %-d")
     time_line = local_dt.strftime("%-I:%M %p %Z")
 
-    desc = f"A new event is coming up!\n\n"
+    desc = "A new event is coming up!\n\n"
     desc += f"**When:** {date_line} at {time_line}\n"
     desc += f"**Max Players:** {event.max_players or 'Unlimited'}\n"
 

--- a/backend/events/discord/embeds.py
+++ b/backend/events/discord/embeds.py
@@ -4,14 +4,14 @@ Embed builders for Discord event notifications.
 Pure functions that construct embed dicts for the Discord API.
 """
 
-import logging
+from telemetry.logging import get_logger
 
 from django.conf import settings
 
 from app.constants import LOGO_URL
 from app.internal_client import get_event_signups
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 SITE_URL = getattr(settings, "SITE_URL", "") or "https://localhost"
 

--- a/backend/events/discord/handlers.py
+++ b/backend/events/discord/handlers.py
@@ -6,11 +6,11 @@ These are synchronous functions — the caller wraps them with sync_to_async.
 Return dicts with 'action' key so the caller knows how to respond.
 """
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from structlog.contextvars import bind_contextvars
 
 from app.cache_utils import invalidate_obj
 from discordbot.models import DiscordEventLog
-from django.core.exceptions import ValidationError as DjangoValidationError
 from events.constants import EventState, SignupStatus
 from events.models import Event, EventSignup
 from events.schemas import (
@@ -45,6 +45,8 @@ def _log_interaction(
     except Exception as e:
         log.error(
             "discord_event_log_write_failed",
+            system="discord",
+            subsystem="interaction",
             kind="interaction",
             action=action,
             event_id=event_id,
@@ -69,6 +71,8 @@ def _log_signup(
     except Exception as e:
         log.error(
             "discord_event_log_write_failed",
+            system="discord",
+            subsystem="interaction",
             kind="signup",
             action=action,
             event_id=event_id,
@@ -182,7 +186,12 @@ def _get_org_user(event, discord_user_id, discord_username=None):
 
 def handle_signup_button(event_id, discord_user_id, discord_username=None):
     """Handle Sign Up button click. Returns action dict."""
-    log.info("handler_invoked", handler="signup_button")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="signup_button",
+    )
     from app.models import GameType
 
     try:
@@ -240,13 +249,24 @@ def handle_signup_button(event_id, discord_user_id, discord_username=None):
 
         try:
             signup = process_rsvp(event, user)
-            log.info("signup_persisted", signup_id=signup.pk, signup_status=signup.status)
+            log.info(
+                "signup_persisted",
+                system="discord",
+                subsystem="interaction",
+                signup_id=signup.pk,
+                signup_status=signup.status,
+            )
             _log_signup(event_id, "signup_direct", discord_user_id, discord_username)
             # notify_signup_changed is dispatched by _create_signup's on_commit hook
             # (services.py:246) — do NOT call directly or the embed updates twice.
             return {"action": "signed_up", "status": signup.status}
         except ValueError as e:
-            log.warning("signup_rejected", reason=str(e))
+            log.warning(
+                "signup_rejected",
+                system="discord",
+                subsystem="interaction",
+                reason=str(e),
+            )
             _log_signup(
                 event_id,
                 "signup_failed",
@@ -292,9 +312,13 @@ def handle_signup_button(event_id, discord_user_id, discord_username=None):
 
 def handle_signup_modal_submit(event_id, discord_user_id, game_type, values):
     """Handle modal form submission. Saves profile data to OrgUser, may need follow-up."""
-    log.info("handler_invoked", handler="signup_modal_submit")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="signup_modal_submit",
+    )
     from app.cache_utils import invalidate_obj
-
     from app.models import GameType
     from org.models_profiles import PlayerDeadlockProfile
 
@@ -364,10 +388,21 @@ def handle_signup_modal_submit(event_id, discord_user_id, game_type, values):
 
         try:
             signup = process_rsvp(event, user)
-            log.info("signup_persisted", signup_id=signup.pk, signup_status=signup.status)
+            log.info(
+                "signup_persisted",
+                system="discord",
+                subsystem="interaction",
+                signup_id=signup.pk,
+                signup_status=signup.status,
+            )
             return {"action": "signed_up", "status": signup.status}
         except ValueError as e:
-            log.warning("signup_rejected", reason=str(e))
+            log.warning(
+                "signup_rejected",
+                system="discord",
+                subsystem="interaction",
+                reason=str(e),
+            )
             return {"action": "error", "message": str(e)}
 
     return {"action": "error", "message": "Unknown game type."}
@@ -385,7 +420,12 @@ def _rank_followup_message(rank_status):
 
 def handle_rank_status_select(event_id, discord_user_id, rank_status):
     """Save the rank status from the select menu to the Dota profile."""
-    log.info("handler_invoked", handler="rank_status_select")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="rank_status_select",
+    )
     from django.core.exceptions import ValidationError as DjangoValidationError
 
     from events.schemas import SignupInputPatch
@@ -413,7 +453,12 @@ def handle_rank_status_select(event_id, discord_user_id, rank_status):
 
 def handle_rank_medal_select(event_id, discord_user_id, medal):
     """Handle active rank medal selection. Saves medal and signs up."""
-    log.info("handler_invoked", handler="rank_medal_select")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="rank_medal_select",
+    )
     from django.core.exceptions import ValidationError as DjangoValidationError
 
     from events.schemas import SignupInputPatch
@@ -452,11 +497,19 @@ def handle_rank_medal_select(event_id, discord_user_id, medal):
 
     try:
         signup = process_rsvp(event, user)
-        log.info("signup_persisted", signup_id=signup.pk, signup_status=signup.status)
+        log.info(
+            "signup_persisted",
+            system="discord",
+            subsystem="interaction",
+            signup_id=signup.pk,
+            signup_status=signup.status,
+        )
         _log_signup(event_id, f"signup_ranked:{medal}", discord_user_id)
         return {"action": "signed_up", "status": signup.status}
     except ValueError as e:
-        log.warning("signup_rejected", reason=str(e))
+        log.warning(
+            "signup_rejected", system="discord", subsystem="interaction", reason=str(e)
+        )
         _log_signup(
             event_id,
             "signup_failed",
@@ -469,7 +522,12 @@ def handle_rank_medal_select(event_id, discord_user_id, medal):
 
 def handle_previous_rank_submit(event_id, discord_user_id, medal, date_text):
     """Handle previous rank modal submission. Saves rank info and signs up."""
-    log.info("handler_invoked", handler="previous_rank_submit")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="previous_rank_submit",
+    )
     from django.core.exceptions import ValidationError as DjangoValidationError
 
     from events.schemas import SignupInputPatch
@@ -508,16 +566,29 @@ def handle_previous_rank_submit(event_id, discord_user_id, medal, date_text):
 
     try:
         signup = process_rsvp(event, user)
-        log.info("signup_persisted", signup_id=signup.pk, signup_status=signup.status)
+        log.info(
+            "signup_persisted",
+            system="discord",
+            subsystem="interaction",
+            signup_id=signup.pk,
+            signup_status=signup.status,
+        )
         return {"action": "signed_up", "status": signup.status}
     except ValueError as e:
-        log.warning("signup_rejected", reason=str(e))
+        log.warning(
+            "signup_rejected", system="discord", subsystem="interaction", reason=str(e)
+        )
         return {"action": "error", "message": str(e)}
 
 
 def handle_battle_cup_submit(event_id, discord_user_id, tier):
     """Handle battle cup modal submission. Saves tier and signs up."""
-    log.info("handler_invoked", handler="battle_cup_submit")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="battle_cup_submit",
+    )
     from django.core.exceptions import ValidationError as DjangoValidationError
 
     from events.schemas import SignupInputPatch
@@ -562,11 +633,19 @@ def handle_battle_cup_submit(event_id, discord_user_id, tier):
 
     try:
         signup = process_rsvp(event, user)
-        log.info("signup_persisted", signup_id=signup.pk, signup_status=signup.status)
+        log.info(
+            "signup_persisted",
+            system="discord",
+            subsystem="interaction",
+            signup_id=signup.pk,
+            signup_status=signup.status,
+        )
         _log_signup(event_id, f"signup_battlecup:T{tier}", discord_user_id)
         return {"action": "signed_up", "status": signup.status}
     except ValueError as e:
-        log.warning("signup_rejected", reason=str(e))
+        log.warning(
+            "signup_rejected", system="discord", subsystem="interaction", reason=str(e)
+        )
         _log_signup(
             event_id,
             "signup_failed",
@@ -581,7 +660,12 @@ def handle_screenshot_upload(
     event_id, discord_user_id, screenshot_type, attachment_url
 ):
     """Validate and save screenshot URL to PlayerDotaProfile."""
-    log.info("handler_invoked", handler="screenshot_upload")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="screenshot_upload",
+    )
     from django.core.exceptions import ValidationError as DjangoValidationError
 
     from events.schemas import SignupInputPatch
@@ -634,7 +718,13 @@ def handle_screenshot_upload(
 
     try:
         signup = process_rsvp(event, user)
-        log.info("signup_persisted", signup_id=signup.pk, signup_status=signup.status)
+        log.info(
+            "signup_persisted",
+            system="discord",
+            subsystem="interaction",
+            signup_id=signup.pk,
+            signup_status=signup.status,
+        )
         _log_signup(
             event_id, f"signup_after_screenshot:{screenshot_type}", discord_user_id
         )
@@ -644,7 +734,9 @@ def handle_screenshot_upload(
             "message": f"Screenshot saved! You're signed up. Status: **{signup.status}**",
         }
     except ValueError as e:
-        log.warning("signup_rejected", reason=str(e))
+        log.warning(
+            "signup_rejected", system="discord", subsystem="interaction", reason=str(e)
+        )
         return {
             "success": True,
             "signed_up": False,
@@ -654,9 +746,13 @@ def handle_screenshot_upload(
 
 def handle_notify_button(event_id, discord_user_id):
     """Handle Notify Me button click. Toggles RepeaterSubscription."""
-    log.info("handler_invoked", handler="notify_button")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="notify_button",
+    )
     from app.cache_utils import invalidate_obj
-
     from app.models import CustomUser
     from events.models import RepeaterSubscription
 
@@ -685,7 +781,12 @@ def handle_notify_button(event_id, discord_user_id):
 
 def handle_decline_button(event_id, discord_user_id):
     """Handle Decline button click. Cancels signup if exists, or no-ops."""
-    log.info("handler_invoked", handler="decline_button")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="decline_button",
+    )
     from events.services import cancel_signup
 
     try:
@@ -716,7 +817,12 @@ def handle_decline_button(event_id, discord_user_id):
 
 def handle_tentative_button(event_id, discord_user_id, discord_username=None):
     """Handle Tentative button click. Routes through create_tentative_signup service."""
-    log.info("handler_invoked", handler="tentative_button")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="tentative_button",
+    )
     try:
         event = Event.objects.select_related("organization").get(pk=event_id)
     except Event.DoesNotExist:
@@ -737,7 +843,9 @@ def handle_tentative_button(event_id, discord_user_id, discord_username=None):
     try:
         signup = create_tentative_signup(event, user)
     except ValueError as e:
-        log.warning("signup_rejected", reason=str(e))
+        log.warning(
+            "signup_rejected", system="discord", subsystem="interaction", reason=str(e)
+        )
         if "already marked as tentative" in str(e).lower():
             return {"action": "already_tentative", "message": str(e)}
         return {"action": "error", "message": str(e)}
@@ -745,6 +853,8 @@ def handle_tentative_button(event_id, discord_user_id, discord_username=None):
     _log_signup(event_id, "tentative", discord_user_id, discord_username)
     log.info(
         "tentative_created",
+        system="discord",
+        subsystem="interaction",
         user_id=user.pk,
         event_id=event.pk,
         signup_id=signup.pk,
@@ -765,7 +875,12 @@ def handle_set_position(
     sets the chosen flag True — doesn't reset others. Multiple clicks
     accumulate positions, matching the pre-migration behavior.
     """
-    log.info("handler_invoked", handler="set_position")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="set_position",
+    )
     if position not in (1, 2, 3, 4, 5):
         return {"action": "error", "message": "Position must be 1-5."}
 
@@ -795,7 +910,12 @@ def handle_get_rank_flow_state(
     Returns dict with rank_status / require_screenshot / min_mmr, or
     error/message on lookup failure.
     """
-    log.info("handler_invoked", handler="get_rank_flow_state")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="get_rank_flow_state",
+    )
     try:
         event = Event.objects.select_related("organization").get(pk=event_id)
     except Event.DoesNotExist:
@@ -832,7 +952,12 @@ def handle_save_positions(
     Used by the PositionConfirmButton flow. Returns {"action": "positions_saved"} on
     success or {"action": "error", "message": str} on validation failure.
     """
-    log.info("handler_invoked", handler="save_positions")
+    log.info(
+        "handler_invoked",
+        system="discord",
+        subsystem="interaction",
+        handler="save_positions",
+    )
     try:
         event = Event.objects.select_related("organization").get(pk=event_id)
     except Event.DoesNotExist:
@@ -855,7 +980,9 @@ def handle_save_positions(
         )
     except DjangoValidationError as exc:
         msg = exc.messages[0] if hasattr(exc, "messages") else str(exc)
-        log.warning("signup_rejected", reason=msg)
+        log.warning(
+            "signup_rejected", system="discord", subsystem="interaction", reason=msg
+        )
         return {"action": "error", "message": msg}
 
     return {"action": "positions_saved"}

--- a/backend/events/discord/reactions.py
+++ b/backend/events/discord/reactions.py
@@ -6,9 +6,9 @@ announcement messages. These are synchronous functions — the bot calls
 them from async handlers via sync_to_async or database_sync_to_async.
 """
 
-import logging
+from telemetry.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def handle_reaction_signup(discord_message_id, discord_user_id):

--- a/backend/events/discord/reactions.py
+++ b/backend/events/discord/reactions.py
@@ -61,18 +61,22 @@ def handle_reaction_signup(discord_message_id, discord_user_id):
     try:
         signup = process_rsvp(event, user)
         logger.info(
-            "Discord reaction signup: user=%s event=%s status=%s",
-            user.pk,
-            event.pk,
-            signup.status,
+            "reaction_signup_created",
+            system="events",
+            subsystem="discord",
+            user_id=user.pk,
+            event_id=event.pk,
+            status=signup.status,
         )
         return True, signup.status
     except ValueError as e:
         logger.info(
-            "Discord reaction signup skipped: user=%s event=%s reason=%s",
-            user.pk,
-            event.pk,
-            str(e),
+            "reaction_signup_skipped",
+            system="events",
+            subsystem="discord",
+            user_id=user.pk,
+            event_id=event.pk,
+            reason=str(e),
         )
         return False, str(e)
 
@@ -125,9 +129,11 @@ def handle_reaction_cancel(discord_message_id, discord_user_id):
         signup = EventSignup.objects.get(event=event, user=user)
         cancel_signup(signup)
         logger.info(
-            "Discord reaction cancel: user=%s event=%s",
-            user.pk,
-            event.pk,
+            "reaction_signup_cancelled",
+            system="events",
+            subsystem="discord",
+            user_id=user.pk,
+            event_id=event.pk,
         )
         return True, "cancelled"
     except EventSignup.DoesNotExist:

--- a/backend/events/discord/tournament_dispatch.py
+++ b/backend/events/discord/tournament_dispatch.py
@@ -4,9 +4,9 @@ These run in Django (same process), so they CAN access ORM.
 They check config flags and fire Celery tasks via .delay().
 """
 
-import logging
+from telemetry.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def notify_draft_started(tournament, draft):

--- a/backend/events/discord/tournament_dispatch.py
+++ b/backend/events/discord/tournament_dispatch.py
@@ -16,7 +16,12 @@ def notify_draft_started(tournament, draft):
     from events.tournament_tasks import send_tournament_draft_links
 
     send_tournament_draft_links.delay(tournament.pk, draft.pk)
-    logger.info("Dispatched draft link DMs for tournament %d", tournament.pk)
+    logger.info(
+        "draft_links_dispatched",
+        system="events",
+        subsystem="dispatch",
+        tournament_id=tournament.pk,
+    )
 
 
 def notify_herodraft_created(tournament, herodraft, game):
@@ -32,7 +37,12 @@ def notify_herodraft_created(tournament, herodraft, game):
         radiant_name=game.radiant_team.name if game.radiant_team else "",
         dire_name=game.dire_team.name if game.dire_team else "",
     )
-    logger.info("Dispatched herodraft link DMs for tournament %d", tournament.pk)
+    logger.info(
+        "herodraft_links_dispatched",
+        system="events",
+        subsystem="dispatch",
+        tournament_id=tournament.pk,
+    )
 
 
 def start_auto_create_herodrafts(tournament):
@@ -42,4 +52,9 @@ def start_auto_create_herodrafts(tournament):
     from events.tournament_tasks import auto_create_herodrafts
 
     auto_create_herodrafts.delay(tournament.pk)
-    logger.info("Started auto-create herodrafts for tournament %d", tournament.pk)
+    logger.info(
+        "herodraft_auto_create_started",
+        system="events",
+        subsystem="dispatch",
+        tournament_id=tournament.pk,
+    )

--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -1,6 +1,5 @@
 import calendar
 import datetime
-import logging
 import re
 from datetime import timedelta
 from zoneinfo import ZoneInfo
@@ -25,7 +24,7 @@ from events.models import (
 )
 from telemetry.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 log = get_logger(__name__)
 
 

--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -4,10 +4,9 @@ import re
 from datetime import timedelta
 from zoneinfo import ZoneInfo
 
-from app.cache_utils import invalidate_obj
 from django.db import models, transaction
 
-from app.cache_utils import invalidate_after_commit
+from app.cache_utils import invalidate_after_commit, invalidate_obj
 from app.models import Tournament
 from events.constants import EventState, RepeatFrequency, SignupStatus, SignupType
 from events.discord import (
@@ -63,9 +62,9 @@ def clear_signup_dedup_state(event_id):
         DiscordEventMsgSignup.objects.filter(event_id=event_id, has_posted=True)
     )
     signup_rows_cleared = len(affected_signups)
-    DiscordEventMsgSignup.objects.filter(
-        event_id=event_id, has_posted=True
-    ).update(has_posted=False)
+    DiscordEventMsgSignup.objects.filter(event_id=event_id, has_posted=True).update(
+        has_posted=False
+    )
     for row in affected_signups:
         row.refresh_from_db()
         invalidate_after_commit(row)
@@ -83,6 +82,7 @@ def clear_signup_dedup_state(event_id):
 def _validate_screenshot_url(url):
     if url and not SCREENSHOT_URL_RE.match(url):
         from django.core.exceptions import ValidationError
+
         raise ValidationError(SCREENSHOT_BAD_URL_MESSAGE, code="screenshot_bad_url")
 
 
@@ -185,18 +185,32 @@ def _create_signup(event, user, event_team=None):
     existing = EventSignup.objects.filter(event=event, user=user).first()
     if existing:
         logger.info(
-            "Existing signup found: user=%s, event=%s, status=%s, id=%s",
-            user.pk,
-            event.pk,
-            existing.status,
-            existing.id,
+            "signup_existing_found",
+            system="events",
+            subsystem="services",
+            user_id=user.pk,
+            event_id=event.pk,
+            status=existing.status,
+            signup_id=existing.id,
         )
         if existing.status in (SignupStatus.CANCELLED, SignupStatus.REJECTED):
             existing.delete()
-            logger.info("Deleted cancelled/rejected signup, allowing re-RSVP")
+            logger.info(
+                "signup_cancelled_deleted",
+                system="events",
+                subsystem="services",
+                user_id=user.pk,
+                event_id=event.pk,
+            )
         elif existing.status == SignupStatus.TENTATIVE:
             existing.delete()
-            logger.info("Upgrading tentative signup to full RSVP")
+            logger.info(
+                "signup_tentative_upgraded",
+                system="events",
+                subsystem="services",
+                user_id=user.pk,
+                event_id=event.pk,
+            )
         else:
             raise ValueError("User has already signed up for this event.")
 
@@ -221,6 +235,8 @@ def _create_signup(event, user, event_team=None):
         invalidate_after_commit(event)
         log.info(
             "signup_post_commit_hooks_scheduled",
+            system="events",
+            subsystem="services",
             signup_id=signup.pk,
             event_id=event.pk,
         )
@@ -251,6 +267,8 @@ def _create_signup(event, user, event_team=None):
     invalidate_after_commit(event)
     log.info(
         "signup_post_commit_hooks_scheduled",
+        system="events",
+        subsystem="services",
         signup_id=signup.pk,
         event_id=event.pk,
     )
@@ -262,7 +280,13 @@ def _create_signup(event, user, event_team=None):
 
 def process_rsvp(event, user, event_team=None):
     """Public-path signup. Locked to SIGNUPS_OPEN."""
-    log.info("process_rsvp_started", event_id=event.pk, user_id=user.pk)
+    log.info(
+        "process_rsvp_started",
+        system="events",
+        subsystem="services",
+        event_id=event.pk,
+        user_id=user.pk,
+    )
     if event.state != EventState.SIGNUPS_OPEN:
         raise ValueError("Event is not accepting signups.")
     signup = _create_signup(event, user, event_team=event_team)
@@ -271,6 +295,8 @@ def process_rsvp(event, user, event_team=None):
     transaction.on_commit(
         lambda: log.info(
             "signup_created",
+            system="events",
+            subsystem="services",
             signup_id=signup.pk,
             status=signup.status,
             event_id=event.pk,
@@ -356,8 +382,7 @@ def apply_signup_input(*, org_user, event, patch):
             # Global scope (matches handlers.py:234 — Friend ID is unique site-wide,
             # not per-org).
             collision = (
-                PlayerDotaProfile.objects
-                .filter(unverified_friend_id=fid)
+                PlayerDotaProfile.objects.filter(unverified_friend_id=fid)
                 .exclude(org_user=org_user)
                 .exists()
             )
@@ -437,7 +462,13 @@ def apply_signup_input(*, org_user, event, patch):
                 changed = True
         if changed:
             user_positions.save(
-                update_fields=["carry", "mid", "offlane", "soft_support", "hard_support"]
+                update_fields=[
+                    "carry",
+                    "mid",
+                    "offlane",
+                    "soft_support",
+                    "hard_support",
+                ]
             )
             invalidate_after_commit(user_positions, user)
     if "rank_status" in set_fields:
@@ -472,6 +503,8 @@ def apply_signup_input(*, org_user, event, patch):
     invalidate_after_commit(profile, org_user, event)
     log.info(
         "signup_input_applied",
+        system="events",
+        subsystem="services",
         set_fields=list(set_fields.keys()),
         profile_id=profile.pk,
         org_user_id=org_user.pk,
@@ -509,9 +542,7 @@ def approve_signup(signup, mmr_override=None):
     if mmr_override is not None:
         if signup.event.organization_id is None:
             raise ValueError("Cannot set MMR for an event without an organization.")
-        org_user = resolve_or_create_org_user(
-            signup.user, signup.event.organization
-        )
+        org_user = resolve_or_create_org_user(signup.user, signup.event.organization)
         org_user.mmr = mmr_override
         org_user.has_active_dota_mmr = True
         org_user.dota_mmr_last_verified = tz.now()
@@ -576,6 +607,8 @@ def cancel_signup(signup):
     transaction.on_commit(
         lambda: log.info(
             "signup_cancelled",
+            system="events",
+            subsystem="services",
             signup_id=signup.pk,
             prior_status=prior_status,
             event_id=signup.event_id,
@@ -825,9 +858,11 @@ def ensure_discord_event(event):
     )
     if created:
         logger.info(
-            "Auto-created DiscordEvent for event %s (guild=%s)",
-            event.pk,
-            org.discord_server_id,
+            "discord_event_auto_created",
+            system="events",
+            subsystem="services",
+            event_id=event.pk,
+            guild_id=str(org.discord_server_id),
         )
     return de
 
@@ -1153,8 +1188,10 @@ def sync_future_events(repeater, *, realign_schedule=False):
         invalidate_after_commit(*future_events)
 
     logger.info(
-        "Synced %d upcoming events for repeater %s",
-        len(future_events),
-        repeater.pk,
+        "repeater_future_events_synced",
+        system="events",
+        subsystem="services",
+        repeater_id=repeater.pk,
+        count=len(future_events),
     )
     return future_events

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from datetime import datetime, timedelta, timezone as tz
 
@@ -54,7 +53,7 @@ from events.discord.embeds import (
 )
 from telemetry.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 log = get_logger(__name__)
 
 

--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -1,5 +1,6 @@
 import time
-from datetime import datetime, timedelta, timezone as tz
+from datetime import datetime, timedelta
+from datetime import timezone as tz
 
 import requests as req
 from celery import shared_task
@@ -57,7 +58,9 @@ logger = get_logger(__name__)
 log = get_logger(__name__)
 
 
-def _bind_celery_context(task_name: str, event_id: int, interaction_id: str | None) -> None:
+def _bind_celery_context(
+    task_name: str, event_id: int, interaction_id: str | None
+) -> None:
     fields = {
         "system": "discord",
         "subsystem": "celery",
@@ -71,11 +74,16 @@ def _bind_celery_context(task_name: str, event_id: int, interaction_id: str | No
     bind_contextvars(**fields)
 
 
-def _celery_bookend_fields(task_name: str, event_id: int, interaction_id: str | None, **extra) -> dict:
+def _celery_bookend_fields(
+    task_name: str, event_id: int, interaction_id: str | None, **extra
+) -> dict:
     """Build kwargs dict for bookend log lines, dropping None values from interaction_id and extras."""
     fields = {
-        "system": "discord", "subsystem": "celery", "tags_csv": "events,signup",
-        "task": task_name, "event_id": event_id,
+        "system": "discord",
+        "subsystem": "celery",
+        "tags_csv": "events,signup",
+        "task": task_name,
+        "event_id": event_id,
     }
     if interaction_id is not None:
         fields["interaction_id"] = interaction_id
@@ -83,7 +91,9 @@ def _celery_bookend_fields(task_name: str, event_id: int, interaction_id: str | 
     return fields
 
 
-def _run_with_bookends(task_name: str, event_id: int, interaction_id: str | None, work, **extra):
+def _run_with_bookends(
+    task_name: str, event_id: int, interaction_id: str | None, work, **extra
+):
     """Wrap a task body with celery_task_started/finished/failed bookend logs.
 
     `work` is a zero-arg callable returning the task's return value. Extra
@@ -100,7 +110,9 @@ def _run_with_bookends(task_name: str, event_id: int, interaction_id: str | None
         failed = True
         log.error(
             "celery_task_failed",
-            error=str(exc), error_type=type(exc).__name__, exc_info=True,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
             **fields,
         )
         raise
@@ -177,9 +189,13 @@ def generate_upcoming_events():
         try:
             count = generate_repeater_events(repeater["pk"])
             total += count
-        except Exception:
+        except Exception as e:
             logger.exception(
-                "Failed to generate events for repeater %s", repeater["pk"]
+                "repeater_events_generate_failed",
+                system="events",
+                subsystem="tasks",
+                repeater_id=repeater["pk"],
+                error=str(e),
             )
     return f"Generated {total} events from {len(repeaters)} repeaters"
 
@@ -206,12 +222,26 @@ def cleanup_stale_events():
             if resp and resp.ok:
                 cancelled_count += 1
                 logger.info(
-                    "Auto-cancelled stale event %s (pk=%s)", event["name"], event["id"]
+                    "event_auto_cancelled",
+                    system="events",
+                    subsystem="tasks",
+                    event_id=event["id"],
                 )
             else:
-                logger.warning("Failed to auto-cancel event %s: %s", event["id"], resp)
-        except Exception:
-            logger.exception("Failed to auto-cancel event %s", event["id"])
+                logger.warning(
+                    "event_auto_cancel_failed",
+                    system="events",
+                    subsystem="tasks",
+                    event_id=event["id"],
+                )
+        except Exception as e:
+            logger.exception(
+                "event_auto_cancel_error",
+                system="events",
+                subsystem="tasks",
+                event_id=event["id"],
+                error=str(e),
+            )
 
     # Started but not closed → completed
     started = get_events_list(states="roll_call,in_progress", scheduled_before=cutoff)
@@ -222,14 +252,26 @@ def cleanup_stale_events():
             if resp and resp.ok:
                 completed_count += 1
                 logger.info(
-                    "Auto-completed stale event %s (pk=%s)", event["name"], event["id"]
+                    "event_auto_completed",
+                    system="events",
+                    subsystem="tasks",
+                    event_id=event["id"],
                 )
             else:
                 logger.warning(
-                    "Failed to auto-complete event %s: %s", event["id"], resp
+                    "event_auto_complete_failed",
+                    system="events",
+                    subsystem="tasks",
+                    event_id=event["id"],
                 )
-        except Exception:
-            logger.exception("Failed to auto-complete event %s", event["id"])
+        except Exception as e:
+            logger.exception(
+                "event_auto_complete_error",
+                system="events",
+                subsystem="tasks",
+                event_id=event["id"],
+                error=str(e),
+            )
 
     return f"Cleaned up {cancelled_count} cancelled, {completed_count} completed"
 
@@ -249,16 +291,26 @@ def open_scheduled_signups():
             if resp and resp.ok:
                 opened += 1
                 logger.info(
-                    "Auto-opened signups for event %s (pk=%s)",
-                    event["name"],
-                    event["id"],
+                    "signups_auto_opened",
+                    system="events",
+                    subsystem="tasks",
+                    event_id=event["id"],
                 )
             else:
                 logger.warning(
-                    "Failed to auto-open signups for event %s: %s", event["id"], resp
+                    "signups_auto_open_failed",
+                    system="events",
+                    subsystem="tasks",
+                    event_id=event["id"],
                 )
-        except Exception:
-            logger.exception("Failed to auto-open signups for event %s", event["id"])
+        except Exception as e:
+            logger.exception(
+                "signups_auto_open_error",
+                system="events",
+                subsystem="tasks",
+                event_id=event["id"],
+                error=str(e),
+            )
     return f"Opened signups for {opened} events"
 
 
@@ -436,7 +488,12 @@ def _send_event_announcement_impl(event_id):
     # Get or create DiscordEvent via internal API
     de_resp = get_or_create_discord_event(event_id=event.pk, guild_id=guild_id or "")
     if not de_resp or not de_resp.ok:
-        logger.error("Failed to get/create DiscordEvent for event %s", event.pk)
+        logger.error(
+            "discord_event_get_or_create_failed",
+            system="events",
+            subsystem="tasks",
+            event_id=event.pk,
+        )
         return "Failed: could not get/create DiscordEvent"
     discord_event_pk = de_resp.json().get("id")
 
@@ -535,7 +592,6 @@ def send_attendance_reminder(event_id):
         get_or_create_discord_event,
     )
     from discordbot.utils import sync_send_embed_with_components
-    from events.discord import build_attendance_reminder_embed
 
     event = get_event_for_task(event_id)
     if not event:
@@ -585,7 +641,6 @@ def send_profile_reminder(event_id):
         get_or_create_discord_event,
     )
     from discordbot.utils import sync_send_embed_with_components
-    from events.discord import build_profile_reminder_embed
 
     event = get_event_for_task(event_id)
     if not event:
@@ -690,7 +745,11 @@ def _send_signup_update_impl(event_id, interaction_id):
     discord_event = None
 
     discord_state = get_discord_event_state(event_id)
-    if discord_state and discord_state.signup_posted and discord_state.signup_message_id:
+    if (
+        discord_state
+        and discord_state.signup_posted
+        and discord_state.signup_message_id
+    ):
         message_id = discord_state.signup_message_id
         edit_channel_id = _resolve_signup_edit_channel(discord_state, fields)
 
@@ -706,8 +765,10 @@ def _send_signup_update_impl(event_id, interaction_id):
 
         if not log_entry or not log_entry.discord_message_id:
             logger.info(
-                "No announcement message found for event %s, skipping update",
-                event.pk,
+                "signup_update_no_announcement",
+                system="events",
+                subsystem="tasks",
+                event_id=event.pk,
             )
             return "Skipped: no announcement message"
 
@@ -834,7 +895,12 @@ def _create_discord_scheduled_event_impl(event_id):
     # Get or create DiscordEvent via internal API
     de_resp = get_or_create_discord_event(event_id=event.pk, guild_id=guild_id)
     if not de_resp or not de_resp.ok:
-        logger.error("Failed to get/create DiscordEvent for event %s", event.pk)
+        logger.error(
+            "discord_event_get_or_create_failed",
+            system="events",
+            subsystem="tasks",
+            event_id=event.pk,
+        )
         return "Failed: could not get/create DiscordEvent"
     discord_event_pk = de_resp.json().get("id")
 
@@ -891,8 +957,11 @@ def _create_discord_scheduled_event_impl(event_id):
             # "Sync: created ..." — the silent-success bug that caused 20+
             # invisible 403 Missing-Permissions failures on prod (0.9.49).
             logger.error(
-                "Discord scheduled-event create failed for event %s: %s",
-                event.pk, error_message,
+                "discord_scheduled_event_create_failed",
+                system="events",
+                subsystem="tasks",
+                event_id=event.pk,
+                reason=error_message,
             )
             raise RuntimeError(
                 f"Discord scheduled-event create failed for event {event.pk}: "
@@ -922,7 +991,11 @@ def _create_discord_scheduled_event_impl(event_id):
             error_message=str(e),
         )
         logger.exception(
-            "Failed to create Discord scheduled event for event %s", event.pk
+            "discord_scheduled_event_create_error",
+            system="events",
+            subsystem="tasks",
+            event_id=event.pk,
+            error=str(e),
         )
         return f"Failed: {e}"
 
@@ -971,7 +1044,13 @@ def _sync_discord_event_signups_impl(event_id):
         )
         return f"Synced signups for event {event.pk}"
     except Exception as e:
-        logger.exception("Failed to sync Discord event signups for event %s", event.pk)
+        logger.exception(
+            "discord_signups_sync_error",
+            system="events",
+            subsystem="tasks",
+            event_id=event.pk,
+            error=str(e),
+        )
         return f"Failed: {e}"
 
 
@@ -1017,7 +1096,12 @@ def _mark_interested_discord_event_impl(event_id, user_id):
         return f"Marked user {user_id} interested: {response.status_code}"
     except Exception as e:
         logger.exception(
-            "Failed to mark interested for event %s user %s", event.pk, user_id
+            "discord_mark_interested_error",
+            system="events",
+            subsystem="tasks",
+            event_id=event.pk,
+            user_id=user_id,
+            error=str(e),
         )
         return f"Failed: {e}"
 
@@ -1030,15 +1114,12 @@ def fire_event_reminder(event_id, reminder_type, fired_by_user_id=None):
     Called from the admin "Fire" button, not from celery beat.
     """
     from app.internal_client import (
-        check_message_log_exists,
         create_event_log,
         get_or_create_discord_event,
     )
     from discordbot.utils import sync_send_embed_with_components
     from events.discord import (
-        build_attendance_reminder_embed,
         build_profile_reminder_embed,
-        build_signup_reminder_embed,
     )
 
     REMINDER_MAP = {
@@ -1134,19 +1215,11 @@ def send_subscriber_notifications(event_id):
 
     Rate-limited at 1 DM/second to respect Discord limits.
     """
-    import time
 
     from app.internal_client import (
-        claim_discord_message_log,
-        create_event_dm,
-        finalize_discord_message_log,
         get_discord_event_state,
         get_event_for_task,
-        get_repeater_subscribers,
-        update_event_dm,
     )
-    from discordbot.utils import sync_send_dm
-    from events.discord.embeds import build_subscriber_dm_embed
 
     event = get_event_for_task(event_id)
     if not event:
@@ -1177,13 +1250,15 @@ def send_subscriber_notifications(event_id):
     )
     if log_pk is None:
         logger.info(
-            "Signup reminder lease for event %s held by another worker — skipping",
-            event_id,
+            "signup_reminder_lease_held",
+            system="events",
+            subsystem="tasks",
+            event_id=event_id,
+            reason="lease_held_by_another_worker",
         )
         return f"Signup reminder for event {event_id}: lease held by another worker"
 
     # Get user PKs who already signed up — skip them
-    from app.internal_client import get_event_signups
 
     all_signups = get_event_signups(event_id)
     signed_up_user_pks = {s.user for s in all_signups if s.status != "cancelled"}
@@ -1263,10 +1338,12 @@ def send_subscriber_notifications(event_id):
     )
 
     logger.info(
-        "Signup reminder DMs for event %s: sent=%d, skipped=%d, failed=%d",
-        event_id,
-        sent,
-        skipped,
-        failed,
+        "signup_reminder_dms_sent",
+        system="events",
+        subsystem="tasks",
+        event_id=event_id,
+        sent=sent,
+        skipped=skipped,
+        failed=failed,
     )
     return f"Sent {sent} DMs, skipped {skipped}, failed {failed} for event {event_id}"

--- a/backend/events/tournament_tasks.py
+++ b/backend/events/tournament_tasks.py
@@ -4,9 +4,9 @@ All data reads via internal_client HTTP calls (no ORM).
 All DB writes via internal API POST/PATCH endpoints.
 """
 
-from telemetry.logging import get_logger
-
 from celery import shared_task
+
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -84,7 +84,14 @@ def send_tournament_draft_links(tournament_id, draft_id):
             success=sent > 0,
         )
 
-    logger.info("Tournament %d draft links: %s", tournament_id, message)
+    logger.info(
+        "tournament_draft_links_sent",
+        system="events",
+        subsystem="tasks",
+        tournament_id=tournament_id,
+        sent=sent,
+        count=len(participants),
+    )
     return message
 
 
@@ -159,7 +166,14 @@ def send_tournament_herodraft_links(
             success=sent > 0,
         )
 
-    logger.info("Tournament %d herodraft links: %s", tournament_id, message)
+    logger.info(
+        "tournament_herodraft_links_sent",
+        system="events",
+        subsystem="tasks",
+        tournament_id=tournament_id,
+        sent=sent,
+        count=len(participants),
+    )
     return message
 
 
@@ -181,11 +195,23 @@ def auto_create_herodrafts(tournament_id):
         return f"Tournament {tournament_id} not found"
 
     if tournament.state == "past":
-        logger.info("Tournament %d completed, stopping auto-create", tournament_id)
+        logger.info(
+            "tournament_auto_create_stopped",
+            system="events",
+            subsystem="tasks",
+            tournament_id=tournament_id,
+            reason="tournament_completed",
+        )
         return "Tournament completed"
 
     if not tournament.auto_create_hero_drafts:
-        logger.info("Tournament %d auto-create disabled", tournament_id)
+        logger.info(
+            "tournament_auto_create_skipped",
+            system="events",
+            subsystem="tasks",
+            tournament_id=tournament_id,
+            reason="config_disabled",
+        )
         return "Config disabled"
 
     games = get_games_without_herodraft(tournament_id)
@@ -197,7 +223,13 @@ def auto_create_herodrafts(tournament_id):
 
         resp = create_herodraft_for_game(game.id)
         if not resp or not resp.ok:
-            logger.error("Failed to create herodraft for game %d", game.id)
+            logger.error(
+                "herodraft_create_failed",
+                system="events",
+                subsystem="tasks",
+                tournament_id=tournament_id,
+                game_id=game.id,
+            )
             continue
 
         result = resp.json()
@@ -216,7 +248,11 @@ def auto_create_herodrafts(tournament_id):
 
     if created_count > 0:
         logger.info(
-            "Tournament %d: auto-created %d hero drafts", tournament_id, created_count
+            "herodrafts_auto_created",
+            system="events",
+            subsystem="tasks",
+            tournament_id=tournament_id,
+            count=created_count,
         )
 
     auto_create_herodrafts.apply_async(args=[tournament_id], countdown=10)

--- a/backend/events/tournament_tasks.py
+++ b/backend/events/tournament_tasks.py
@@ -4,11 +4,11 @@ All data reads via internal_client HTTP calls (no ORM).
 All DB writes via internal API POST/PATCH endpoints.
 """
 
-import logging
+from telemetry.logging import get_logger
 
 from celery import shared_task
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @shared_task

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -1,14 +1,13 @@
-from telemetry.logging import get_logger
-
 from cacheops import cached_as
 from django.db import transaction
-
-from app.cache_utils import invalidate_obj
 from django.db.models import BooleanField, Count, Exists, F, OuterRef, Q, Value
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
+
+from app.cache_utils import invalidate_obj
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -209,9 +208,7 @@ class EventRepeaterViewSet(viewsets.ModelViewSet):
         schedule_changed = any(
             before[f] != getattr(repeater, f) for f in schedule_fields
         )
-        future_events = sync_future_events(
-            repeater, realign_schedule=schedule_changed
-        )
+        future_events = sync_future_events(repeater, realign_schedule=schedule_changed)
         # Single batched invalidation — repeater + every cascaded child
         invalidate_after_commit(repeater, *future_events)
 
@@ -454,7 +451,8 @@ class EventViewSet(viewsets.ModelViewSet):
                 self.permission_denied(request)
 
     @action(
-        detail=True, methods=["post"],
+        detail=True,
+        methods=["post"],
         permission_classes=[permissions.IsAuthenticated],
     )
     def signup(self, request, pk=None):
@@ -512,7 +510,9 @@ class EventViewSet(viewsets.ModelViewSet):
         except ValueError as exc:
             return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response(EventSignupSerializer(signup).data, status=status.HTTP_201_CREATED)
+        return Response(
+            EventSignupSerializer(signup).data, status=status.HTTP_201_CREATED
+        )
 
     @action(detail=True, methods=["post"], url_path="admin-signup")
     def admin_signup(self, request, pk=None):
@@ -1066,9 +1066,7 @@ def get_event_task_schedule(request, event_id):
         # Discord post is missing (deleted externally) or to push a fresh
         # version. fire_event_task clears dedup state before re-running.
         repostable = task in ("signup_post", "announcement")
-        entry["can_fire"] = (
-            s in ("ready", "pending") or (s == "fired" and repostable)
-        )
+        entry["can_fire"] = s in ("ready", "pending") or (s == "fired" and repostable)
         if log_source and log_source in last_fired_map:
             info = last_fired_map[log_source]
             entry["last_fired_at"] = info["created_at"].isoformat()
@@ -1338,9 +1336,11 @@ def fire_event_task(request, event_id, task_name):
         current_app.send_task(celery_task)
 
     logger.info(
-        "Manual fire: task=%s event=%s by user=%s",
-        task_name,
-        event_id,
-        request.user.pk,
+        "task_manually_fired",
+        system="events",
+        subsystem="views",
+        task_name=task_name,
+        event_id=event_id,
+        user_id=request.user.pk,
     )
     return Response({"fired": task_name, "event_id": event_id})

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -1,4 +1,4 @@
-import logging
+from telemetry.logging import get_logger
 
 from cacheops import cached_as
 from django.db import transaction
@@ -10,7 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 from app.models import Organization
 from app.permissions_org import has_event_staff_access, has_org_staff_access

--- a/backend/org/views.py
+++ b/backend/org/views.py
@@ -4,8 +4,6 @@ Organization Views
 Handles org admin functionality including claim request management.
 """
 
-from telemetry.logging import get_logger
-
 from django.db import transaction
 from django.utils import timezone
 from rest_framework import status, viewsets
@@ -15,7 +13,6 @@ from rest_framework.response import Response
 
 from app.models import (
     DraftRound,
-    HeroDraftEvent,
     LeagueLog,
     LeagueMatchParticipant,
     LeagueRating,
@@ -29,6 +26,7 @@ from league.models import LeagueUser
 from org.models import OrgUser
 from org.serializers import ProfileClaimRequestSerializer
 from steam.models import LeaguePlayerStats, PlayerMatchStats
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -134,8 +132,12 @@ class ClaimRequestViewSet(viewsets.ModelViewSet):
             )
 
             log.info(
-                f"Claim approved: {claimer.username} claimed profile {target_user.pk} "
-                f"(steamid={target_user.steamid})"
+                "claim_approved",
+                system="org",
+                subsystem="views",
+                user_id=claimer.pk,
+                target_user_id=target_pk,
+                target_steamid=target_steamid,
             )
 
         return Response(

--- a/backend/org/views.py
+++ b/backend/org/views.py
@@ -4,7 +4,7 @@ Organization Views
 Handles org admin functionality including claim request management.
 """
 
-import logging
+from telemetry.logging import get_logger
 
 from django.db import transaction
 from django.utils import timezone
@@ -30,7 +30,7 @@ from org.models import OrgUser
 from org.serializers import ProfileClaimRequestSerializer
 from steam.models import LeaguePlayerStats, PlayerMatchStats
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ClaimRequestViewSet(viewsets.ModelViewSet):

--- a/backend/scripts/check_logging_taxonomy.py
+++ b/backend/scripts/check_logging_taxonomy.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Enforce DraftForge structured-logging taxonomy.
+
+Every call to a structlog logger (a variable assigned from
+`telemetry.logging.get_logger(...)`) must:
+
+  1. pass a string-literal event name as the first positional arg
+     (snake_case by convention; not an f-string / `%`-format string), and
+  2. include both `system=` and `subsystem=` keyword arguments.
+
+Only files that bind a logger via `get_logger(...)` are checked, so stdlib
+`logging` users (telemetry/, settings.py, tests, management commands) are
+ignored automatically.
+
+A call that forwards `**kwargs` is exempt (the taxonomy may be supplied
+dynamically or via bound context vars).
+
+Usage:
+    python backend/scripts/check_logging_taxonomy.py [PATH ...]
+
+With no PATH, scans `backend/` recursively. Exits non-zero on any violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+LEVELS = {"debug", "info", "warning", "warn", "error", "exception", "critical"}
+
+
+def _logger_vars(tree: ast.Module) -> set[str]:
+    """Names bound from get_logger(...), e.g. `log = get_logger(__name__)`."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            fn = node.value.func
+            fname = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            if fname == "get_logger":
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        names.add(tgt.id)
+    return names
+
+
+def check_file(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError as e:
+        return [f"{path}:{e.lineno}: could not parse ({e.msg})"]
+
+    loggers = _logger_vars(tree)
+    if not loggers:
+        return []
+
+    problems: list[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr not in LEVELS:
+            continue
+        if not (isinstance(node.func.value, ast.Name) and node.func.value.id in loggers):
+            continue
+
+        kw_names = {k.arg for k in node.keywords}
+        if None in kw_names:  # **kwargs splat -> can't verify statically; exempt
+            continue
+
+        loc = f"{path}:{node.lineno}"
+        # 1) event name = first positional string literal
+        if not node.args or not (
+            isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str)
+        ):
+            problems.append(f"{loc}: first arg must be a string-literal event name (no f-strings)")
+        # 2) system + subsystem present
+        missing = {"system", "subsystem"} - kw_names
+        if missing:
+            problems.append(f"{loc}: log call missing {', '.join(sorted(missing))}=")
+    return problems
+
+
+def _excluded(p: Path) -> bool:
+    parts = set(p.parts)
+    return "tests" in parts or "migrations" in parts or p.name.startswith("test_")
+
+
+def iter_paths(args: list[str]):
+    roots = [Path(a) for a in args] or [Path("backend")]
+    for root in roots:
+        if root.is_dir():
+            yield from (p for p in sorted(root.rglob("*.py")) if not _excluded(p))
+        elif root.suffix == ".py" and not _excluded(root):
+            yield root
+
+
+def main(argv: list[str]) -> int:
+    problems: list[str] = []
+    for p in iter_paths(argv):
+        problems.extend(check_file(p))
+    for line in problems:
+        print(line)
+    if problems:
+        print(f"\n{len(problems)} logging-taxonomy violation(s).", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/backend/steam/functions/api.py
+++ b/backend/steam/functions/api.py
@@ -1,4 +1,4 @@
-import logging
+from telemetry.logging import get_logger
 
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -39,7 +39,7 @@ from steam.serializers import (
 from steam.services.match_suggestions import get_match_suggestions_for_game
 from steam.utils.steam_api_caller import SteamAPI
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 @api_view(["POST"])

--- a/backend/steam/functions/api.py
+++ b/backend/steam/functions/api.py
@@ -1,5 +1,3 @@
-from telemetry.logging import get_logger
-
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
@@ -38,6 +36,7 @@ from steam.serializers import (
 )
 from steam.services.match_suggestions import get_match_suggestions_for_game
 from steam.utils.steam_api_caller import SteamAPI
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -281,7 +280,6 @@ def link_game_match(request, game_id):
     Requires league staff access.
     """
     from app.cache_utils import invalidate_obj
-
     from app.models import Game
 
     serializer = LinkMatchRequestSerializer(data=request.data)
@@ -331,7 +329,6 @@ def unlink_game_match(request, game_id):
     Requires league staff access.
     """
     from app.cache_utils import invalidate_obj
-
     from app.models import Game
 
     try:

--- a/backend/steam/functions/game_linking.py
+++ b/backend/steam/functions/game_linking.py
@@ -1,11 +1,11 @@
-import logging
+from telemetry.logging import get_logger
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
 from app.models import Game, Tournament
 from steam.models import GameMatchSuggestion, Match
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def check_match_for_games(match):

--- a/backend/steam/functions/game_linking.py
+++ b/backend/steam/functions/game_linking.py
@@ -1,9 +1,9 @@
-from telemetry.logging import get_logger
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
 from app.models import Game, Tournament
 from steam.models import GameMatchSuggestion, Match
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -68,7 +68,13 @@ def check_match_for_games(match):
                     player_overlap=overlap,
                     auto_linked=True,
                 )
-                log.info(f"Auto-linked game {game.id} to match {match.match_id}")
+                log.info(
+                    "game_auto_linked",
+                    system="steam",
+                    subsystem="game_linking",
+                    game_id=game.id,
+                    match_id=match.match_id,
+                )
             else:
                 # Partial match - create suggestion for review
                 GameMatchSuggestion.objects.create(
@@ -145,7 +151,12 @@ def _determine_winner_from_match(game, match):
     option_b_score = radiant_as_dire + dire_as_radiant
 
     if option_a_score == 0 and option_b_score == 0:
-        log.warning(f"Cannot determine team mapping for game {game.id}")
+        log.warning(
+            "team_mapping_indeterminate",
+            system="steam",
+            subsystem="game_linking",
+            game_id=game.id,
+        )
         return None
 
     # Determine which mapping is correct
@@ -163,8 +174,14 @@ def _determine_winner_from_match(game, match):
             winner = game.radiant_team
 
     log.info(
-        f"Game {game.id}: Determined winner is {winner.name} "
-        f"(option_a={option_a_score}, option_b={option_b_score}, radiant_win={match.radiant_win})"
+        "game_winner_determined",
+        system="steam",
+        subsystem="game_linking",
+        game_id=game.id,
+        winner=winner.name,
+        option_a_score=option_a_score,
+        option_b_score=option_b_score,
+        radiant_win=match.radiant_win,
     )
     return winner
 
@@ -187,11 +204,20 @@ def _link_game_to_match(game, match):
         game.winning_team = winner
         game.status = "completed"
         log.info(
-            f"Linked game {game.id} to match {match.match_id}, winner: {winner.name}"
+            "game_linked_with_winner",
+            system="steam",
+            subsystem="game_linking",
+            game_id=game.id,
+            match_id=match.match_id,
+            winner=winner.name,
         )
     else:
         log.warning(
-            f"Linked game {game.id} to match {match.match_id}, but could not determine winner"
+            "game_linked_winner_unknown",
+            system="steam",
+            subsystem="game_linking",
+            game_id=game.id,
+            match_id=match.match_id,
         )
 
     game.save(update_fields=["gameid", "winning_team", "status"])
@@ -543,12 +569,24 @@ def auto_assign_matches_by_time(tournament_id, preview=True, min_overlap=4):
                 _link_game_to_match(game, match)
                 linked_count += 1
                 log.info(
-                    f"Auto-assigned game {game.id} ({game.bracket_type} R{game.round}) "
-                    f"to match {match.match_id} via {assignment['match_method']} "
-                    f"(overlap: {assignment['player_overlap']})"
+                    "game_auto_assigned",
+                    system="steam",
+                    subsystem="game_linking",
+                    game_id=game.id,
+                    bracket_type=game.bracket_type,
+                    round=game.round,
+                    match_id=match.match_id,
+                    match_method=assignment["match_method"],
+                    player_overlap=assignment["player_overlap"],
                 )
             except Exception as e:
-                log.error(f"Failed to link game {assignment['game_id']}: {e}")
+                log.error(
+                    "game_link_failed",
+                    system="steam",
+                    subsystem="game_linking",
+                    game_id=assignment["game_id"],
+                    error=str(e),
+                )
 
     return {
         "assignments": assignments,

--- a/backend/steam/functions/league_sync.py
+++ b/backend/steam/functions/league_sync.py
@@ -27,8 +27,9 @@ def link_user_to_stats(player_stats):
         player_stats.user = user
         player_stats.save(update_fields=["user"])
         log.debug(
-            "Linked player to user",
-            domain="steam",
+            "player_linked_to_user",
+            system="steam",
+            subsystem="league_sync",
             steam_id=player_stats.steam_id,
             username=user.username,
         )
@@ -52,7 +53,10 @@ def relink_all_users():
             linked_count += 1
 
     log.info(
-        "Relinked player stats to users", domain="steam", linked_count=linked_count
+        "player_stats_relinked",
+        system="steam",
+        subsystem="league_sync",
+        count=linked_count,
     )
     return linked_count
 
@@ -97,7 +101,12 @@ def process_match(match_id, league_id=None, match_seq_num=None):
     success, result = retry_with_backoff(fetch, max_retries=3, base_delay=1.0)
 
     if not success or not result or "result" not in result:
-        log.warning("Failed to fetch match", domain="steam", match_id=match_id)
+        log.warning(
+            "match_fetch_failed",
+            system="steam",
+            subsystem="league_sync",
+            match_id=match_id,
+        )
         return None
 
     data = result["result"]
@@ -116,8 +125,9 @@ def process_match(match_id, league_id=None, match_seq_num=None):
 
     if created:
         log.info(
-            "New steam match stored",
-            domain="steam",
+            "match_stored",
+            system="steam",
+            subsystem="league_sync",
             match_id=match.match_id,
             league_id=league_id,
             radiant_win=match.radiant_win,
@@ -173,7 +183,12 @@ def sync_league_matches(league_id, full_sync=False):
     )
 
     if state.is_syncing:
-        log.warning("Sync already in progress", domain="steam", league_id=league_id)
+        log.warning(
+            "league_sync_already_running",
+            system="steam",
+            subsystem="league_sync",
+            league_id=league_id,
+        )
         return {
             "error": "Sync already in progress",
             "synced_count": 0,
@@ -204,8 +219,9 @@ def sync_league_matches(league_id, full_sync=False):
 
             if not result or "result" not in result:
                 log.error(
-                    "Failed to fetch match history",
-                    domain="steam",
+                    "match_history_fetch_failed",
+                    system="steam",
+                    subsystem="league_sync",
                     league_id=league_id,
                 )
                 break
@@ -256,8 +272,9 @@ def sync_league_matches(league_id, full_sync=False):
         state.save()
 
     log.info(
-        "League sync complete",
-        domain="steam",
+        "league_sync_complete",
+        system="steam",
+        subsystem="league_sync",
         league_id=league_id,
         synced_count=synced_count,
         failed_count=failed_count,
@@ -302,8 +319,9 @@ def retry_failed_matches(league_id):
     state.save()
 
     log.info(
-        "Retry failed matches complete",
-        domain="steam",
+        "league_retry_complete",
+        system="steam",
+        subsystem="league_sync",
         league_id=league_id,
         retried_count=retried_count,
         still_failed_count=len(still_failed),

--- a/backend/steam/functions/match_utils.py
+++ b/backend/steam/functions/match_utils.py
@@ -1,8 +1,5 @@
+from steam.models import Match
 from telemetry.logging import get_logger
-
-from django.db.models import Count, Q
-
-from steam.models import Match, PlayerMatchStats
 
 log = get_logger(__name__)
 

--- a/backend/steam/functions/match_utils.py
+++ b/backend/steam/functions/match_utils.py
@@ -1,10 +1,10 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.db.models import Count, Q
 
 from steam.models import Match, PlayerMatchStats
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def find_matches_by_players(steam_ids, require_all=True, league_id=None):

--- a/backend/steam/functions/mmr_calculation.py
+++ b/backend/steam/functions/mmr_calculation.py
@@ -1,9 +1,9 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.conf import settings
 from django.db.models import Avg, Max
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def get_league_avg_kda(league_id: int) -> float:

--- a/backend/steam/functions/mmr_calculation.py
+++ b/backend/steam/functions/mmr_calculation.py
@@ -1,7 +1,7 @@
-from telemetry.logging import get_logger
-
 from django.conf import settings
 from django.db.models import Avg, Max
+
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -125,8 +125,13 @@ def update_user_league_mmr(user, organization=None, league=None) -> None:
             league_user.mmr = calculated_league_mmr
             league_user.save(update_fields=["mmr"])
             logger.debug(
-                f"Updated {user.username} LeagueUser.mmr to {calculated_league_mmr} "
-                f"(base: {base_mmr}, adjustment: {best_adjustment})"
+                "league_mmr_updated",
+                system="steam",
+                subsystem="mmr",
+                username=user.username,
+                mmr=calculated_league_mmr,
+                base_mmr=base_mmr,
+                adjustment=best_adjustment,
             )
         except LeagueUser.DoesNotExist:
             # No LeagueUser entry, nothing to update
@@ -134,6 +139,11 @@ def update_user_league_mmr(user, organization=None, league=None) -> None:
     else:
         # No league context, nothing to update
         logger.debug(
-            f"No league context for {user.username}, skipping league MMR update "
-            f"(base: {base_mmr}, adjustment: {best_adjustment})"
+            "league_mmr_skipped",
+            system="steam",
+            subsystem="mmr",
+            username=user.username,
+            reason="no_league_context",
+            base_mmr=base_mmr,
+            adjustment=best_adjustment,
         )

--- a/backend/steam/functions/stats_update.py
+++ b/backend/steam/functions/stats_update.py
@@ -1,4 +1,4 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.db.models import Sum
 
@@ -8,7 +8,7 @@ from steam.functions.mmr_calculation import (
 )
 from steam.models import LeaguePlayerStats, PlayerMatchStats
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def update_player_league_stats(user, league_id: int) -> LeaguePlayerStats:

--- a/backend/steam/functions/stats_update.py
+++ b/backend/steam/functions/stats_update.py
@@ -1,5 +1,3 @@
-from telemetry.logging import get_logger
-
 from django.db.models import Sum
 
 from steam.functions.mmr_calculation import (
@@ -7,6 +5,7 @@ from steam.functions.mmr_calculation import (
     update_user_league_mmr,
 )
 from steam.models import LeaguePlayerStats, PlayerMatchStats
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -23,7 +22,13 @@ def update_player_league_stats(user, league_id: int) -> LeaguePlayerStats:
     ).select_related("match")
 
     if not match_stats.exists():
-        logger.debug(f"No match stats found for {user.username} in league {league_id}")
+        logger.debug(
+            "stats_not_found",
+            system="steam",
+            subsystem="stats",
+            username=user.username,
+            league_id=league_id,
+        )
         return None
 
     # Calculate aggregates
@@ -77,8 +82,15 @@ def update_player_league_stats(user, league_id: int) -> LeaguePlayerStats:
     update_user_league_mmr(user)
 
     logger.info(
-        f"Updated league stats for {user.username}: "
-        f"{games_played} games, {wins}W-{losses}L, adjustment={stats.mmr_adjustment}"
+        "league_stats_updated",
+        system="steam",
+        subsystem="stats",
+        username=user.username,
+        league_id=league_id,
+        games_played=games_played,
+        wins=wins,
+        losses=losses,
+        mmr_adjustment=stats.mmr_adjustment,
     )
 
     return stats
@@ -107,5 +119,11 @@ def update_all_league_stats_for_league(league_id: int) -> int:
         except CustomUser.DoesNotExist:
             continue
 
-    logger.info(f"Updated league stats for {updated_count} users in league {league_id}")
+    logger.info(
+        "league_stats_bulk_updated",
+        system="steam",
+        subsystem="stats",
+        league_id=league_id,
+        count=updated_count,
+    )
     return updated_count

--- a/backend/steam/models.py
+++ b/backend/steam/models.py
@@ -1,8 +1,8 @@
-from telemetry.logging import get_logger
-
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+
+from telemetry.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -180,11 +180,21 @@ def invalidate_game_cache_on_match_save(sender, instance, **kwargs):
             )
             invalidate_after_commit(*linked_games, *tournaments)
             logger.debug(
-                f"Scheduled cache invalidation for {len(linked_games)} games, "
-                f"{len(tournaments)} tournaments linked to Match {instance.match_id}"
+                "match_cache_invalidated",
+                system="steam",
+                subsystem="model",
+                match_id=instance.match_id,
+                game_count=len(linked_games),
+                tournament_count=len(tournaments),
             )
     except ImportError:
         # cacheops not installed or not configured
         pass
     except Exception as e:
-        logger.warning(f"Failed to invalidate cache for Match {instance.match_id}: {e}")
+        logger.warning(
+            "match_cache_invalidation_failed",
+            system="steam",
+            subsystem="model",
+            match_id=instance.match_id,
+            error=str(e),
+        )

--- a/backend/steam/models.py
+++ b/backend/steam/models.py
@@ -1,10 +1,10 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Match(models.Model):

--- a/backend/steam/steam/functions/api.py
+++ b/backend/steam/steam/functions/api.py
@@ -1,4 +1,4 @@
-import logging
+from telemetry.logging import get_logger
 
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -35,7 +35,7 @@ from steam.serializers import (
 )
 from steam.utils.steam_api_caller import SteamAPI
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 @api_view(["POST"])

--- a/backend/steam/steam/functions/api.py
+++ b/backend/steam/steam/functions/api.py
@@ -1,5 +1,3 @@
-from telemetry.logging import get_logger
-
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAdminUser
@@ -34,6 +32,7 @@ from steam.serializers import (
     SyncStatusSerializer,
 )
 from steam.utils.steam_api_caller import SteamAPI
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 

--- a/backend/steam/steam/functions/game_linking.py
+++ b/backend/steam/steam/functions/game_linking.py
@@ -1,11 +1,11 @@
-import logging
+from telemetry.logging import get_logger
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
 from app.models import Game, Tournament
 from steam.models import GameMatchSuggestion, Match
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def check_match_for_games(match):

--- a/backend/steam/steam/functions/game_linking.py
+++ b/backend/steam/steam/functions/game_linking.py
@@ -1,9 +1,9 @@
-from telemetry.logging import get_logger
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
 from app.models import Game, Tournament
 from steam.models import GameMatchSuggestion, Match
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -69,7 +69,13 @@ def check_match_for_games(match):
                     player_overlap=overlap,
                     auto_linked=True,
                 )
-                log.info(f"Auto-linked game {game.id} to match {match.match_id}")
+                log.info(
+                    "game_auto_linked",
+                    system="steam",
+                    subsystem="game_linking",
+                    game_id=game.id,
+                    match_id=match.match_id,
+                )
             else:
                 # Partial match - create suggestion for review
                 GameMatchSuggestion.objects.create(
@@ -234,7 +240,13 @@ def auto_link_matches_for_tournament(tournament_id):
                     auto_linked=True,
                 )
                 auto_linked_count += 1
-                log.info(f"Auto-linked game {game.id} to match {match.match_id}")
+                log.info(
+                    "game_auto_linked",
+                    system="steam",
+                    subsystem="game_linking",
+                    game_id=game.id,
+                    match_id=match.match_id,
+                )
                 break  # Game is now linked, move to next game
             else:
                 # Partial match - create suggestion

--- a/backend/steam/steam/functions/league_sync.py
+++ b/backend/steam/steam/functions/league_sync.py
@@ -1,11 +1,10 @@
-from telemetry.logging import get_logger
-
 from django.utils import timezone
 
 from app.models import CustomUser
 from steam.models import LeagueSyncState, Match, PlayerMatchStats
 from steam.utils.retry import retry_with_backoff
 from steam.utils.steam_api_caller import SteamAPI
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -27,7 +26,13 @@ def link_user_to_stats(player_stats):
         user = CustomUser.objects.get(steamid=player_stats.steam_id)
         player_stats.user = user
         player_stats.save(update_fields=["user"])
-        log.debug(f"Linked player {player_stats.steam_id} to user {user.username}")
+        log.debug(
+            "player_linked_to_user",
+            system="steam",
+            subsystem="league_sync",
+            steam_id=player_stats.steam_id,
+            username=user.username,
+        )
         return True
     except CustomUser.DoesNotExist:
         return False
@@ -47,7 +52,12 @@ def relink_all_users():
         if link_user_to_stats(stats):
             linked_count += 1
 
-    log.info(f"Relinked {linked_count} player stats to users")
+    log.info(
+        "player_stats_relinked",
+        system="steam",
+        subsystem="league_sync",
+        count=linked_count,
+    )
     return linked_count
 
 
@@ -91,7 +101,12 @@ def process_match(match_id, league_id=None, match_seq_num=None):
     success, result = retry_with_backoff(fetch, max_retries=3, base_delay=1.0)
 
     if not success or not result or "result" not in result:
-        log.warning(f"Failed to fetch match {match_id}")
+        log.warning(
+            "match_fetch_failed",
+            system="steam",
+            subsystem="league_sync",
+            match_id=match_id,
+        )
         return None
 
     data = result["result"]
@@ -155,7 +170,12 @@ def sync_league_matches(league_id, full_sync=False):
     )
 
     if state.is_syncing:
-        log.warning(f"Sync already in progress for league {league_id}")
+        log.warning(
+            "league_sync_already_running",
+            system="steam",
+            subsystem="league_sync",
+            league_id=league_id,
+        )
         return {
             "error": "Sync already in progress",
             "synced_count": 0,
@@ -181,7 +201,12 @@ def sync_league_matches(league_id, full_sync=False):
             )
 
             if not result or "result" not in result:
-                log.error(f"Failed to fetch match history for league {league_id}")
+                log.error(
+                    "match_history_fetch_failed",
+                    system="steam",
+                    subsystem="league_sync",
+                    league_id=league_id,
+                )
                 break
 
             matches = result["result"].get("matches", [])
@@ -228,7 +253,12 @@ def sync_league_matches(league_id, full_sync=False):
         state.save()
 
     log.info(
-        f"Sync complete for league {league_id}: {synced_count} synced, {failed_count} failed"
+        "league_sync_complete",
+        system="steam",
+        subsystem="league_sync",
+        league_id=league_id,
+        synced_count=synced_count,
+        failed_count=failed_count,
     )
 
     return {
@@ -269,7 +299,12 @@ def retry_failed_matches(league_id):
     state.save()
 
     log.info(
-        f"Retry complete for league {league_id}: {retried_count} succeeded, {len(still_failed)} still failed"
+        "league_retry_complete",
+        system="steam",
+        subsystem="league_sync",
+        league_id=league_id,
+        retried_count=retried_count,
+        still_failed_count=len(still_failed),
     )
 
     return {

--- a/backend/steam/steam/functions/league_sync.py
+++ b/backend/steam/steam/functions/league_sync.py
@@ -1,4 +1,4 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.utils import timezone
 
@@ -7,7 +7,7 @@ from steam.models import LeagueSyncState, Match, PlayerMatchStats
 from steam.utils.retry import retry_with_backoff
 from steam.utils.steam_api_caller import SteamAPI
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def link_user_to_stats(player_stats):

--- a/backend/steam/steam/functions/match_utils.py
+++ b/backend/steam/steam/functions/match_utils.py
@@ -1,8 +1,5 @@
+from steam.models import Match
 from telemetry.logging import get_logger
-
-from django.db.models import Count, Q
-
-from steam.models import Match, PlayerMatchStats
 
 log = get_logger(__name__)
 

--- a/backend/steam/steam/functions/match_utils.py
+++ b/backend/steam/steam/functions/match_utils.py
@@ -1,10 +1,10 @@
-import logging
+from telemetry.logging import get_logger
 
 from django.db.models import Count, Q
 
 from steam.models import Match, PlayerMatchStats
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def find_matches_by_players(steam_ids, require_all=True, league_id=None):

--- a/backend/steam/steam/utils/retry.py
+++ b/backend/steam/steam/utils/retry.py
@@ -1,5 +1,6 @@
-from telemetry.logging import get_logger
 import time
+
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -27,7 +28,12 @@ def retry_with_backoff(func, max_retries=3, base_delay=1.0):
             if attempt < max_retries - 1:
                 delay = base_delay * (2**attempt)
                 log.warning(
-                    f"Attempt {attempt + 1} failed: {e}. Retrying in {delay}s..."
+                    "retry_attempt_failed",
+                    system="steam",
+                    subsystem="retry",
+                    attempt=attempt + 1,
+                    delay=delay,
+                    error=str(e),
                 )
                 time.sleep(delay)
 

--- a/backend/steam/steam/utils/retry.py
+++ b/backend/steam/steam/utils/retry.py
@@ -1,7 +1,7 @@
-import logging
+from telemetry.logging import get_logger
 import time
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def retry_with_backoff(func, max_retries=3, base_delay=1.0):

--- a/backend/steam/utils/retry.py
+++ b/backend/steam/utils/retry.py
@@ -1,6 +1,7 @@
-from telemetry.logging import get_logger
 import time
 from functools import wraps
+
+from telemetry.logging import get_logger
 
 log = get_logger(__name__)
 
@@ -69,7 +70,12 @@ def retry_with_backoff(func, max_retries=3, base_delay=1.0):
             if attempt < max_retries - 1:
                 delay = base_delay * (2**attempt)
                 log.warning(
-                    f"Attempt {attempt + 1} failed: {e}. Retrying in {delay}s..."
+                    "retry_attempt_failed",
+                    system="steam",
+                    subsystem="retry",
+                    attempt=attempt + 1,
+                    delay=delay,
+                    error=str(e),
                 )
                 time.sleep(delay)
 

--- a/backend/steam/utils/retry.py
+++ b/backend/steam/utils/retry.py
@@ -1,8 +1,8 @@
-import logging
+from telemetry.logging import get_logger
 import time
 from functools import wraps
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Module-level state for throttling
 _last_request_time = 0.0

--- a/backend/telemetry/celery.py
+++ b/backend/telemetry/celery.py
@@ -1,7 +1,7 @@
 """Celery telemetry base task with context binding."""
 
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 from celery import Task
@@ -56,14 +56,20 @@ class TelemetryTask(Task):
         # Bind context
         structlog.contextvars.bind_contextvars(**context)
 
-        log.info("task_started")
+        log.info("task_started", system="celery", subsystem="task")
 
         try:
             result = self.run(*args, **kwargs)
-            log.info("task_completed")
+            log.info("task_completed", system="celery", subsystem="task")
             return result
         except Exception as e:
-            log.error("task_failed", error=str(e), exc_info=True)
+            log.error(
+                "task_failed",
+                system="celery",
+                subsystem="task",
+                error=str(e),
+                exc_info=True,
+            )
             raise
         finally:
             structlog.contextvars.clear_contextvars()

--- a/backend/telemetry/websocket.py
+++ b/backend/telemetry/websocket.py
@@ -75,7 +75,12 @@ class TelemetryConsumerMixin:
         structlog.contextvars.bind_contextvars(**context)
 
         # Log connection
-        log.info("ws_connected", client_ip=client_ip)
+        log.info(
+            "ws_connected",
+            system="websocket",
+            subsystem="connection",
+            client_ip=client_ip,
+        )
 
     async def telemetry_disconnect(self, close_code: int) -> None:
         """
@@ -86,7 +91,12 @@ class TelemetryConsumerMixin:
         Args:
             close_code: WebSocket close code
         """
-        log.info("ws_disconnected", close_code=close_code)
+        log.info(
+            "ws_disconnected",
+            system="websocket",
+            subsystem="connection",
+            close_code=close_code,
+        )
 
         # Clear context
         structlog.contextvars.clear_contextvars()
@@ -102,4 +112,9 @@ class TelemetryConsumerMixin:
         """
         # Log with truncated data to avoid huge log entries
         preview = text_data[:100] if text_data else None
-        log.debug("ws_receive", data_preview=preview)
+        log.debug(
+            "ws_receive",
+            system="websocket",
+            subsystem="connection",
+            data_preview=preview,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,33 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 
-[tool.isort]
-profile = "black"
-src_paths = ["backend", "."]
-line_length = 88
-multi_line_output = 3
-include_trailing_comma = true
+[tool.ruff]
+# Ruff replaces black (ruff format) AND isort (the `I` lint rules).
+target-version = "py312"
+line-length = 88
+src = ["backend", "."]
+extend-exclude = ["**/migrations/**"]
+
+[tool.ruff.lint]
+# E,F = pycodestyle/pyflakes  •  I = isort (import order)
+# ANN = flake8-annotations (push type coverage forward over time)
+# TID = flake8-tidy-imports (banned-api below)
+select = ["E", "F", "I", "ANN", "TID"]
+# E501 (line length) is owned by the formatter; ANN401 allows `Any` for
+# framework-injected callback params.
+ignore = ["E501", "ANN401"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"logging.getLogger".msg = "Use `from telemetry.logging import get_logger` (structlog -> OTEL). See .claude/skills/logging."
+
+[tool.ruff.lint.per-file-ignores]
+# Legit stdlib-logging users / not part of the OTEL-exported request·task flow.
+"**/telemetry/logging.py" = ["TID251"]
+"**/telemetry/config.py" = ["TID251"]
+"**/telemetry/tracing.py" = ["TID251"]
+"**/telemetry/db.py" = ["TID251"]
+"**/settings.py" = ["TID251"]
+"**/management/commands/*.py" = ["TID251"]
+# Tests use stdlib logging freely and are not annotation-gated.
+"**/tests/**" = ["ANN", "TID251"]
+"**/test_*.py" = ["ANN", "TID251"]


### PR DESCRIPTION
## Summary

Adds a path-scoped GitHub Copilot review rule for backend logging, migrates the
remaining base-stdlib-logging modules to the structlog/OTEL convention, and
adopts ruff to enforce both deterministically.

**Copilot review**
- New `.github/instructions/logging.instructions.md` (`applyTo: backend/**/*.py`,
  with a management-command carve-out) summarising the logging skill; registered
  in the `.github/copilot-instructions.md` skill table.

**Logging migration** (event-name-first + `system`/`subsystem`, no f-strings)
- `app/auth.py` → `auth/internal` (internal-service auth reject/fail)
- `app/broadcast.py` → `websocket/broadcast` (draft + herodraft event/state; `kind` field)
- `app/pipelines.py` → `auth/social` (Discord OAuth reclaim/match); drops the full
  `social_auth.extra_data` dump (PII)
- Touched functions type-annotated. Management commands intentionally keep stdlib logging.
- `.claude/skills/logging/SKILL.md` taxonomy table updated with the 3 new pairs.

**Tooling — ruff replaces black + isort**
- `ruff-format` (formatting) + `ruff` lint (`E,F,I,ANN,TID`); pre-commit runs format before check.
- `TID` banned-api forbids `logging.getLogger` (waived for telemetry/, settings.py, tests, management commands).
- `ANN` enforces annotation presence, surfacing gradually on touched files.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all migrated files
- [x] TID logging ban verified firing on violators, waived for carve-outs
- [x] Full backend suite: **424 tests, OK** (`just test::run 'python manage.py test app.tests'`)
- [x] Django system check clean; structlog events confirmed emitting with trace correlation