### PR TITLE
feat(discord): discriminated modal_config contract (#268, PR2/3)

### DIFF
--- a/backend/discordbot/components.py
+++ b/backend/discordbot/components.py
@@ -163,27 +163,14 @@ class SignupButton(ui.Button):
                     content=f"\u2705 You're signed up! Status: **{result['status']}**",
                 )
             elif result["action"] == "needs_modal":
+                # modal_config is the typed per-game config dict (same keys as
+                # the old flat fields, plus `kind`). Downstream
+                # self.event_config.get("...") reads are unchanged.
                 modal = EventSignupModal(
                     event_id=self.event_id,
                     game_type=result["game_type"],
                     prefill=result.get("prefill", {}),
-                    event_config={
-                        "require_steam_id": result.get("require_steam_id", True),
-                        "require_rank_screenshot": result.get(
-                            "require_rank_screenshot", False
-                        ),
-                        "require_battlecup_screenshot": result.get(
-                            "require_battlecup_screenshot", False
-                        ),
-                        "min_mmr": result.get("min_mmr"),
-                        "allow_active_mmr": result.get("allow_active_mmr", True),
-                        "allow_previous_rank": result.get(
-                            "allow_previous_rank", True
-                        ),
-                        "allow_battlecup_rating": result.get(
-                            "allow_battlecup_rating", True
-                        ),
-                    },
+                    event_config=result.get("modal_config", {}) or {},
                 )
                 await send_modal_v2(interaction, modal)
             elif result["action"] == "error":
@@ -440,16 +427,15 @@ class EventSignupModal(ui.Modal):
             ctx.set_outcome(result["action"])
 
             if result["action"] == "needs_rank_details":
+                from events.schemas import DotaModalConfig, dota_require_screenshot
+
                 rank_status = values.get("rank_status", "never")
-                require_screenshot = (
-                    self.event_config.get("require_rank_screenshot", False)
-                    if rank_status == "active"
-                    else (
-                        self.event_config.get("require_battlecup_screenshot", False)
-                        if rank_status == "never"
-                        else False
-                    )
-                )
+                cfg = DotaModalConfig(**{
+                    k: v
+                    for k, v in self.event_config.items()
+                    if k in DotaModalConfig.model_fields
+                })
+                require_screenshot = dota_require_screenshot(rank_status, cfg)
                 view = PositionSelectView(
                     self.event_id,
                     rank_status,

--- a/backend/events/discord/handlers.py
+++ b/backend/events/discord/handlers.py
@@ -13,7 +13,13 @@ from discordbot.models import DiscordEventLog
 from django.core.exceptions import ValidationError as DjangoValidationError
 from events.constants import EventState, SignupStatus
 from events.models import Event, EventSignup
-from events.schemas import SignupInputPatch
+from events.schemas import (
+    DeadlockModalConfig,
+    DotaModalConfig,
+    SignupInputPatch,
+    SignupModalConfig,
+    dota_require_screenshot,
+)
 from org.models_profiles import PlayerDotaProfile
 from telemetry.logging import get_logger
 
@@ -251,8 +257,23 @@ def handle_signup_button(event_id, discord_user_id, discord_username=None):
             )
             return {"action": "error", "message": str(e)}
 
+    if event.game_type == GameType.DOTA2:
+        modal_config = DotaModalConfig(
+            require_steam_id=event.require_steam_id,
+            require_rank_screenshot=event.discord_require_rank_screenshot,
+            require_battlecup_screenshot=event.discord_require_battlecup_screenshot,
+            min_mmr=event.min_mmr,
+            allow_active_mmr=event.allow_active_mmr,
+            allow_previous_rank=event.allow_previous_rank,
+            allow_battlecup_rating=event.allow_battlecup_rating,
+        )
+    elif event.game_type == GameType.DEADLOCK:
+        modal_config = DeadlockModalConfig(require_steam_id=event.require_steam_id)
+    else:
+        modal_config = SignupModalConfig(require_steam_id=event.require_steam_id)
+
     _log_interaction(event_id, "signup_modal_opened", discord_user_id, discord_username)
-    # Needs modal — return prefill data + event config flags
+    # Needs modal — return prefill data + typed per-game modal_config
     return {
         "action": "needs_modal",
         "game_type": event.game_type,
@@ -265,13 +286,7 @@ def handle_signup_button(event_id, discord_user_id, discord_username=None):
             )
             or "",
         },
-        "require_steam_id": event.require_steam_id,
-        "require_rank_screenshot": event.discord_require_rank_screenshot,
-        "require_battlecup_screenshot": event.discord_require_battlecup_screenshot,
-        "min_mmr": event.min_mmr,
-        "allow_active_mmr": event.allow_active_mmr,
-        "allow_previous_rank": event.allow_previous_rank,
-        "allow_battlecup_rating": event.allow_battlecup_rating,
+        "modal_config": modal_config.model_dump(),
     }
 
 
@@ -433,7 +448,6 @@ def handle_rank_medal_select(event_id, discord_user_id, medal):
         return {
             "action": "needs_screenshot",
             "screenshot_type": "rank",
-            "medal": medal,
         }
 
     try:
@@ -490,7 +504,6 @@ def handle_previous_rank_submit(event_id, discord_user_id, medal, date_text):
         return {
             "action": "needs_screenshot",
             "screenshot_type": "rank",
-            "medal": medal,
         }
 
     try:
@@ -545,7 +558,6 @@ def handle_battle_cup_submit(event_id, discord_user_id, tier):
         return {
             "action": "needs_screenshot",
             "screenshot_type": "battlecup",
-            "tier": tier,
         }
 
     try:
@@ -796,14 +808,12 @@ def handle_get_rank_flow_state(
 
     profile, _ = PlayerDotaProfile.objects.get_or_create(org_user=org_user)
     rank_status = profile.rank_status or "never"
-    require_screenshot = (
-        bool(event.discord_require_rank_screenshot)
-        if rank_status == "active"
-        else (
-            bool(event.discord_require_battlecup_screenshot)
-            if rank_status == "never"
-            else False
-        )
+    require_screenshot = dota_require_screenshot(
+        rank_status,
+        DotaModalConfig(
+            require_rank_screenshot=event.discord_require_rank_screenshot,
+            require_battlecup_screenshot=event.discord_require_battlecup_screenshot,
+        ),
     )
     return {
         "rank_status": rank_status,

--- a/backend/events/schemas.py
+++ b/backend/events/schemas.py
@@ -25,7 +25,7 @@ transport package. Request bodies for the same endpoints live in
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -263,6 +263,50 @@ class SignupInputPatch(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class SignupModalConfig(BaseModel):
+    """Base / default game config carried in the needs_modal response."""
+
+    kind: Literal["default"] = "default"
+    require_steam_id: bool = True
+
+
+class DotaModalConfig(SignupModalConfig):
+    kind: Literal["dota"] = "dota"
+    require_rank_screenshot: bool = False
+    require_battlecup_screenshot: bool = False
+    min_mmr: int | None = None
+    allow_active_mmr: bool = True
+    allow_previous_rank: bool = True
+    allow_battlecup_rating: bool = True
+
+
+class DeadlockModalConfig(SignupModalConfig):
+    kind: Literal["deadlock"] = "deadlock"
+
+
+# Discriminated union — REQUIRED so model_validate(dict) -> model_dump() keeps
+# subclass fields. A plain `SignupModalConfig` annotation serializes by the
+# base type and silently drops the Dota fields on the wire path.
+ModalConfig = Annotated[
+    DotaModalConfig | DeadlockModalConfig | SignupModalConfig,
+    Field(discriminator="kind"),
+]
+
+
+def dota_require_screenshot(rank_status: str, cfg: "DotaModalConfig") -> bool:
+    """Single home for the screenshot-required rule.
+
+    Was duplicated as a ternary in components.py (modal follow-up) and in
+    handle_get_rank_flow_state. Pure over the transported config so both
+    processes call it.
+    """
+    if rank_status == "active":
+        return cfg.require_rank_screenshot
+    if rank_status == "never":
+        return cfg.require_battlecup_screenshot
+    return False
+
+
 class SignupActionResponse(BaseModel):
     """All bot-facing handler return dicts share this shape.
 
@@ -282,18 +326,10 @@ class SignupActionResponse(BaseModel):
     # signup_modal_submit / signup_button: needs_modal payload
     game_type: int | None = None
     prefill: dict | None = None
-    require_steam_id: bool | None = None
-    require_rank_screenshot: bool | None = None
-    require_battlecup_screenshot: bool | None = None
-    min_mmr: int | None = None
-    allow_active_mmr: bool | None = None
-    allow_previous_rank: bool | None = None
-    allow_battlecup_rating: bool | None = None
+    modal_config: "ModalConfig | None" = None  # discriminated (was 8 flat flags)
 
     # rank_medal_select / battle_cup_submit: needs_screenshot payload
-    screenshot_type: str | None = None
-    medal: str | None = None
-    tier: str | None = None
+    screenshot_type: str | None = None  # stays FLAT (views bracket-index it)
 
     # notify_button
     subscribed: bool | None = None
@@ -305,7 +341,7 @@ class SignupActionResponse(BaseModel):
     # save_positions
     positions: list[int] | None = None
 
-    model_config = {"extra": "ignore"}
+    model_config = {"extra": "forbid"}
 
 
 class RankFlowStateResponse(BaseModel):

--- a/backend/events/tests/test_modal_config_contract.py
+++ b/backend/events/tests/test_modal_config_contract.py
@@ -1,0 +1,80 @@
+"""Contract tests for the #268 PR2 discriminated `modal_config` envelope.
+
+Written as SimpleTestCase (no DB) so they run under the canonical
+`manage.py test` runner that CI uses — the def-style pytest tests in
+test_signup_schema.py are not collected by manage.py test.
+"""
+
+from django.test import SimpleTestCase
+
+from events.schemas import (
+    DeadlockModalConfig,
+    DotaModalConfig,
+    SignupActionResponse,
+    SignupModalConfig,
+    dota_require_screenshot,
+)
+
+
+class ModalConfigKindTest(SimpleTestCase):
+    def test_dota_kind_and_fields(self):
+        cfg = DotaModalConfig(min_mmr=3000, allow_active_mmr=False)
+        self.assertEqual(cfg.kind, "dota")
+        self.assertEqual(cfg.min_mmr, 3000)
+        self.assertFalse(cfg.allow_active_mmr)
+
+    def test_deadlock_kind(self):
+        self.assertEqual(DeadlockModalConfig().kind, "deadlock")
+
+    def test_base_kind_default(self):
+        self.assertEqual(SignupModalConfig().kind, "default")
+
+
+class DotaRequireScreenshotTest(SimpleTestCase):
+    def test_truth_table(self):
+        on = DotaModalConfig(require_rank_screenshot=True, require_battlecup_screenshot=True)
+        self.assertTrue(dota_require_screenshot("active", on))
+        self.assertTrue(dota_require_screenshot("never", on))
+        self.assertFalse(dota_require_screenshot("previous", on))
+
+        off = DotaModalConfig(require_rank_screenshot=False, require_battlecup_screenshot=False)
+        self.assertFalse(dota_require_screenshot("active", off))
+        self.assertFalse(dota_require_screenshot("never", off))
+
+
+class SignupActionResponseContractTest(SimpleTestCase):
+    def test_modal_config_survives_validate_then_dump(self):
+        """Wire path is model_validate(dict).model_dump() in signup_actions.py.
+
+        A plain base annotation would serialize-as-base and drop the Dota
+        fields; the kind-discriminated union keeps them.
+        """
+        resp = SignupActionResponse(
+            action="needs_modal",
+            game_type=1,
+            modal_config=DotaModalConfig(min_mmr=2500, require_rank_screenshot=True),
+        )
+        rt = SignupActionResponse.model_validate(resp.model_dump()).model_dump()
+        self.assertEqual(rt["modal_config"]["kind"], "dota")
+        self.assertEqual(rt["modal_config"]["min_mmr"], 2500)
+        self.assertTrue(rt["modal_config"]["require_rank_screenshot"])
+
+    def test_deadlock_config_round_trips_as_deadlock(self):
+        resp = SignupActionResponse(
+            action="needs_modal", game_type=2, modal_config=DeadlockModalConfig()
+        )
+        rt = SignupActionResponse.model_validate(resp.model_dump())
+        self.assertIsInstance(rt.modal_config, DeadlockModalConfig)
+
+    def test_forbids_legacy_flat_keys(self):
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            SignupActionResponse.model_validate(
+                {"action": "needs_modal", "game_type": 1, "min_mmr": 3000}
+            )
+
+    def test_screenshot_type_stays_flat(self):
+        resp = SignupActionResponse(action="needs_screenshot", screenshot_type="rank")
+        rt = SignupActionResponse.model_validate(resp.model_dump())
+        self.assertEqual(rt.screenshot_type, "rank")

--- a/backend/events/tests/test_signup_interactions.py
+++ b/backend/events/tests/test_signup_interactions.py
@@ -87,9 +87,11 @@ class HandleSignupButtonTest(EventTestCase):
             discord_user_id="100000000000000001",
         )
         self.assertEqual(result["action"], "needs_modal")
-        self.assertTrue(result["require_rank_screenshot"])
-        self.assertFalse(result["require_battlecup_screenshot"])
-        self.assertEqual(result["min_mmr"], 3000)
+        cfg = result["modal_config"]
+        self.assertEqual(cfg["kind"], "dota")
+        self.assertTrue(cfg["require_rank_screenshot"])
+        self.assertFalse(cfg["require_battlecup_screenshot"])
+        self.assertEqual(cfg["min_mmr"], 3000)
 
 
 class HandleSignupModalSubmitTest(EventTestCase):

--- a/docs/superpowers/plans/2026-06-01-discord-providers-pr1-signup-responses-missing.md
+++ b/docs/superpowers/plans/2026-06-01-discord-providers-pr1-signup-responses-missing.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stop `respond_to_signup_user` from raising `TypeError` when a user with DMs disabled signs up and no `view`/`embed` was passed.
 
-**Architecture:** discord.py's `Webhook.send` (the `interaction.followup.send` fallback path) rejects a literal `None` for `view`/`embed` (`None` is not `MISSING` and has no `__discord_ui_view__`). The DM path (`Messageable.send`) tolerates `None`. Fix: pass `discord.utils.MISSING` instead of `None` on both sends.
+**Architecture:** discord.py's `Webhook.send` (the `interaction.followup.send` fallback path) rejects a literal `None` for `view`/`embed` (`None` is not `MISSING` and has no `__discord_ui_view__`). The DM path (`Messageable.send`) tolerates `None`. Fix: pass `discord.utils.MISSING` instead of `None` on the `followup.send` path **only** (the DM send stays unchanged — it tolerates `None` and an existing test asserts it).
 
 **Tech Stack:** Python, discord.py, Django `SimpleTestCase`, run via `just test::run`.
 
@@ -64,15 +64,14 @@ In `backend/discordbot/signup_responses.py`, add the import near the top (with t
 from discord.utils import MISSING
 ```
 
-Then in `respond_to_signup_user`, replace the two send calls. The DM send (currently `await dm_channel.send(content=content, embed=embed, view=view)`) and the fallback send become:
+Then in `respond_to_signup_user`, change ONLY the `followup.send` fallback (the
+crash site). Leave the DM `dm_channel.send` unchanged — `Messageable.send`
+tolerates `None`, and an existing test asserts the DM send receives `view=None`:
 
 ```python
-    send_embed = embed if embed is not None else MISSING
-    send_view = view if view is not None else MISSING
-
     try:
         dm_channel = await interaction.user.create_dm()
-        await dm_channel.send(content=content, embed=send_embed, view=send_view)
+        await dm_channel.send(content=content, embed=embed, view=view)  # unchanged
         try:
             await interaction.delete_original_response()
             log.info(
@@ -91,8 +90,12 @@ Then in `respond_to_signup_user`, replace the two send calls. The DM send (curre
         if getattr(e, "code", None) == 50007:
             mention = f"<@{user_id}>"
             text = f"{mention} {content}".strip() if content else mention
+            # Webhook.send rejects a literal None view/embed — pass MISSING.
             await interaction.followup.send(
-                content=text, embed=send_embed, view=send_view, ephemeral=True
+                content=text,
+                embed=embed if embed is not None else MISSING,
+                view=view if view is not None else MISSING,
+                ephemeral=True,
             )
             channel = ResponseChannel.EPHEMERAL
         else:
@@ -135,5 +138,5 @@ git commit -m "fix(discord): MISSING sentinel for view/embed in DM-disabled sign
 ## Self-Review
 - **Spec coverage:** Implements "Bugs fixed in-flight → bug 1" and its test bullet. ✓
 - **Placeholders:** none — full test + full replacement block.
-- **Type consistency:** `send_embed`/`send_view` used in both sends; `MISSING` imported.
+- **Type consistency:** `MISSING` imported; sentinel applied inline on the `followup.send` call only.
 - **Scope:** single file + its test; independent of the refactor; safe to ship first.

--- a/docs/superpowers/plans/2026-06-01-discord-providers-pr2-pydantic-contract.md
+++ b/docs/superpowers/plans/2026-06-01-discord-providers-pr2-pydantic-contract.md
@@ -12,6 +12,8 @@
 
 **Deploy note:** `extra:"forbid"` turns a backend↔bot version skew into a crash. This PR's two containers MUST deploy from the same release tag (the existing release model). See spec "Deploy-skew note".
 
+**Test-runner correction (learned during implementation):** the `python -m pytest events/tests/...` commands below DO NOT WORK here — CI runs only `python manage.py test` (Django unittest runner, TestCase only), and bare pytest fails collecting `events/tests/` (`ModuleNotFoundError: app.schemas`, a `/app/backend/__init__.py` rootdir quirk). Write contract tests as a `SimpleTestCase` in `backend/events/tests/test_modal_config_contract.py` and run via `just test::run 'python manage.py test events.tests.test_modal_config_contract -v 2'`. The def-style `test_signup_schema.py` tests are orphaned (not collected by CI) — leave them; don't append to them.
+
 ---
 
 ### Task 1: Add the config models + union + `dota_require_screenshot` to `events/schemas.py`

--- a/docs/superpowers/specs/2026-05-31-discord-game-type-providers-design.md
+++ b/docs/superpowers/specs/2026-05-31-discord-game-type-providers-design.md
@@ -610,9 +610,10 @@ fallback passes `view=view`/`embed=embed` (often `None`) to
 `TypeError: expected view parameter to be of type View not NoneType` — `None`
 is not `MISSING` and lacks `__discord_ui_view__`. The DM path (`Messageable.send`)
 tolerates `None`, so only the fallback crashes. **Fix:** use the
-`discord.utils.MISSING` sentinel (`send_view = view if view is not None else
-MISSING`, same for embed) on the `followup.send` call (and defensively on
-`dm_channel.send`). `signup_responses.py` is not split by the refactor, so this
+`discord.utils.MISSING` sentinel (`view if view is not None else MISSING`, same
+for embed) on the `followup.send` call **only** — the DM `Messageable.send` path
+tolerates `None` (an existing test asserts the DM send receives `view=None`), so
+it stays unchanged. `signup_responses.py` is not split by the refactor, so this
 is a small self-contained edit on the branch; `base.py`'s RSVP confirmation path
 depends on it.
 


### PR DESCRIPTION
## Summary
PR2 of the 3-PR Discord game-type provider stack. **Stacked on PR #270** — review/merge that first.

Replaces the eight flat Dota config flags (and write-only `medal`/`tier`) on `SignupActionResponse` with a single `kind`-discriminated `modal_config` sub-model, tightens the envelope to `extra:"forbid"`, and centralizes the screenshot-required rule. Behavior-preserving (same modal fields, same screenshot logic) — only the internal Django↔bot wire shape changes.

## Why a discriminated union
With a plain `SignupModalConfig` base annotation, Pydantic v2 serializes by the declared type and **drops the Dota subclass fields** on the `model_validate→model_dump` wire path (verified). A `kind` discriminator (`DotaModalConfig | DeadlockModalConfig | SignupModalConfig`) round-trips intact.

## Changes
- `events/schemas.py`: config models + `ModalConfig` union + `dota_require_screenshot()`; envelope reshaped (`modal_config` nested, `medal`/`tier` dropped, `extra:forbid`).
- `handlers.py` producers: `handle_signup_button` builds per-game config; 3 `needs_screenshot` producers drop `medal`/`tier`; `handle_get_rank_flow_state` uses the shared rule.
- `components.py` consumer: reads `result['modal_config']`; follow-up ternary uses `dota_require_screenshot`.

## Tests
- New `test_modal_config_contract.py` (SimpleTestCase): kind discriminators, round-trip survival, `extra:forbid` rejection, flat `screenshot_type`, deadlock round-trip — 8/8.
- 55 affected backend tests pass (interactions, components, signup_logging, events_discord).

## Deploy note
`extra:"forbid"` makes a backend↔bot version skew a hard error, not a degrade — both containers must deploy from the same release tag (existing release model already does this).

## Stack
PR1 #270 → **this** → PR3 (structural provider/registry refactor, no further wire change).