### PR TITLE
fix: surface guest state in hero draft + land on tournament page after start (#278, #267)

### DIFF
--- a/frontend/app/components/herodraft/HeroDraftModal.tsx
+++ b/frontend/app/components/herodraft/HeroDraftModal.tsx
@@ -21,6 +21,7 @@ import { getHeroIcon, getHeroName as getHeroNameFromLib } from "~/lib/dota/heroe
 import { CaptainToast, HeroActionToast } from "./DraftToasts";
 import { Send, ArrowLeft, Users, Pause, Play } from "lucide-react";
 import { HistoryButton, PrimaryButton, SecondaryButton } from "~/components/ui/buttons";
+import { LoginButton } from "~/components/navbar/login";
 import {
   Tooltip,
   TooltipContent,
@@ -386,6 +387,10 @@ export function HeroDraftModal({ draftId, open, onClose }: HeroDraftModalProps) 
     t.members?.some((m) => m.pk === currentUser?.pk)
   );
   const isOnTeam = !!myTeam;
+  // A logged-out viewer is an empty user object (no pk), so every captain/
+  // member check above silently resolves false and the UI looks identical to
+  // an authenticated spectator. Surface the guest state explicitly (#278).
+  const isLoggedIn = !!currentUser?.pk;
   // roll_winner is already the full DraftTeam object from the backend
   const rollWinnerTeam = draft?.roll_winner ?? null;
 
@@ -411,6 +416,21 @@ export function HeroDraftModal({ draftId, open, onClose }: HeroDraftModalProps) 
             <div className="flex flex-col h-full w-full bg-background overflow-hidden" data-testid="herodraft-container">
               {/* Top Bar */}
               <DraftTopBar draft={draft} tick={tick} />
+
+              {/* Guest notice during the pre-draft (ready / roll / choose) phases:
+                  a logged-out captain would otherwise see no Ready button and no
+                  hint as to why (#278). */}
+              {!isLoggedIn &&
+                (draft.state === "waiting_for_captains" ||
+                  draft.state === "rolling" ||
+                  draft.state === "choosing") && (
+                  <div
+                    className="shrink-0 border-b border-yellow-700/50 bg-yellow-900/30 px-3 py-2 text-center text-xs sm:text-sm text-yellow-200"
+                    data-testid="herodraft-guest-notice"
+                  >
+                    You're not logged in — viewing as a guest. Log in to ready up and draft as a captain.
+                  </div>
+                )}
 
               {/* Pre-draft phases */}
               {draft.state === "waiting_for_captains" && (
@@ -646,6 +666,13 @@ export function HeroDraftModal({ draftId, open, onClose }: HeroDraftModalProps) 
 
                 {/* Right side controls */}
                 <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+                  {/* Login button - shown to guests so they can authenticate and
+                      return straight back to this draft (#278). */}
+                  {!isLoggedIn && (
+                    <span data-testid="herodraft-login-btn">
+                      <LoginButton />
+                    </span>
+                  )}
                   {/* Pause button - shown during drafting for captains/staff */}
                   {draft.state === "drafting" && (isCaptain || currentUser?.is_staff) && (
                     <Tooltip>

--- a/frontend/app/routes/rollcall.tsx
+++ b/frontend/app/routes/rollcall.tsx
@@ -457,10 +457,12 @@ export default function RollCallPage() {
             setIsNavigating(true);
             const result = await actions.startTournament.mutateAsync();
             toast.success('Tournament started!');
-            // Navigate to the tournament page if available, otherwise back to event
+            // Navigate to the tournament page if available, otherwise back to event.
+            // Land on the tournament overview rather than jumping straight into the
+            // draft view so the organizer can pick the draft type from there (#267).
             const tournamentPk = result?.tournament;
             if (tournamentPk) {
-              navigate(`/tournament/${tournamentPk}/teams/draft`);
+              navigate(`/tournament/${tournamentPk}`);
             } else {
               navigate(`/events/${eventId}`);
             }


### PR DESCRIPTION
Bundles two bug fixes.

## #278 — Can't see you aren't logged in the hero draft view
A logged-out viewer is represented by an empty user object, so every captain/member check in the hero draft view silently resolved `false` and the screen looked identical to an authenticated spectator. A guest "captain" saw no Ready button and no explanation.

- **Guest notice** during the pre-draft phases (`waiting_for_captains` / `rolling` / `choosing`) explaining you're viewing as a guest and need to log in to ready up and draft.
- **Small Login button** in the bottom-right toolbar (reuses the existing `LoginButton`, which returns the user straight back to the draft after Discord auth).

Both are gated on `!isLoggedIn`, so authenticated users (and existing e2e tests) see no change.

## #267 — Event start tournament shouldn't go straight to draft
Starting a tournament from roll call navigated straight into the draft view (`/tournament/:pk/teams/draft`). It now lands on the tournament overview page (`/tournament/:pk`) so the organizer reaches the draft-type selection from there.

## Testing
- `eslint` clean on both changed files.
- `tsc` introduces no new type errors (baseline `main` already has 33 pre-existing errors, including an unrelated `myTeam` possibly-undefined in this same file — see note below).
- The roll-call demo only asserts the URL matches `/tournament/`, which still holds.

> [!NOTE]
> Pre-existing (not touched here): `HeroDraftModal.tsx` has a latent `TS18048: 'myTeam' is possibly 'undefined'` in the `choosing` phase. Left out of scope to keep this PR focused.

Fixes #278
Fixes #267