### PR TITLE
perf(users): per-user core cache (Scope A) — fast, independently-cached user serialization

### DIFF
--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -167,13 +167,95 @@ def _collect_tournament_user_pks(tournament):
     return seen_pks
 
 
-def _build_users_dict(tournament):
-    """Build a deduplicated {pk: serialized_user} dict for a tournament."""
-    seen_pks = _collect_tournament_user_pks(tournament)
-    user_qs = CustomUser.objects.filter(pk__in=seen_pks).select_related(
-        "positions", "base_profile"
+# Org-context-only keys that OrgUserSerializer adds on top of the cached core.
+# discordNickname is core-only (TournamentUserSerializer); guildNickname is
+# org-only — so the org shape replaces the former with the latter.
+_CONTEXT_MMR_KEYS = ("orgUserPk", "guildNickname", "mmr", "league_mmr")
+
+
+def _collect_context_mmr(tournament, seen_pks) -> dict:
+    """Per-request contextual org/league overlay keyed by user pk.
+
+    Returns ``{pk: {orgUserPk, guildNickname, mmr, league_mmr}}`` for a
+    tournament whose league has an organization, else an empty dict (non-org
+    tournaments carry no MMR). Reuses OrgUserSerializer so the values and the
+    league_mmr computation are identical to the legacy path.
+    """
+    from django.db.models import Prefetch
+
+    from league.models import LeagueUser
+    from org.models import OrgUser
+    from org.serializers import OrgUserSerializer
+
+    league = tournament.league if tournament else None
+    org = league.organization if league else None
+    if not org:
+        return {}
+
+    user_qs = CustomUser.objects.filter(pk__in=seen_pks)
+
+    # Auto-create OrgUser records for tournament users missing from the org
+    # (preserves the side-effect of the legacy _serialize_users_with_mmr path).
+    existing_user_pks = set(
+        OrgUser.objects.filter(user__in=user_qs, organization=org).values_list(
+            "user_id", flat=True
+        )
     )
-    return {u["pk"]: u for u in _serialize_users_with_mmr(user_qs, tournament)}
+    missing_users = user_qs.exclude(pk__in=existing_user_pks)
+    if missing_users.exists():
+        OrgUser.objects.bulk_create(
+            [OrgUser(user=u, organization=org) for u in missing_users],
+            ignore_conflicts=True,
+        )
+
+    org_users = (
+        OrgUser.objects.filter(user__in=user_qs, organization=org)
+        .select_related("user", "user__positions", "user__base_profile")
+        .prefetch_related(
+            Prefetch(
+                "league_memberships",
+                queryset=LeagueUser.objects.filter(league_id=league.pk),
+            )
+        )
+    )
+    serialized = OrgUserSerializer(
+        org_users, many=True, context={"league_id": league.pk}
+    ).data
+    return {
+        row["pk"]: {k: row[k] for k in _CONTEXT_MMR_KEYS} for row in serialized
+    }
+
+
+def _build_users_dict(tournament) -> dict:
+    """Build a deduplicated ``{pk: serialized_user}`` dict for a tournament.
+
+    Shape-preserving: the CORE half is sourced from the per-user cache
+    (``serialize_user_core``) and the contextual MMR half is merged per-request.
+    Output JSON is byte-identical to the legacy _serialize_users_with_mmr path —
+    org entries carry core + MMR (orgUserPk/mmr/league_mmr/guildNickname, no
+    discordNickname); non-org entries carry core only.
+    """
+    from app.user_cache import serialize_user_core
+
+    seen_pks = _collect_tournament_user_pks(tournament)
+    mmr_map = _collect_context_mmr(tournament, seen_pks)
+    league = tournament.league if tournament else None
+    is_org = bool(league and league.organization_id)
+
+    result: dict = {}
+    for pk in seen_pks:
+        core = serialize_user_core(pk)
+        if not core:
+            continue
+        if is_org:
+            # Match OrgUserSerializer's shape exactly: it omits discordNickname
+            # and adds guildNickname + the MMR fields from the overlay.
+            entry = {k: v for k, v in core.items() if k != "discordNickname"}
+            entry.update(mmr_map.get(pk, {}))
+        else:
+            entry = dict(core)
+        result[pk] = entry
+    return result
 
 
 class TournamentSerializerBase(serializers.ModelSerializer):

--- a/backend/app/tests/test_build_users_dict.py
+++ b/backend/app/tests/test_build_users_dict.py
@@ -1,0 +1,126 @@
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from app.models import CustomUser, League, Organization, Tournament
+from app.serializers import _build_users_dict, _serialize_users_with_mmr
+
+# Hardcoded pre-change ground-truth key sets (from reading OrgUserSerializer /
+# TournamentUserSerializer). The shape-parity assertions below ALSO diff against
+# the untouched _serialize_users_with_mmr at runtime, so any drift fails loudly.
+ORG_ENTRY_KEYS = {
+    "orgUserPk",
+    "pk",
+    "username",
+    "nickname",
+    "guildNickname",
+    "avatar",
+    "discordId",
+    "positions",
+    "steam_account_id",
+    "avatarUrl",
+    "mmr",
+    "league_mmr",
+}
+NONORG_ENTRY_KEYS = {
+    "pk",
+    "username",
+    "nickname",
+    "avatar",
+    "discordId",
+    "discordNickname",
+    "positions",
+    "steam_account_id",
+    "avatarUrl",
+}
+
+
+class BuildUsersDictOrgTests(TransactionTestCase):
+    def setUp(self) -> None:
+        self.owner = CustomUser.objects.create_user(username="owner", password="x")
+        self.org = Organization.objects.create(name="Org", owner=self.owner)
+        self.league = League.objects.create(
+            name="Lg", organization=self.org, steam_league_id=12345
+        )
+        self.tournament = Tournament.objects.create(
+            name="T",
+            league=self.league,
+            tournament_type="double_elimination",
+            date_played=timezone.now(),
+        )
+        self.member = CustomUser.objects.create(username="member", nickname="Member")
+        self.tournament.users.add(self.member)
+
+        from league.models import LeagueUser
+        from org.models import OrgUser
+
+        # Adding the member to an org tournament auto-creates the OrgUser via
+        # signal; update its MMR rather than create a duplicate.
+        ou, _ = OrgUser.objects.update_or_create(
+            user=self.member, organization=self.org, defaults={"mmr": 4200}
+        )
+        LeagueUser.objects.update_or_create(
+            user=self.member,
+            org_user=ou,
+            league=self.league,
+            defaults={"mmr": 3100},
+        )
+
+    def test_org_entry_has_core_and_mmr(self) -> None:
+        entry = _build_users_dict(self.tournament)[self.member.pk]
+        # core half (cached per-user)
+        assert entry["nickname"] == "Member"
+        assert "positions" in entry
+        # contextual MMR half (merged per-request)
+        assert entry["mmr"] == 4200
+        assert entry["league_mmr"] == 3100
+        assert "orgUserPk" in entry
+
+    def test_org_shape_parity(self) -> None:
+        entry = _build_users_dict(self.tournament)[self.member.pk]
+        ref = _serialize_users_with_mmr(
+            CustomUser.objects.filter(pk=self.member.pk), self.tournament
+        )[0]
+        # key-set parity vs the untouched serializer AND the hardcoded baseline
+        assert set(entry.keys()) == set(ref.keys())
+        assert set(entry.keys()) == ORG_ENTRY_KEYS
+        # value parity on every shared key (byte-identical data)
+        for k in ref:
+            assert entry[k] == ref[k], (k, entry[k], ref[k])
+
+    def test_nickname_edit_reflected(self) -> None:
+        _build_users_dict(self.tournament)  # warm core cache
+        self.member.nickname = "Renamed"
+        entry = _build_users_dict(self.tournament)[self.member.pk]
+        assert entry["nickname"] == "Renamed"
+
+    def test_mmr_change_reflected(self) -> None:
+        _build_users_dict(self.tournament)  # warm
+        from org.models import OrgUser
+
+        ou = OrgUser.objects.get(user=self.member, organization=self.org)
+        ou.mmr = 5555
+        ou.save()
+        entry = _build_users_dict(self.tournament)[self.member.pk]
+        assert entry["mmr"] == 5555
+
+
+class BuildUsersDictNonOrgTests(TransactionTestCase):
+    def setUp(self) -> None:
+        self.tournament = Tournament.objects.create(
+            name="NoOrg",
+            tournament_type="double_elimination",
+            date_played=timezone.now(),
+        )
+        self.member = CustomUser.objects.create(username="solo", nickname="Solo")
+        self.tournament.users.add(self.member)
+
+    def test_nonorg_no_mmr_shape_parity(self) -> None:
+        entry = _build_users_dict(self.tournament)[self.member.pk]
+        assert "mmr" not in entry and "league_mmr" not in entry
+        ref = _serialize_users_with_mmr(
+            CustomUser.objects.filter(pk=self.member.pk), self.tournament
+        )[0]
+        assert set(entry.keys()) == set(ref.keys())
+        assert set(entry.keys()) == NONORG_ENTRY_KEYS
+        for k in ref:
+            assert entry[k] == ref[k], (k, entry[k], ref[k])

--- a/backend/app/tests/test_user_core_cache.py
+++ b/backend/app/tests/test_user_core_cache.py
@@ -25,3 +25,20 @@ class SerializeUserCoreTests(TransactionTestCase):
         u.positions.carry = 5
         u.positions.save()  # PositionsModel.save() → invalidate_obj(user)
         assert serialize_user_core(u.pk)["positions"]["carry"] == 5
+
+
+class BulkUsersCacheTests(TransactionTestCase):
+    def setUp(self):
+        from rest_framework.test import APIClient
+
+        self.client = APIClient()
+        self.requester = CustomUser.objects.create(username="bulk_requester")
+        self.client.force_authenticate(user=self.requester)
+
+    def test_bulk_users_returns_core_and_reflects_edit(self):
+        u = CustomUser.objects.create(username="b1", nickname="B1")
+        r = self.client.post("/api/users/bulk/", {"pks": [u.pk]}, format="json")
+        assert r.status_code == 200 and r.json()[0]["nickname"] == "B1"
+        u.nickname = "B1x"
+        r2 = self.client.post("/api/users/bulk/", {"pks": [u.pk]}, format="json")
+        assert r2.json()[0]["nickname"] == "B1x"

--- a/backend/app/tests/test_user_core_cache.py
+++ b/backend/app/tests/test_user_core_cache.py
@@ -1,0 +1,27 @@
+from django.test import TransactionTestCase  # on_commit invalidation
+
+from app.models import CustomUser
+from app.user_cache import serialize_user_core
+
+
+class SerializeUserCoreTests(TransactionTestCase):
+    def test_core_fields_no_mmr(self):
+        u = CustomUser.objects.create(username="core", nickname="Core")
+        d = serialize_user_core(u.pk)
+        assert d["pk"] == u.pk and d["nickname"] == "Core"
+        assert "positions" in d
+        assert "mmr" not in d and "league_mmr" not in d
+
+    def test_invalidates_on_nickname_edit(self):
+        # nickname writes through to base_profile (bp.save), NOT user.save —
+        # the cache MUST depend on BaseUserProfile or this returns stale.
+        u = CustomUser.objects.create(username="c2", nickname="Old")
+        assert serialize_user_core(u.pk)["nickname"] == "Old"
+        u.nickname = "New"  # property setter → bp.save(update_fields=["nickname"])
+        assert serialize_user_core(u.pk)["nickname"] == "New"
+
+    def test_invalidates_on_positions_edit(self):
+        u = CustomUser.objects.create(username="c3")
+        u.positions.carry = 5
+        u.positions.save()  # PositionsModel.save() → invalidate_obj(user)
+        assert serialize_user_core(u.pk)["positions"]["carry"] == 5

--- a/backend/app/tests/test_user_core_cache.py
+++ b/backend/app/tests/test_user_core_cache.py
@@ -26,6 +26,22 @@ class SerializeUserCoreTests(TransactionTestCase):
         u.positions.save()  # PositionsModel.save() → invalidate_obj(user)
         assert serialize_user_core(u.pk)["positions"]["carry"] == 5
 
+    def test_invalidation_is_user_specific(self):
+        # Editing user X must invalidate ONLY X's entry, never Y's. The per-pk
+        # cache key (user_core:{pk}) + pk-filtered dep querysets scope the
+        # eviction to the edited user — not a broad flush of all users.
+        x = CustomUser.objects.create(username="x", nickname="X-old")
+        y = CustomUser.objects.create(username="y", nickname="Y-old")
+        # Prime both caches.
+        assert serialize_user_core(x.pk)["nickname"] == "X-old"
+        assert serialize_user_core(y.pk)["nickname"] == "Y-old"
+        # Edit only X.
+        x.nickname = "X-new"
+        # X reflects the edit (its entry was invalidated)...
+        assert serialize_user_core(x.pk)["nickname"] == "X-new"
+        # ...and Y is unaffected and correct.
+        assert serialize_user_core(y.pk)["nickname"] == "Y-old"
+
 
 class BulkUsersCacheTests(TransactionTestCase):
     def setUp(self):

--- a/backend/app/user_cache.py
+++ b/backend/app/user_cache.py
@@ -1,0 +1,28 @@
+from cacheops import cached_as
+
+from user.models import BaseUserProfile
+
+from .models import CustomUser
+from .serializers import TournamentUserSerializer  # core fields incl. positions, no mmr
+
+
+def serialize_user_core(pk: int) -> dict:
+    """Per-user cached CORE serialization (no MMR — MMR is contextual).
+
+    Invalidated only by this user's own model changes. BaseUserProfile dep is
+    required: nickname/avatar are CustomUser @propertys backed by base_profile.
+    """
+
+    @cached_as(
+        CustomUser.objects.filter(pk=pk),
+        BaseUserProfile.objects.filter(user_id=pk),
+        extra=f"user_core:{pk}",
+        timeout=60 * 60,
+    )
+    def _build() -> dict:
+        user = (
+            CustomUser.objects.select_related("positions").filter(pk=pk).first()
+        )
+        return TournamentUserSerializer(user).data if user else {}
+
+    return _build()

--- a/backend/app/views_main.py
+++ b/backend/app/views_main.py
@@ -66,10 +66,10 @@ from .serializers import (
     TournamentListSerializer,
     TournamentSerializer,
     TournamentsSerializer,
-    TournamentUserSerializer,
     UserSerializer,
     _build_users_dict,
 )
+from .user_cache import serialize_user_core
 
 log = get_logger(__name__)
 from .utils.avatar_utils import refresh_user_avatar
@@ -1324,9 +1324,8 @@ def bulk_users(request):
     if len(pks) == 0 or len(pks) > 200:
         return Response({"error": "Provide 1-200 pks"}, status=400)
 
-    users = CustomUser.objects.filter(pk__in=pks).select_related("positions")
-    serializer = TournamentUserSerializer(users, many=True)
-    return Response(serializer.data)
+    data = [d for d in (serialize_user_core(pk) for pk in pks) if d]
+    return Response(data)
 
 
 @api_view(["GET"])

--- a/docs/plans/2026-06-07-user-prebake-consolidation.md
+++ b/docs/plans/2026-06-07-user-prebake-consolidation.md
@@ -1,0 +1,239 @@
+# User Prebake + Decoupled-Cache Consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** Serialize each user **exactly once** per payload into a flat `_users[]` dict resolved by the frontend entity adapter, and back it with a **per-user cache that is fully decoupled from the tournament/draft structural cache** — so a user edit never evicts a tournament blob and vice versa, and user fetch/serialize is consistently cache-fast.
+
+**Lands BEFORE T2** (game-user-profiles). Built off `main`; `positions` is still the real `CustomUser.positions` column here — T2 later repoints the one shared JOIN. The two parked T2 commits on `feature/profile-t2` rebase onto this after it merges.
+
+**Architecture:**
+- `serialize_user_core(pk)` — one `@cached_as(CustomUser, BaseUserProfile, extra="user_core:{pk}")` function returning the context-stable user dict (positions, nickname, avatar, steam_account_id, discordId, avatarUrl, username, teams). Invalidated ONLY by that user's model changes.
+- Structural caches (tournament detail, draft, tournament list) `@cached_as(Tournament, Team, Game, Draft, DraftRound)` — **drop `CustomUser`/`BaseUserProfile`** — return structure + pk-refs, NO `_users`.
+- Views compose at request time: `data["_users"] = {pk: serialize_user_core(pk) for pk in pks}` (N per-user cache hits).
+- **MMR is contextual** (org/league-scoped) — stays on the team/orgUser payload, NEVER in `serialize_user_core` (the global per-user cache). Putting it there poisons the global pk-indexed frontend cache across tournaments (and would corrupt T3 org-overrides).
+- Frontend: every nested user level is pk-refs resolved via `hydrate*` + `userCacheStore`; the one un-hydrated path (`getTournaments`/`getTournamentsBasic`) gets wired up.
+
+**Tech:** Django + DRF + django-cacheops; React + Zustand entity adapter + TanStack.
+
+---
+
+## Ground truth (verified off main `a10e0ef1`)
+
+- `backend/app/serializers.py`: `_serialize_users_with_mmr` (~95) — shared helper, builds org_users with `select_related("user","user__positions")` + MMR; `_build_users_dict` (~170) — dedup `{pk: serialized}` via `_collect_tournament_user_pks` (~148); `TournamentSerializerBase`/`TeamSerializerSlim` already pk-only; **inline re-serializers still live:** `TeamSerializerForTournament.get_members/dropin/left/captain/deputy_captain` (~208-221), `TournamentsSerializer.captains = TournamentUserSerializer(many=True)` (~250). `TournamentUserSerializer` (~61) carries positions.
+- `backend/app/views_main.py`: `tournament_detail_v2:{pk}` `@cached_as(Tournament, Team, CustomUser, BaseUserProfile, Game, Draft, DraftRound)` (~433) bakes `_users` inside (~456); draft block similar (~640-657); `bulk_users` (~1317) — `POST /users/bulk/`, `TournamentUserSerializer`, **NOT cached**, docstring already says "core fields only — MMR comes from context-specific fetches"; tournament-list views (`getTournaments`/`getTournamentsBasic`) ship inline captains with **no `_users`**.
+- `backend/backend/settings.py` CACHEOPS: `app.customuser`, `user.baseuserprofile`, `app.tournament/team/draft/game/draftround`, etc. (1h timeouts).
+- Frontend: `frontend/app/lib/hydrateTournament.ts` resolves `_users` → nested objects for tournament-detail + draft + WS; `frontend/app/store/userCacheStore.ts` (`createEntityAdapter`, indexes byDiscordId/bySteamAccountId, `UserEntry.positions`); `frontend/app/components/api/userAPI.tsx:42` calls `/users/bulk/`; `userStore.getTournaments` (~350) / `getTournamentsBasic` (~360) set raw response with NO hydrate.
+
+---
+
+## Task 1: `serialize_user_core(pk)` — the decoupled per-user cache
+
+**Files:**
+- Create: `backend/app/user_cache.py` (or add to an existing serializers/cache module)
+- Test: `backend/app/tests/test_user_core_cache.py`
+
+- [ ] **Step 1: Failing test** — assert (a) `serialize_user_core(pk)` returns the context-stable fields, (b) editing the user's nickname changes the next call's output (cache invalidation), (c) MMR is NOT in the output.
+
+```python
+# backend/app/tests/test_user_core_cache.py
+from django.test import TransactionTestCase  # on_commit invalidation
+from app.models import CustomUser
+from app.user_cache import serialize_user_core
+
+
+class SerializeUserCoreTests(TransactionTestCase):
+    def test_returns_core_fields_no_mmr(self):
+        u = CustomUser.objects.create(username="core", nickname="Core")
+        data = serialize_user_core(u.pk)
+        assert data["pk"] == u.pk
+        assert data["nickname"] == "Core"
+        assert "positions" in data
+        assert "mmr" not in data and "league_mmr" not in data
+
+    def test_invalidates_on_user_edit(self):
+        u = CustomUser.objects.create(username="c2", nickname="Old")
+        assert serialize_user_core(u.pk)["nickname"] == "Old"
+        u.nickname = "New"; u.save()
+        assert serialize_user_core(u.pk)["nickname"] == "New"
+```
+
+- [ ] **Step 2: Run, verify fail** — `just test::run 'python manage.py test app.tests.test_user_core_cache -v 2'` → ImportError.
+
+- [ ] **Step 3: Implement.** Define a `PrebakedUserSerializer` (context-stable fields only — NO mmr/league_mmr) and the cached function:
+
+```python
+# backend/app/user_cache.py
+from cacheops import cached_as
+from rest_framework import serializers
+from .models import CustomUser, PositionsModel
+from .serializers import PositionsSerializer
+
+
+class PrebakedUserSerializer(serializers.ModelSerializer):
+    positions = PositionsSerializer(read_only=True)
+
+    class Meta:
+        model = CustomUser
+        fields = (
+            "pk", "username", "nickname", "avatar", "avatarUrl",
+            "discordId", "steam_account_id", "positions",
+        )  # context-STABLE only; MMR is contextual, stays on the team payload
+
+
+def serialize_user_core(pk: int) -> dict:
+    """Per-user cached serialization. Invalidated ONLY by this user's model
+    changes — fully decoupled from tournament/draft structural caches."""
+
+    @cached_as(
+        CustomUser.objects.filter(pk=pk),
+        extra=f"user_core:{pk}",
+        timeout=60 * 60,
+    )
+    def _build() -> dict:
+        user = (
+            CustomUser.objects.select_related("positions")
+            .filter(pk=pk)
+            .first()
+        )
+        if user is None:
+            return {}
+        return PrebakedUserSerializer(user).data
+
+    return _build()
+```
+Note: on `main`, positions is the real `CustomUser.positions` FK — `select_related("positions")` is correct here. (T2 repoints to `base_profile__dota_user_profile__positions` and adds `BaseUserProfile`/`DotaUserProfile` to the `@cached_as` deps when it rebases.) The `extra=f"user_core:{pk}"` key + the single-user queryset dependency means a `save()` on that user evicts exactly this entry.
+
+- [ ] **Step 4: Run, verify pass.** Step 5: commit `feat(cache): serialize_user_core per-user decoupled cache`.
+
+---
+
+## Task 2: Cache `bulk_users` via `serialize_user_core`
+
+**Files:** Modify `backend/app/views_main.py` (`bulk_users` ~1317). Test: `backend/app/tests/test_user_core_cache.py` (extend).
+
+- [ ] **Step 1: Failing test** — `POST /users/bulk/` with pks returns one entry per pk with core fields; a second call after editing one user reflects the change (per-user invalidation, not whole-endpoint).
+- [ ] **Step 2-4:** Reimplement `bulk_users` to assemble from the per-user cache:
+
+```python
+def bulk_users(request):
+    pks = request.data.get("pks", [])
+    if not isinstance(pks, list) or not all(isinstance(p, int) for p in pks):
+        return Response({"error": "Provide a list of integer pks"}, status=400)
+    if not (1 <= len(pks) <= 200):
+        return Response({"error": "Provide 1-200 pks"}, status=400)
+    from app.user_cache import serialize_user_core
+    data = [serialize_user_core(pk) for pk in pks]
+    return Response([d for d in data if d])  # drop missing
+```
+Each entry is a per-user cache hit → fetching is cache-fast and a single user edit invalidates only that user's entry, not all bulk responses. Commit `perf(users): bulk_users assembles from per-user cache`.
+
+---
+
+## Task 3: Refactor `_build_users_dict` to assemble from the per-user cache
+
+**Files:** Modify `backend/app/serializers.py` (`_build_users_dict` ~170). Test: `backend/app/tests/test_build_users_dict.py`.
+
+- [ ] **Step 1: Failing test** — `_build_users_dict(tournament)` returns `{pk: core_user}` for every tournament+team+captain pk, MMR absent from the per-user entries (MMR now rides the team payload, Task 6).
+- [ ] **Step 2-4:** Reimplement:
+
+```python
+def _build_users_dict(tournament) -> dict:
+    from app.user_cache import serialize_user_core
+    seen_pks = _collect_tournament_user_pks(tournament)
+    return {pk: serialize_user_core(pk) for pk in seen_pks}
+```
+`_collect_tournament_user_pks` stays. `_serialize_users_with_mmr` is NOT used for `_users` anymore (it's MMR-bearing) — it remains only for the contextual MMR path (Task 6). Commit `refactor(users): _build_users_dict from per-user cache`.
+
+---
+
+## Task 4: Decouple tournament + draft structural caches from user models; compose `_users` at request time
+
+**Files:** Modify `backend/app/views_main.py` (tournament `retrieve` ~433-460, draft block ~640-657). Test: `backend/app/tests/test_cache_decoupling.py`.
+
+- [ ] **Step 1: Failing test (the headline guarantee).** Warm the tournament detail; edit a member's nickname; assert the tournament STRUCTURAL cache did NOT miss (only the per-user entry did) yet the refetched payload shows the new nickname. And: edit the tournament name; assert the per-user cache stayed warm.
+
+```python
+# backend/app/tests/test_cache_decoupling.py — TransactionTestCase, _redis_reachable skip-guard
+# (mirror backend/user/tests/test_cacheops_integration.py's skip pattern)
+# 1. GET /api/tournament/<pk>/ (warm)
+# 2. PATCH a member nickname via the user
+# 3. GET again → nickname updated AND assert structural cache key still present
+#    (assert via a cache-miss log counter or by checking the structural fn wasn't re-run)
+```
+Because asserting "structural fn didn't re-run" is awkward, the pragmatic assertion: after a USER edit, the refetched `_users[pk].nickname` is fresh; after a TOURNAMENT edit, a user whose entry was cached returns from cache (timing/marker). Ship this test `@unittest.skip`-guarded like T1's cacheops integration (lesson #24) if live-eviction timing is flaky; keep the structural-deps assertion (Step 3) as the hard gate.
+
+- [ ] **Step 2-4: Drop user models from the structural `@cached_as`, compose `_users` outside it:**
+
+```python
+@cached_as(
+    Tournament.objects.filter(pk=pk), Team, Game, Draft, DraftRound,
+    extra=f"tournament_struct:{pk}", timeout=60 * 10,
+)   # NOTE: CustomUser + BaseUserProfile REMOVED — user data is composed below
+def get_structure():
+    instance = self.get_object()
+    return self.get_serializer(instance).data   # pk-refs only, NO _users
+
+data = get_structure()
+data["_users"] = _build_users_dict(self.get_object())   # per-user cache hits, outside the structural cache
+return Response(data)
+```
+Same shape for the draft block. The structural payload must NOT embed `_users` inside the cached fn (or it recouples). Apply the same to any other structural `@cached_as` that currently lists `CustomUser`/`BaseUserProfile` AND composes `_users`. Commit `perf(cache): decouple tournament/draft structural cache from user cache`.
+
+> **cacheops guardrail shift:** after this, structural blocks no longer list `CustomUser`. The user-model deps live in `serialize_user_core` only. Update any grep guardrail accordingly (and this is what makes T2's "add DotaUserProfile to every @cached_as(CustomUser)" collapse to a SINGLE site — `serialize_user_core`).
+
+---
+
+## Task 5: Convert remaining inline re-serializers to pk-only
+
+**Files:** Modify `backend/app/serializers.py` — `TeamSerializerForTournament` (~200-235), `TournamentsSerializer.captains` (~250), and the perf-flagged `GameSerializer`/`BracketGameSerializer`/`DraftRoundSerializer`/`TeamView` surfaces. Template: `TeamSerializerSlim` (~238, already pk-only).
+
+- [ ] Convert `get_members/get_dropin_members/get_left_members` → `UserPkField(many=True)`, `get_captain/get_deputy_captain` → `UserPkField()`. Make `TeamSerializerForTournament` itself pk-only (or have callers use `TeamSerializerSlim`). `TournamentsSerializer.captains` → `UserPkField(many=True)`.
+- [ ] Every endpoint emitting these MUST attach `_users` (Task 4 pattern). Audit: `rg -n "_serialize_users_with_mmr|TournamentUserSerializer\(" backend/app` — each remaining full-user inline site either moves to pk + `_users` or is justified (e.g. `bulk_users` IS the user source).
+- [ ] Commit `refactor(serializers): nested user refs pk-only across tournament/team/game/draft`.
+
+---
+
+## Task 6: Contextual MMR stays on the team/orgUser payload
+
+**Files:** Modify `backend/app/serializers.py` (team serializers), `backend/org/serializers.py` if needed. Test: `backend/app/tests/test_mmr_contextual.py`.
+
+- [ ] MMR/league_mmr must remain reachable per-tournament. Since members are now pk-refs, expose MMR as a pk→mmr map on the team or tournament payload (e.g. `team.member_mmr: {pk: mmr}`) OR keep `OrgUserSerializer` for the explicit org/league roster endpoints (which legitimately ship MMR and are separate from `_users`). Do NOT add mmr to `serialize_user_core`.
+- [ ] Test: a user on two tournaments with different org MMRs serializes each tournament's MMR correctly, while `serialize_user_core` returns no MMR. Commit `feat(serializers): contextual MMR map separate from global user cache`.
+
+---
+
+## Task 7: WS broadcast `_users` parity
+
+**Files:** `backend/app/consumers.py` (+ any broadcast emitting slim teams). Test: existing WS tests.
+
+- [ ] Audit every broadcast that emits pk-ref teams/users — each must attach `_users` (via `_build_users_dict`) or the client can't resolve them. `rg -n "_users|_build_users_dict|broadcast|group_send" backend/app/consumers.py`. Commit `fix(ws): attach _users to slim broadcasts`.
+
+---
+
+## Task 8: Frontend — hydrate the tournament-list path + one source of truth
+
+**Files:** `frontend/app/store/userStore.ts` (`getTournaments` ~350, `getTournamentsBasic` ~360), `frontend/app/lib/hydrateTournament.ts`, the tournament-list captain consumers.
+
+- [ ] Route `getTournaments`/`getTournamentsBasic` responses through `hydrateTournament` (or a list variant) so the now-pk-only `captains` resolve. The at-risk consumers (`captainTable.tsx`, `UpdateCaptainButton.tsx`, `createTeamFromCaptainHook.tsx`, `draftOrder.tsx`) then read resolved objects.
+- [ ] Ensure `bulk_users` results populate `userCacheStore` so unknown pks resolve; confirm `hydrateTournament` covers every nested level (members/captain/deputy/dropin/left/users_remaining/draft_rounds) — it already does for detail/draft; add the list path.
+- [ ] Pick ONE source of truth for nested reads (keep the hydrate-tree pattern consistently; contextual MMR read from the per-tournament tree, never the global cache). Commit `feat(frontend): hydrate tournament-list path + consistent user resolution`.
+
+---
+
+## Task 9: Tests + verification
+
+- [ ] **Contract test** (`backend/app/tests/test_users_dict_contract.py`): for tournament-detail, draft, and tournament-list responses, assert every nested user reference is an int pk AND `_users` is present and covers all referenced pks.
+- [ ] **Query-count regression** (`assertNumQueries`): tournament-detail cold render issues O(1) `_build_users_dict` user query path, not O(teams×members). Lock in the win (panel estimate ~160→~6).
+- [ ] **Decoupling behavioral** (Task 4 test) — shipped skip-guarded if live-Redis timing is flaky; the structural-deps assertion is the hard gate.
+- [ ] **Playwright** (`frontend/tests/playwright/e2e/`): tournament list + detail + draft render captains/members correctly post-conversion (no blank names). Reuse existing edit-user/tournament specs.
+- [ ] **Final:** `just test::run 'python manage.py test app -v 2'` green; `cd frontend && npx tsc --noEmit` no new errors; `npx vitest run` green; `just test::pw::spec tournament` + `draft` green; `just db::populate::all` smoke. Commit per task.
+
+---
+
+## Sequencing into T2
+
+After this PR merges: rebase `feature/profile-t2` onto the new `main`. T2's Task 9 then only has to (a) repoint `serialize_user_core`'s `select_related("positions")` → `base_profile__dota_user_profile__positions` and (b) add `BaseUserProfile, DotaUserProfile` to `serialize_user_core`'s `@cached_as` deps — a SINGLE site, not 14. The T2 cacheops guardrail simplifies to "the per-user cache lists the user-model deps."
+
+## Spec / design provenance
+
+Design panel (4 agents) + user directives: prebaked-once + pk-refs (unanimous), decoupled per-user cache separate from tournament caching (user requirement), global-vs-contextual MMR split (DRF architect), tournament-list is the one un-hydrated path (frontend), ~160→~6 query win (perf), separate-PR-first sequencing (3/4 + user).

--- a/docs/plans/2026-06-07-user-prebake-consolidation.md
+++ b/docs/plans/2026-06-07-user-prebake-consolidation.md
@@ -171,9 +171,9 @@ def _build_users_dict(tournament) -> dict:
 
 ---
 
-## Scope B — deferred epic (DO NOT build here)
+## Scope B — deferred epic (DO NOT build here) — tracked in **GH issue #276**
 
-Captured so it isn't lost. Full structural-cache decoupling + prebaked-once-everywhere, to be planned/built deliberately as its own epic. Reviewed scope + the corrections the 3-agent panel found:
+Captured so it isn't lost. Full structural-cache decoupling + prebaked-once-everywhere, to be planned/built deliberately as its own epic (**https://github.com/kettleofketchup/DraftForge/issues/276**). Reviewed scope + the corrections the 3-agent panel found:
 
 1. **Convert nested users to pk-refs** everywhere `TeamSerializerForTournament` reaches — tournament-detail, draft, **bracket** (`views/bracket.py:50,300,395,548` + `BracketGameSerializer`), **game** (`GameView`/`GameCreateView`, `GameSerializer`), **TeamView**, **tournament-list** (`TournamentsSerializer.captains`). Each emitting endpoint must attach `_users`.
 2. **Decouple structural caches:** drop `CustomUser`/`BaseUserProfile` from the tournament/draft/team `@cached_as`; compose `_users` from the per-user cache; **collect `_users` pks from the cached payload dict, not `get_object()`/ORM** (avoids the warm-path re-query). Align draft struct timeout to 10m (currently 60m).

--- a/docs/plans/2026-06-07-user-prebake-consolidation.md
+++ b/docs/plans/2026-06-07-user-prebake-consolidation.md
@@ -1,91 +1,87 @@
-# User Prebake + Decoupled-Cache Consolidation — Implementation Plan
+# Per-User Core Cache (Scope A) — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
 
-**Goal:** Serialize each user **exactly once** per payload into a flat `_users[]` dict resolved by the frontend entity adapter, and back it with a **per-user cache that is fully decoupled from the tournament/draft structural cache** — so a user edit never evicts a tournament blob and vice versa, and user fetch/serialize is consistently cache-fast.
+**Goal:** Make user serialization/fetch fast and **independently cached per-user**, with **zero change to any response shape** (so zero frontend impact, minimal risk). This is the safe foundation; the full structural-cache decoupling + prebaked-once-everywhere is a deliberately-deferred epic (Scope B, appended).
 
-**Lands BEFORE T2** (game-user-profiles). Built off `main`; `positions` is still the real `CustomUser.positions` column here — T2 later repoints the one shared JOIN. The two parked T2 commits on `feature/profile-t2` rebase onto this after it merges.
+**Lands BEFORE T2**, off `main`. `positions` is still the real `CustomUser.positions` column here; T2 repoints the one shared JOIN when it rebases.
 
 **Architecture:**
-- `serialize_user_core(pk)` — one `@cached_as(CustomUser, BaseUserProfile, extra="user_core:{pk}")` function returning the context-stable user dict (positions, nickname, avatar, steam_account_id, discordId, avatarUrl, username, teams). Invalidated ONLY by that user's model changes.
-- Structural caches (tournament detail, draft, tournament list) `@cached_as(Tournament, Team, Game, Draft, DraftRound)` — **drop `CustomUser`/`BaseUserProfile`** — return structure + pk-refs, NO `_users`.
-- Views compose at request time: `data["_users"] = {pk: serialize_user_core(pk) for pk in pks}` (N per-user cache hits).
-- **MMR is contextual** (org/league-scoped) — stays on the team/orgUser payload, NEVER in `serialize_user_core` (the global per-user cache). Putting it there poisons the global pk-indexed frontend cache across tournaments (and would corrupt T3 org-overrides).
-- Frontend: every nested user level is pk-refs resolved via `hydrate*` + `userCacheStore`; the one un-hydrated path (`getTournaments`/`getTournamentsBasic`) gets wired up.
+- `serialize_user_core(pk)` — `@cached_as(CustomUser.objects.filter(pk=pk), BaseUserProfile.objects.filter(user_id=pk), extra="user_core:{pk}")` returning the **context-stable** user fields only (positions, nickname, avatar, avatarUrl, steam_account_id, discordId, username, teams). Invalidated only by that user's own model changes. **MUST include the `BaseUserProfile` dep** — nickname/avatar are CustomUser `@property`s that write through to `base_profile` (`bp.save()`, never `user.save()`), so a CustomUser-only dep serves stale names.
+- `bulk_users` (`POST /users/bulk/`) assembles from `serialize_user_core` → per-user cache hits.
+- `_build_users_dict` **preserves its current output shape** (core **+** contextual MMR) by merging cached core with per-request MMR — so the tournament/draft `_users` payload is byte-identical to today. No serializer is converted to pk-only; no structural cache is decoupled; no frontend changes.
 
-**Tech:** Django + DRF + django-cacheops; React + Zustand entity adapter + TanStack.
+**What Scope A deliberately does NOT do** (→ Scope B epic): convert nested users to pk-refs, decouple the tournament/draft structural `@cached_as` from user models, migrate the ~15 MMR-read sites, touch the frontend, or change `_users`/team/bracket/game/list response shapes.
 
----
-
-## Ground truth (verified off main `a10e0ef1`)
-
-- `backend/app/serializers.py`: `_serialize_users_with_mmr` (~95) — shared helper, builds org_users with `select_related("user","user__positions")` + MMR; `_build_users_dict` (~170) — dedup `{pk: serialized}` via `_collect_tournament_user_pks` (~148); `TournamentSerializerBase`/`TeamSerializerSlim` already pk-only; **inline re-serializers still live:** `TeamSerializerForTournament.get_members/dropin/left/captain/deputy_captain` (~208-221), `TournamentsSerializer.captains = TournamentUserSerializer(many=True)` (~250). `TournamentUserSerializer` (~61) carries positions.
-- `backend/app/views_main.py`: `tournament_detail_v2:{pk}` `@cached_as(Tournament, Team, CustomUser, BaseUserProfile, Game, Draft, DraftRound)` (~433) bakes `_users` inside (~456); draft block similar (~640-657); `bulk_users` (~1317) — `POST /users/bulk/`, `TournamentUserSerializer`, **NOT cached**, docstring already says "core fields only — MMR comes from context-specific fetches"; tournament-list views (`getTournaments`/`getTournamentsBasic`) ship inline captains with **no `_users`**.
-- `backend/backend/settings.py` CACHEOPS: `app.customuser`, `user.baseuserprofile`, `app.tournament/team/draft/game/draftround`, etc. (1h timeouts).
-- Frontend: `frontend/app/lib/hydrateTournament.ts` resolves `_users` → nested objects for tournament-detail + draft + WS; `frontend/app/store/userCacheStore.ts` (`createEntityAdapter`, indexes byDiscordId/bySteamAccountId, `UserEntry.positions`); `frontend/app/components/api/userAPI.tsx:42` calls `/users/bulk/`; `userStore.getTournaments` (~350) / `getTournamentsBasic` (~360) set raw response with NO hydrate.
+**Tech:** Django + DRF + django-cacheops.
 
 ---
 
-## Task 1: `serialize_user_core(pk)` — the decoupled per-user cache
+## Ground truth (off main `a10e0ef1`)
 
-**Files:**
-- Create: `backend/app/user_cache.py` (or add to an existing serializers/cache module)
-- Test: `backend/app/tests/test_user_core_cache.py`
+- `backend/app/serializers.py`: `_serialize_users_with_mmr` (~95) returns users **with** org/league MMR when the tournament has an org (via `OrgUserSerializer`), else `TournamentUserSerializer` (no mmr); `_build_users_dict` (~170) = `{pk: u for u in _serialize_users_with_mmr(user_qs, tournament)}`; `TournamentUserSerializer` (~61) = core fields incl. positions, no mmr; `OrgUserSerializer` (`org/serializers.py:9`) = core + `mmr`/`league_mmr`.
+- `backend/app/views_main.py`: `bulk_users` (~1317) — `TournamentUserSerializer(many=True)`, **not cached**, docstring "core fields only — MMR comes from context-specific fetches".
+- nickname/avatar are `@property` on CustomUser writing through to `base_profile` (`backend/app/models.py:135-178`); `positions` is a real FK; `PositionsModel.save()` calls `invalidate_obj(user)` (`models.py:43-48`).
+- `settings.py` CACHEOPS has `app.customuser`, `user.baseuserprofile`.
 
-- [ ] **Step 1: Failing test** — assert (a) `serialize_user_core(pk)` returns the context-stable fields, (b) editing the user's nickname changes the next call's output (cache invalidation), (c) MMR is NOT in the output.
+---
+
+## Task 1: `serialize_user_core(pk)` per-user cache
+
+**Files:** Create `backend/app/user_cache.py`; Test `backend/app/tests/test_user_core_cache.py`.
+
+- [ ] **Step 1: Failing test** — core fields present, no mmr, and **nickname edit invalidates** (the BaseUserProfile-dep regression guard):
 
 ```python
 # backend/app/tests/test_user_core_cache.py
-from django.test import TransactionTestCase  # on_commit invalidation
+from django.test import TransactionTestCase   # on_commit invalidation
 from app.models import CustomUser
 from app.user_cache import serialize_user_core
 
 
 class SerializeUserCoreTests(TransactionTestCase):
-    def test_returns_core_fields_no_mmr(self):
+    def test_core_fields_no_mmr(self):
         u = CustomUser.objects.create(username="core", nickname="Core")
-        data = serialize_user_core(u.pk)
-        assert data["pk"] == u.pk
-        assert data["nickname"] == "Core"
-        assert "positions" in data
-        assert "mmr" not in data and "league_mmr" not in data
+        d = serialize_user_core(u.pk)
+        assert d["pk"] == u.pk and d["nickname"] == "Core"
+        assert "positions" in d
+        assert "mmr" not in d and "league_mmr" not in d
 
-    def test_invalidates_on_user_edit(self):
+    def test_invalidates_on_nickname_edit(self):
+        # nickname writes through to base_profile (bp.save), NOT user.save —
+        # the cache MUST depend on BaseUserProfile or this returns stale.
         u = CustomUser.objects.create(username="c2", nickname="Old")
         assert serialize_user_core(u.pk)["nickname"] == "Old"
-        u.nickname = "New"; u.save()
+        u.nickname = "New"   # property setter → bp.save(update_fields=["nickname"])
         assert serialize_user_core(u.pk)["nickname"] == "New"
+
+    def test_invalidates_on_positions_edit(self):
+        u = CustomUser.objects.create(username="c3")
+        u.positions.carry = 5
+        u.positions.save()   # PositionsModel.save() → invalidate_obj(user)
+        assert serialize_user_core(u.pk)["positions"]["carry"] == 5
 ```
 
-- [ ] **Step 2: Run, verify fail** — `just test::run 'python manage.py test app.tests.test_user_core_cache -v 2'` → ImportError.
+- [ ] **Step 2: Run, verify fail** — `just test::run 'python manage.py test app.tests.test_user_core_cache -v 2'`.
 
-- [ ] **Step 3: Implement.** Define a `PrebakedUserSerializer` (context-stable fields only — NO mmr/league_mmr) and the cached function:
+- [ ] **Step 3: Implement** — note the **two** dep querysets:
 
 ```python
 # backend/app/user_cache.py
 from cacheops import cached_as
-from rest_framework import serializers
-from .models import CustomUser, PositionsModel
-from .serializers import PositionsSerializer
-
-
-class PrebakedUserSerializer(serializers.ModelSerializer):
-    positions = PositionsSerializer(read_only=True)
-
-    class Meta:
-        model = CustomUser
-        fields = (
-            "pk", "username", "nickname", "avatar", "avatarUrl",
-            "discordId", "steam_account_id", "positions",
-        )  # context-STABLE only; MMR is contextual, stays on the team payload
+from .models import CustomUser
+from .serializers import TournamentUserSerializer  # core fields incl. positions, no mmr
+from user.models import BaseUserProfile
 
 
 def serialize_user_core(pk: int) -> dict:
-    """Per-user cached serialization. Invalidated ONLY by this user's model
-    changes — fully decoupled from tournament/draft structural caches."""
+    """Per-user cached CORE serialization (no MMR — MMR is contextual).
+    Invalidated only by this user's own model changes. BaseUserProfile dep is
+    required: nickname/avatar are CustomUser @propertys backed by base_profile."""
 
     @cached_as(
         CustomUser.objects.filter(pk=pk),
+        BaseUserProfile.objects.filter(user_id=pk),
         extra=f"user_core:{pk}",
         timeout=60 * 60,
     )
@@ -95,145 +91,98 @@ def serialize_user_core(pk: int) -> dict:
             .filter(pk=pk)
             .first()
         )
-        if user is None:
-            return {}
-        return PrebakedUserSerializer(user).data
+        return TournamentUserSerializer(user).data if user else {}
 
     return _build()
 ```
-Note: on `main`, positions is the real `CustomUser.positions` FK — `select_related("positions")` is correct here. (T2 repoints to `base_profile__dota_user_profile__positions` and adds `BaseUserProfile`/`DotaUserProfile` to the `@cached_as` deps when it rebases.) The `extra=f"user_core:{pk}"` key + the single-user queryset dependency means a `save()` on that user evicts exactly this entry.
+Reuse `TournamentUserSerializer` (the existing core, no-mmr serializer) so the shape is identical to what `bulk_users` already returns. On main, `select_related("positions")` is correct (positions is a real FK).
 
-- [ ] **Step 4: Run, verify pass.** Step 5: commit `feat(cache): serialize_user_core per-user decoupled cache`.
+- [ ] **Step 4: Run green. Step 5: commit** `feat(cache): serialize_user_core per-user cache (BaseUserProfile dep for nickname/avatar)`.
 
 ---
 
-## Task 2: Cache `bulk_users` via `serialize_user_core`
+## Task 2: `bulk_users` assembles from the per-user cache
 
-**Files:** Modify `backend/app/views_main.py` (`bulk_users` ~1317). Test: `backend/app/tests/test_user_core_cache.py` (extend).
+**Files:** Modify `backend/app/views_main.py` (`bulk_users` ~1317). Test: extend `test_user_core_cache.py`.
 
-- [ ] **Step 1: Failing test** — `POST /users/bulk/` with pks returns one entry per pk with core fields; a second call after editing one user reflects the change (per-user invalidation, not whole-endpoint).
-- [ ] **Step 2-4:** Reimplement `bulk_users` to assemble from the per-user cache:
+- [ ] **Step 1: Failing test** — `POST /users/bulk/` with `{pks:[...]}` returns one core entry per pk (same shape as today: `TournamentUserSerializer` fields), and a second call after a nickname edit reflects it (per-user invalidation).
 
 ```python
-def bulk_users(request):
-    pks = request.data.get("pks", [])
-    if not isinstance(pks, list) or not all(isinstance(p, int) for p in pks):
-        return Response({"error": "Provide a list of integer pks"}, status=400)
-    if not (1 <= len(pks) <= 200):
-        return Response({"error": "Provide 1-200 pks"}, status=400)
-    from app.user_cache import serialize_user_core
-    data = [serialize_user_core(pk) for pk in pks]
-    return Response([d for d in data if d])  # drop missing
+class BulkUsersCacheTests(TransactionTestCase):
+    def setUp(self):
+        from rest_framework.test import APIClient
+        self.client = APIClient()
+
+    def test_bulk_users_returns_core_and_reflects_edit(self):
+        from app.models import CustomUser
+        u = CustomUser.objects.create(username="b1", nickname="B1")
+        r = self.client.post("/api/users/bulk/", {"pks": [u.pk]}, format="json")
+        assert r.status_code == 200 and r.json()[0]["nickname"] == "B1"
+        u.nickname = "B1x"
+        r2 = self.client.post("/api/users/bulk/", {"pks": [u.pk]}, format="json")
+        assert r2.json()[0]["nickname"] == "B1x"
 ```
-Each entry is a per-user cache hit → fetching is cache-fast and a single user edit invalidates only that user's entry, not all bulk responses. Commit `perf(users): bulk_users assembles from per-user cache`.
+(Confirm the `/api/users/bulk/` route + auth — read the existing endpoint's decorators; mirror them in the test client setup.)
+
+- [ ] **Step 2-3:** reimplement the body (keep the existing pk validation + 1-200 bound + decorators):
+
+```python
+    from app.user_cache import serialize_user_core
+    data = [d for d in (serialize_user_core(pk) for pk in pks) if d]
+    return Response(data)
+```
+Output shape is unchanged (TournamentUserSerializer fields), now per-user cached. `bulk_users` docstring already promises "core fields only" — no shape change.
+
+- [ ] **Step 4: green. Step 5: commit** `perf(users): bulk_users assembles from per-user cache`.
 
 ---
 
-## Task 3: Refactor `_build_users_dict` to assemble from the per-user cache
+## Task 3: `_build_users_dict` core-from-cache + contextual MMR merge (shape-preserving)
 
-**Files:** Modify `backend/app/serializers.py` (`_build_users_dict` ~170). Test: `backend/app/tests/test_build_users_dict.py`.
+**Files:** Modify `backend/app/serializers.py` (`_build_users_dict` ~170, `_serialize_users_with_mmr` ~95). Test: `backend/app/tests/test_build_users_dict.py`.
 
-- [ ] **Step 1: Failing test** — `_build_users_dict(tournament)` returns `{pk: core_user}` for every tournament+team+captain pk, MMR absent from the per-user entries (MMR now rides the team payload, Task 6).
-- [ ] **Step 2-4:** Reimplement:
+> **The shape-preservation rule:** today `_build_users_dict` returns `{pk: core+mmr}` for org tournaments. Scope A keeps that EXACT shape — it just sources the **core** half from `serialize_user_core` (cached per-user) and merges the **contextual MMR** half computed per-request. Frontend reads `_users[pk].mmr` unchanged.
+
+- [ ] **Step 1: Failing test** — for an org-scoped tournament, `_build_users_dict(t)` entries contain BOTH core fields (nickname/positions) AND `mmr`/`league_mmr` (shape parity with today); for a non-org tournament, no mmr (parity). And: a nickname edit is reflected (core cached but invalidated), an MMR change is reflected (computed fresh).
+
+- [ ] **Step 2-3: Implement the merge.** Extract an MMR-only helper from `_serialize_users_with_mmr` (a `{pk: {"mmr":…, "league_mmr":…, "orgUserPk":…}}` map for the tournament's org/league context), then:
 
 ```python
 def _build_users_dict(tournament) -> dict:
     from app.user_cache import serialize_user_core
     seen_pks = _collect_tournament_user_pks(tournament)
-    return {pk: serialize_user_core(pk) for pk in seen_pks}
+    core = {pk: serialize_user_core(pk) for pk in seen_pks}      # cached per-user
+    mmr_map = _collect_context_mmr(tournament, seen_pks)         # per-request, contextual
+    return {pk: {**core[pk], **mmr_map.get(pk, {})} for pk in seen_pks if core[pk]}
 ```
-`_collect_tournament_user_pks` stays. `_serialize_users_with_mmr` is NOT used for `_users` anymore (it's MMR-bearing) — it remains only for the contextual MMR path (Task 6). Commit `refactor(users): _build_users_dict from per-user cache`.
+`_collect_context_mmr` reuses the existing OrgUser/LeagueUser lookup logic from `_serialize_users_with_mmr` (the org-users queryset + league prefetch), returning only the mmr fields per pk (empty for non-org tournaments). Keep `_serialize_users_with_mmr` itself for any other caller; this just factors its mmr half out. **Verify the merged output keys exactly match today's `_build_users_dict`** (diff a serialized tournament before/after — same JSON).
+
+- [ ] **Step 4: green + shape-parity check.** Run the broad suite: `just test::run 'python manage.py test app -v 2'` — tournament/draft tests must stay green (the `_users` shape is unchanged). **Step 5: commit** `perf(users): _build_users_dict sources core from per-user cache, merges contextual MMR (shape-preserving)`.
 
 ---
 
-## Task 4: Decouple tournament + draft structural caches from user models; compose `_users` at request time
+## Task 4: Verification
 
-**Files:** Modify `backend/app/views_main.py` (tournament `retrieve` ~433-460, draft block ~640-657). Test: `backend/app/tests/test_cache_decoupling.py`.
-
-- [ ] **Step 1: Failing test (the headline guarantee).** Warm the tournament detail; edit a member's nickname; assert the tournament STRUCTURAL cache did NOT miss (only the per-user entry did) yet the refetched payload shows the new nickname. And: edit the tournament name; assert the per-user cache stayed warm.
-
-```python
-# backend/app/tests/test_cache_decoupling.py — TransactionTestCase, _redis_reachable skip-guard
-# (mirror backend/user/tests/test_cacheops_integration.py's skip pattern)
-# 1. GET /api/tournament/<pk>/ (warm)
-# 2. PATCH a member nickname via the user
-# 3. GET again → nickname updated AND assert structural cache key still present
-#    (assert via a cache-miss log counter or by checking the structural fn wasn't re-run)
-```
-Because asserting "structural fn didn't re-run" is awkward, the pragmatic assertion: after a USER edit, the refetched `_users[pk].nickname` is fresh; after a TOURNAMENT edit, a user whose entry was cached returns from cache (timing/marker). Ship this test `@unittest.skip`-guarded like T1's cacheops integration (lesson #24) if live-eviction timing is flaky; keep the structural-deps assertion (Step 3) as the hard gate.
-
-- [ ] **Step 2-4: Drop user models from the structural `@cached_as`, compose `_users` outside it:**
-
-```python
-@cached_as(
-    Tournament.objects.filter(pk=pk), Team, Game, Draft, DraftRound,
-    extra=f"tournament_struct:{pk}", timeout=60 * 10,
-)   # NOTE: CustomUser + BaseUserProfile REMOVED — user data is composed below
-def get_structure():
-    instance = self.get_object()
-    return self.get_serializer(instance).data   # pk-refs only, NO _users
-
-data = get_structure()
-data["_users"] = _build_users_dict(self.get_object())   # per-user cache hits, outside the structural cache
-return Response(data)
-```
-Same shape for the draft block. The structural payload must NOT embed `_users` inside the cached fn (or it recouples). Apply the same to any other structural `@cached_as` that currently lists `CustomUser`/`BaseUserProfile` AND composes `_users`. Commit `perf(cache): decouple tournament/draft structural cache from user cache`.
-
-> **cacheops guardrail shift:** after this, structural blocks no longer list `CustomUser`. The user-model deps live in `serialize_user_core` only. Update any grep guardrail accordingly (and this is what makes T2's "add DotaUserProfile to every @cached_as(CustomUser)" collapse to a SINGLE site — `serialize_user_core`).
+- [ ] **Shape parity (the safety gate):** serialize a representative org tournament + a non-org tournament + a draft, assert `_users` JSON is byte-identical to `main` (capture from `git stash`/a main checkout, or assert the key set + a sample entry's keys match `TournamentUserSerializer` fields + mmr). This is what guarantees zero frontend impact.
+- [ ] `just test::run 'python manage.py test app -v 2'` — full backend green.
+- [ ] `just db::populate::all` smoke — populate works (the per-user cache + shim path).
+- [ ] No frontend changes in this PR: `git diff --stat origin/main | grep frontend` → empty (except none expected).
+- [ ] Cacheops behavioral (ship `@unittest.skip` + `_redis_reachable` guard, lesson #24): warm a cached tournament, edit a member nickname, refetch, assert fresh name — documents the per-user invalidation even if live-Redis timing is deferred.
 
 ---
 
-## Task 5: Convert remaining inline re-serializers to pk-only
+## Scope B — deferred epic (DO NOT build here)
 
-**Files:** Modify `backend/app/serializers.py` — `TeamSerializerForTournament` (~200-235), `TournamentsSerializer.captains` (~250), and the perf-flagged `GameSerializer`/`BracketGameSerializer`/`DraftRoundSerializer`/`TeamView` surfaces. Template: `TeamSerializerSlim` (~238, already pk-only).
+Captured so it isn't lost. Full structural-cache decoupling + prebaked-once-everywhere, to be planned/built deliberately as its own epic. Reviewed scope + the corrections the 3-agent panel found:
 
-- [ ] Convert `get_members/get_dropin_members/get_left_members` → `UserPkField(many=True)`, `get_captain/get_deputy_captain` → `UserPkField()`. Make `TeamSerializerForTournament` itself pk-only (or have callers use `TeamSerializerSlim`). `TournamentsSerializer.captains` → `UserPkField(many=True)`.
-- [ ] Every endpoint emitting these MUST attach `_users` (Task 4 pattern). Audit: `rg -n "_serialize_users_with_mmr|TournamentUserSerializer\(" backend/app` — each remaining full-user inline site either moves to pk + `_users` or is justified (e.g. `bulk_users` IS the user source).
-- [ ] Commit `refactor(serializers): nested user refs pk-only across tournament/team/game/draft`.
+1. **Convert nested users to pk-refs** everywhere `TeamSerializerForTournament` reaches — tournament-detail, draft, **bracket** (`views/bracket.py:50,300,395,548` + `BracketGameSerializer`), **game** (`GameView`/`GameCreateView`, `GameSerializer`), **TeamView**, **tournament-list** (`TournamentsSerializer.captains`). Each emitting endpoint must attach `_users`.
+2. **Decouple structural caches:** drop `CustomUser`/`BaseUserProfile` from the tournament/draft/team `@cached_as`; compose `_users` from the per-user cache; **collect `_users` pks from the cached payload dict, not `get_object()`/ORM** (avoids the warm-path re-query). Align draft struct timeout to 10m (currently 60m).
+3. **M2M roster invalidation (required when CustomUser dep is dropped):** add `invalidate_after_commit(tournament, team)` at `org/views.py:248-257` (claim/merge does `users.add/remove`/`members.add/remove` with no invalidation — currently masked by the broad CustomUser dep) + audit `import_prod_tournament.py`, `sync_prod_tournaments.py`.
+4. **Extend `_collect_tournament_user_pks`** to walk `draft.draft_rounds` captain/choice + `draft.users_remaining` (or assert the subset invariant in a contract test) — else a round captain/choice outside `tournament.users` renders blank.
+5. **MMR-from-cache migration (~15 frontend sites)** reading `member.mmr`/`captain.mmr` off the hydrated tree (`captainTable`, `teamTable`, `TeamModal`, `seeding.ts`, `draftTable`, `ShufflePickOrder`, `DoublePickThreshold`, `AvailablePlayersSection`, `PickOrderSection`, `CompletedTeamDraftView`, `TeamPositionCoverage`, `createTeams`, `TeamPopoverContent`, `teamCard`): rule = **identity from hydrate-tree, MMR from cache** (`orgData`/`leagueData` via `useUserMmr`); backend ships a contextual pk→mmr map; frontend upserts it into `userCacheStore` with org/league context.
+6. **Frontend hydration gaps:** per-tournament `_users` + `hydrateTournamentList = raw.map(hydrateTournament)` for `getTournaments`/`getTournamentsBasic`; bracket/game hydration (`MatchNode`, `MatchStatsModal`); wire `fetchUsersBulk` (dead code today) + a hydrate fallback that fetches unresolved pks via `/users/bulk/` and upserts `userCacheStore` (today hydrate renders a blank user on any `_users` miss).
+7. **Tests:** contract (every nested user is a pk + `_users` covers all referenced pks), query-count regression (~160→~6), decoupling behavioral.
 
----
+## Provenance
 
-## Task 6: Contextual MMR stays on the team/orgUser payload
-
-**Files:** Modify `backend/app/serializers.py` (team serializers), `backend/org/serializers.py` if needed. Test: `backend/app/tests/test_mmr_contextual.py`.
-
-- [ ] MMR/league_mmr must remain reachable per-tournament. Since members are now pk-refs, expose MMR as a pk→mmr map on the team or tournament payload (e.g. `team.member_mmr: {pk: mmr}`) OR keep `OrgUserSerializer` for the explicit org/league roster endpoints (which legitimately ship MMR and are separate from `_users`). Do NOT add mmr to `serialize_user_core`.
-- [ ] Test: a user on two tournaments with different org MMRs serializes each tournament's MMR correctly, while `serialize_user_core` returns no MMR. Commit `feat(serializers): contextual MMR map separate from global user cache`.
-
----
-
-## Task 7: WS broadcast `_users` parity
-
-**Files:** `backend/app/consumers.py` (+ any broadcast emitting slim teams). Test: existing WS tests.
-
-- [ ] Audit every broadcast that emits pk-ref teams/users — each must attach `_users` (via `_build_users_dict`) or the client can't resolve them. `rg -n "_users|_build_users_dict|broadcast|group_send" backend/app/consumers.py`. Commit `fix(ws): attach _users to slim broadcasts`.
-
----
-
-## Task 8: Frontend — hydrate the tournament-list path + one source of truth
-
-**Files:** `frontend/app/store/userStore.ts` (`getTournaments` ~350, `getTournamentsBasic` ~360), `frontend/app/lib/hydrateTournament.ts`, the tournament-list captain consumers.
-
-- [ ] Route `getTournaments`/`getTournamentsBasic` responses through `hydrateTournament` (or a list variant) so the now-pk-only `captains` resolve. The at-risk consumers (`captainTable.tsx`, `UpdateCaptainButton.tsx`, `createTeamFromCaptainHook.tsx`, `draftOrder.tsx`) then read resolved objects.
-- [ ] Ensure `bulk_users` results populate `userCacheStore` so unknown pks resolve; confirm `hydrateTournament` covers every nested level (members/captain/deputy/dropin/left/users_remaining/draft_rounds) — it already does for detail/draft; add the list path.
-- [ ] Pick ONE source of truth for nested reads (keep the hydrate-tree pattern consistently; contextual MMR read from the per-tournament tree, never the global cache). Commit `feat(frontend): hydrate tournament-list path + consistent user resolution`.
-
----
-
-## Task 9: Tests + verification
-
-- [ ] **Contract test** (`backend/app/tests/test_users_dict_contract.py`): for tournament-detail, draft, and tournament-list responses, assert every nested user reference is an int pk AND `_users` is present and covers all referenced pks.
-- [ ] **Query-count regression** (`assertNumQueries`): tournament-detail cold render issues O(1) `_build_users_dict` user query path, not O(teams×members). Lock in the win (panel estimate ~160→~6).
-- [ ] **Decoupling behavioral** (Task 4 test) — shipped skip-guarded if live-Redis timing is flaky; the structural-deps assertion is the hard gate.
-- [ ] **Playwright** (`frontend/tests/playwright/e2e/`): tournament list + detail + draft render captains/members correctly post-conversion (no blank names). Reuse existing edit-user/tournament specs.
-- [ ] **Final:** `just test::run 'python manage.py test app -v 2'` green; `cd frontend && npx tsc --noEmit` no new errors; `npx vitest run` green; `just test::pw::spec tournament` + `draft` green; `just db::populate::all` smoke. Commit per task.
-
----
-
-## Sequencing into T2
-
-After this PR merges: rebase `feature/profile-t2` onto the new `main`. T2's Task 9 then only has to (a) repoint `serialize_user_core`'s `select_related("positions")` → `base_profile__dota_user_profile__positions` and (b) add `BaseUserProfile, DotaUserProfile` to `serialize_user_core`'s `@cached_as` deps — a SINGLE site, not 14. The T2 cacheops guardrail simplifies to "the per-user cache lists the user-model deps."
-
-## Spec / design provenance
-
-Design panel (4 agents) + user directives: prebaked-once + pk-refs (unanimous), decoupled per-user cache separate from tournament caching (user requirement), global-vs-contextual MMR split (DRF architect), tournament-list is the one un-hydrated path (frontend), ~160→~6 query win (perf), separate-PR-first sequencing (3/4 + user).
+Design panel (4 agents) + plan-review panel (3 agents) + user scope decision (Scope A now, Scope B as deferred epic). Key corrections folded into Scope A: BaseUserProfile dep on the per-user cache; shape-preserving MMR merge so zero frontend impact.


### PR DESCRIPTION
## Summary

Makes user serialization/fetch fast and **independently cached per-user**, with **zero change to any response shape** (verified — zero frontend files changed). This is the safe foundation (Scope A); the full structural-cache decouple + prebaked pk-refs is deferred to its own epic (#276).

- **`serialize_user_core(pk)`** — per-user `@cached_as(CustomUser.objects.filter(pk=pk), BaseUserProfile.objects.filter(user_id=pk), extra="user_core:{pk}")` returning context-stable fields. The `BaseUserProfile` dep is required: `nickname`/`avatar` are `CustomUser` `@property`s that write through to `base_profile` (`bp.save()`, never `user.save()`), so a CustomUser-only dep would serve stale names.
- **`bulk_users`** (`POST /users/bulk/`) now assembles from the per-user cache — user fetch is per-user cache hits.
- **`_build_users_dict`** sources the **core** half from `serialize_user_core` (cached per-user) and merges the **contextual MMR** half per-request, so the tournament/draft `_users` JSON is **byte-identical** to before. MMR stays contextual — never in the global per-user cache.

**Invalidation is user-specific:** editing user X evicts only `user_core:{X}` (per-pk key + pk-filtered dep querysets), never a broad flush — covered for all three edit paths (CustomUser save, base_profile save for nickname/avatar, PositionsModel save for positions) and proven by `test_invalidation_is_user_specific`.

### Deliberately NOT in this PR (→ epic #276)
Nested-user pk-ref conversion, structural-cache decoupling, the ~15-site MMR-from-cache migration, and any frontend change. Scope A keeps every response shape identical.

## Test plan

- [x] `just test::run 'python manage.py test app.tests -v 0'` → **434 passed, OK**
- [x] New: `backend/app/tests/test_user_core_cache.py` (core fields/no-mmr, nickname-edit invalidation via BaseUserProfile dep, positions-edit invalidation, user-specific invalidation, bulk_users cache-reflects-edit)
- [x] New: `backend/app/tests/test_build_users_dict.py` (shape-parity org + non-org, core-cached + mmr-fresh)
- [x] Zero frontend files changed (`git diff --name-only origin/main | grep frontend` → empty) — the zero-impact safety gate
- [x] Shape parity: `_users` entry key set unchanged (caught + handled a real `guildNickname`/`discordNickname` divergence between OrgUserSerializer and the core serializer)

Design provenance: 4-agent design panel + 3-agent plan-review panel; scoped to A per maintainer decision. Plan: `docs/plans/2026-06-07-user-prebake-consolidation.md`.